### PR TITLE
docs: add link to go pkg documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # configuration-anomaly-detection
-[![Go Report Card](https://goreportcard.com/badge/github.com/openshift/configuration-anomaly-detection)](https://goreportcard.com/report/github.com/openshift/configuration-anomaly-detection)
-
+[![Go Report Card](https://goreportcard.com/badge/github.com/openshift/configuration-anomaly-detection)](https://goreportcard.com/report/github.com/openshift/configuration-anomaly-detection) [![PkgGoDev](https://pkg.go.dev/badge/github.com/openshift/configuration-anomaly-detection)](https://pkg.go.dev/github.com/openshift/configuration-anomaly-detection)
 
 ## Purpose
 


### PR DESCRIPTION
This adds just a badge for https://pkg.go.dev/