### PR TITLE
fix(typos): using typos

### DIFF
--- a/cadctl/cmd/cluster-missing/cluster-missing.go
+++ b/cadctl/cmd/cluster-missing/cluster-missing.go
@@ -69,5 +69,5 @@ var (
 )
 
 func init() {
-	ClusterMissingCmd.Flags().StringVarP(&incidentID, "payload", "p", "", "The incident payload as recieved from the PagerDuty WebHook")
+	ClusterMissingCmd.Flags().StringVarP(&incidentID, "payload", "p", "", "The incident payload as received from the PagerDuty WebHook")
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,11 +18,11 @@ Wait a minute until it becomes available, then apply the rest:
 oc apply -f . 
 ```
 
-**Note**: The pipeline require a persistant storage. The pvc defined here only works for AWS, so for local testing on a crc a pvc with the same name should be created manually.
+**Note**: The pipeline require a persistent storage. The pvc defined here only works for AWS, so for local testing on a crc a pvc with the same name should be created manually.
 
 The CRs are going to be created in the `configuration-anomaly-detection` namespace.
 
-After applying the CRs, a Weblistner will be opened for triggereing pipelines. F.e. http://el-pipeline-event-listener.configuration-anomaly-detection.svc.cluster.local:8080 on CRC.
+After applying the CRs, a Weblistner will be opened for triggering pipelines. F.e. http://el-pipeline-event-listener.configuration-anomaly-detection.svc.cluster.local:8080 on CRC.
 
 ## Trigger a Pipeline Run
 

--- a/deploy/pipeline.yaml
+++ b/deploy/pipeline.yaml
@@ -4,7 +4,7 @@
 # https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTkw-v3-overview#webhook-payload
 
 # The Pipeline will use a pvc for pesistent storage of logs and outputs inbetween PipelineRuns.
-# The logs will be accessable over a simple dashboards
+# The logs will be accessible over a simple dashboards
 # Each step of the Pipeline will store in the following file structure:
 #   /logs/<clusterID>/<eventID>-<pipelineID>/<task>
 

--- a/pkg/pagerduty/README.md
+++ b/pkg/pagerduty/README.md
@@ -34,14 +34,14 @@ INCIDENT_ID= # the ID pulled from the create command
 pd incident:resolve --ids ${INCIDENT_ID}
 ```
 
-## Recieving PagerDuty Webhook Messages
+## Receiving PagerDuty Webhook Messages
 
 ### Manual Testing
 #### Set up the WebHook
 To do this I needed to create a webhook https://support.pagerduty.com/docs/webhooks#add-a-v3-webhook-subscription
 and attach it to a schedule (I put all of the options on)
 
-#### Provide an http reciever to push the webhook data to
+#### Provide an http receiver to push the webhook data to
 
 then I installed https://ngrok.com/ on my machine and started it with 
 ```
@@ -55,7 +55,7 @@ this is what I plumbed to PD
 NGROK HAS NOT BEEN APPROVED BY THE SECURITY TEAM, DO NOT USE WITH PRODUCTION DATA
 TODO: find a better alternative
 
-#### Connect the http reciever to a local port to recieve the webhook data
+#### Connect the http receive to a local port to receive the webhook data
 then I used `nc` to retrieve the data:
 
 ```

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -196,7 +196,7 @@ func (_ PagerDuty) ExtractIDFromCHGM(data map[string]interface{}) (string, error
 	return internalBody.ClusterID, nil
 }
 
-// fileReader will wrap the os or fstest.MapFS stucts so we are not locked in
+// fileReader will wrap the os or fstest.MapFS structs so we are not locked in
 type fileReader interface {
 	ReadFile(name string) ([]byte, error)
 }
@@ -258,7 +258,7 @@ func (p PagerDuty) ExtractExternalIDFromBytes(data []byte) (string, error) {
 	return "", fmt.Errorf("could not find an ExternalID in the given alerts")
 }
 
-// readPayloadFile is a temporary function soley responsible to retrieve the payload data from somewhere.
+// readPayloadFile is a temporary function solely responsible to retrieve the payload data from somewhere.
 // if we choose to pivot and use a different way of pulling the payload data we can change this function and ExtractExternalIDFromPayload inputs
 func readPayloadFile(payloadFilePath string, reader fileReader) ([]byte, error) {
 	data, err := reader.ReadFile(payloadFilePath)

--- a/pkg/pagerduty/pagerduty_test.go
+++ b/pkg/pagerduty/pagerduty_test.go
@@ -257,7 +257,7 @@ var _ = Describe("Pagerduty", func() {
 			})
 		})
 
-		When("If the incident that is passed to the funcion doesn't exist", func() {
+		When("If the incident that is passed to the function doesn't exist", func() {
 			It("Should throw an error (404 notFound)", func() {
 				//Arrange
 				mux.HandleFunc(fmt.Sprintf("/incidents/%s/notes", incidentID), func(w http.ResponseWriter, r *http.Request) {
@@ -330,7 +330,7 @@ var _ = Describe("Pagerduty", func() {
 			})
 		})
 
-		When("If the incident that is passed to the funcion doesn't exist", func() {
+		When("If the incident that is passed to the function doesn't exist", func() {
 			It("Should throw an error (404 notFound)", func() {
 				//Arrange
 				mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/pagerduty/parsed-by-yq-webhook-payloads-from-test-pagerduty.yaml
+++ b/pkg/pagerduty/parsed-by-yq-webhook-payloads-from-test-pagerduty.yaml
@@ -149,7 +149,7 @@ items:
         type: ping
 
   - description: a local nc instance of PD
-    # this is the parsed data, not conformant with what I actually recieved from PD
+    # this is the parsed data, not conformant with what I actually received from PD
     id: 123abc
     event: hi321
     created_on: "0001-01-01T00:00:00Z"


### PR DESCRIPTION
rust has a typos cli, which works better than misspell

this is what it found
https://github.com/crate-ci/typos
