### PR TITLE
feat(pagerduty): add getalerts endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ target.
 ## verify error messages are unique
 in order to grep any part of an error message and see the exact location is was created in, use the following command:
 ```shell
-grep -Ir  'fmt.Errorf("' . | grep -v ./CONTRIBUTING.md | sed 's/\(.*\)\(fmt.Errorf.*\)/\2/'  | sort
+grep -Ir 'fmt.Errorf("' . | grep -v './.git' -v ./CONTRIBUTING.md | sed 's/\(.*\)\(fmt.Errorf.*\)/\2/' | sort
 ```
 and verify there are no two entries with the same string
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -78,11 +78,11 @@ func NewClientFrmFileCredentials(dir string, region string) (AwsClient, error) {
 
 	accessKeyBytes, err := ioutil.ReadFile(path.Join(filepath, accessKeyIDFilename))
 	if err != nil {
-		return AwsClient{}, fmt.Errorf("%s cannot be read from %s", accessKeyIDFilename, filepath)
+		return AwsClient{}, fmt.Errorf("cannot read accessKeyID '%s' from path  %s", accessKeyIDFilename, filepath)
 	}
 	secretKeyBytes, err := ioutil.ReadFile(path.Join(filepath, secretAccessKeyIDFilename))
 	if err != nil {
-		return AwsClient{}, fmt.Errorf("%s cannot be read from %s", secretAccessKeyIDFilename, filepath)
+		return AwsClient{}, fmt.Errorf("cannot read secretKeyID '%s' from path  %s", secretAccessKeyIDFilename, filepath)
 	}
 	accessKeyID := strings.TrimRight(string(accessKeyBytes), "\n")
 	secretKeyID := strings.TrimRight(string(secretKeyBytes), "\n")

--- a/pkg/pagerduty/errors.go
+++ b/pkg/pagerduty/errors.go
@@ -39,42 +39,6 @@ func (_ InvalidInputParamsErr) Is(target error) bool {
 	return ok
 }
 
-// UnknownUpdateIncidentError wraps the error so it can be handled by the parent function
-type UnknownUpdateIncidentError struct {
-	Err error
-}
-
-// Error prints the wrapped error only
-// this is helpful to make this comply the error interface
-func (i UnknownUpdateIncidentError) Error() string {
-	err := fmt.Errorf("an unknown error was triggered while updating the incident: %w", i.Err)
-	return err.Error()
-}
-
-// Is ignores the internal error, thus making errors.Is work (as by default it compares the internal objects)
-func (_ UnknownUpdateIncidentError) Is(target error) bool {
-	_, ok := target.(UnknownUpdateIncidentError)
-	return ok
-}
-
-// UnknownAddIncidentNoteError wraps the error so it can be handled by the parent function
-type UnknownAddIncidentNoteError struct {
-	Err error
-}
-
-// Error prints the wrapped error only
-// this is helpful to make this comply the error interface
-func (i UnknownAddIncidentNoteError) Error() string {
-	err := fmt.Errorf("an unknown error was triggered while adding a note to the incident: %w", i.Err)
-	return err.Error()
-}
-
-// Is ignores the internal error, thus making errors.Is work (as by default it compares the internal objects)
-func (_ UnknownAddIncidentNoteError) Is(target error) bool {
-	_, ok := target.(UnknownAddIncidentNoteError)
-	return ok
-}
-
 // IncidentNotFoundErr wraps the PagerDuty not found error while adding notes to an incident
 type IncidentNotFoundErr struct {
 	Err error
@@ -102,7 +66,12 @@ type AlertBodyExternalCastErr struct {
 
 // Error prints data (to conform to the other errors in the package
 func (a AlertBodyExternalCastErr) Error() string {
-	err := fmt.Errorf("'%s' field is not '%s' it is '%s', the resource is '%s' ", a.FailedProperty, a.ExpectedType, a.ActualType, a.ActualBodyResource)
+	err := fmt.Errorf("'%s' field is not '%s' it is '%s', the resource is '%s' ",
+		a.FailedProperty,
+		a.ExpectedType,
+		a.ActualType,
+		a.ActualBodyResource,
+	)
 	return err.Error()
 }
 

--- a/pkg/pagerduty/types.go
+++ b/pkg/pagerduty/types.go
@@ -1,0 +1,6 @@
+package pagerduty
+
+type Alert struct {
+	ID         string
+	ExternalID string
+}


### PR DESCRIPTION
- add errors
- add private parser to local object
- put the alert type into 'types.go' (can move back to 'pagerduty.go' if
   wanted)
- general un-nesting of errors
- fix CONTRIBUTING.md
