### PR TITLE
fix: hardcore algorithm into image digest

### DIFF
--- a/hack/update-template/main.go
+++ b/hack/update-template/main.go
@@ -192,7 +192,7 @@ func fixTaskImage(fileAsMap map[interface{}]interface{}) error {
 		if extractedStep["name"] != "check-infrastructure" {
 			continue
 		}
-		extractedStep["image"] = "${REGISTRY_IMG}@${IMAGE_DIGEST}"
+		extractedStep["image"] = "${REGISTRY_IMG}@sha256:${IMAGE_DIGEST}"
 	}
 	return nil
 }

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -233,5 +233,5 @@ objects:
           name: cad-ocm-client-secret
       - secretRef:
           name: cad-pd-token
-      image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+      image: ${REGISTRY_IMG}@sha256:${IMAGE_DIGEST}
       name: check-infrastructure


### PR DESCRIPTION
The APP-SRE pipeline is not setting the algorithm in the image_digest. This is tracked in: https://issues.redhat.com/browse/APPSRE-5547

let us use a workaround for now