### PR TITLE
feat(chgm): Make notes/logging human readable for CAD events

### DIFF
--- a/pkg/aws/README.md
+++ b/pkg/aws/README.md
@@ -52,7 +52,6 @@ func GetAWSClient() (aws.Client, error) {
 		fmt.Println("AWS_SESSION_TOKEN not provided, but is not required ")
 	}
 	if !hasAwsDefaultRegion {
-		fmt.Println("setting AWS_DEFAULT_REGION to a default value")
 		awsDefaultRegion = "us-east-1"
 	}
 

--- a/pkg/pagerduty/README.md
+++ b/pkg/pagerduty/README.md
@@ -5,12 +5,20 @@ Use the `pagerduty.NewWithToken` to create the PagerDuty client, and use the fun
 ```go
 // GetPDClient will retrieve the PagerDuty from the 'pagerduty' package
 func GetPDClient() (pagerduty.Client, error) {
-	cadPD, ok := os.LookupEnv("CAD_PD")
-	if !ok {
-		return pagerduty.Client{}, fmt.Errorf("could not load CAD_PD envvar")
+	cadPD, hasCadPD := os.LookupEnv("CAD_PD")
+	cadEscalationPolicy, hasCadEscalationPolicy := os.LookupEnv("CAD_ESCALATION_POLICY")
+	cadSilentPolicy, hasCadSilentPolicy := os.LookupEnv("CAD_SILENT_POLICY")
+
+	if !hasCadEscalationPolicy || !hasCadSilentPolicy || !hasCadPD {
+		return pagerduty.Client{}, fmt.Errorf("one of the required envvars in the list '(CAD_ESCALATION_POLICY CAD_SILENT_POLICY CAP_PD)' is missing")
 	}
 
-	return pagerduty.NewWithToken(cadPD)
+	client, err := pagerduty.NewWithToken(cadPD, cadEscalationPolicy, cadSilentPolicy)
+	if err != nil {
+		return pagerduty.Client{}, fmt.Errorf("could not initialze the client: %w", err)
+	}
+
+	return client, nil
 }
 ```
 

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -123,15 +123,16 @@ func (i InvestigateInstancesOutput) String() string {
 	msg := ""
 	msg += fmt.Sprintf("Is user authorized: '%v' \n", i.UserAuthorized)
 	// TODO: check if %v is the best formatting for UserInfo
-	msg += fmt.Sprintf("User: '%v' \n", i.User)
-	msg += fmt.Sprintf("The amount of non running instances is: '%v' \n", len(i.NonRunningInstances))
+	msg += fmt.Sprintf("\nUserName : '%v'", i.User.UserName)
+	msg += fmt.Sprintf("\nIssuerUserName: '%v'", i.User.IssuerUserName)
+	msg += fmt.Sprintf("\nThe amount of non running instances is: '%v'", len(i.NonRunningInstances))
 	ids := []string{}
 	for _, nonRunningInstance := range i.NonRunningInstances {
 		// TODO: add also the StateTransitionReason to the output if needed
 		ids = append(ids, *nonRunningInstance.InstanceId)
 	}
 	if len(i.NonRunningInstances) > 0 {
-		msg += fmt.Sprintf("Instance IDs: '%v' \n", ids)
+		msg += fmt.Sprintf("\nInstance IDs: '%v'", ids)
 	}
 	return msg
 }

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
@@ -116,17 +115,25 @@ type UserInfo struct {
 type InvestigateInstancesOutput struct {
 	NonRunningInstances []*ec2.Instance
 	User                UserInfo
-	StopTime            time.Time
 	UserAuthorized      bool
 }
 
 // String implements the stringer interface for InvestigateInstancesOutput
 func (i InvestigateInstancesOutput) String() string {
-	msg, err := json.Marshal(&i)
-	if err != nil {
-		panic(fmt.Errorf("could not marshal: %w", err))
+	msg := ""
+	msg += fmt.Sprintf("Is user authorized: '%v' \n", i.UserAuthorized)
+	// TODO: check if %v is the best formatting for UserInfo
+	msg += fmt.Sprintf("User: '%v' \n", i.User)
+	msg += fmt.Sprintf("The amount of non running instances is: '%v' \n", len(i.NonRunningInstances))
+	ids := []string{}
+	for _, nonRunningInstance := range i.NonRunningInstances {
+		// TODO: add also the StateTransitionReason to the output if needed
+		ids = append(ids, *nonRunningInstance.InstanceId)
 	}
-	return string(msg)
+	if len(i.NonRunningInstances) > 0 {
+		msg += fmt.Sprintf("Instance IDs: '%v' \n", ids)
+	}
+	return msg
 }
 
 func (c *Client) populateStuctWith(externalID string) error {


### PR DESCRIPTION
When we send notes into incidents we are currently dumping out a lot of json data that is not easy to digest.

This PR will make the notes human readable.

See playground link for example of output.

[OSD-11014](https://issues.redhat.com//browse/OSD-11014)

https://go.dev/play/p/2h3BMITpdAk
