### PR TITLE
fix: retag images for app-sre pipeline

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+make osd-container-image-build-push
+
+# Generate version and tag information from inputs
+COMMIT_NUMBER=$(git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
+CURRENT_COMMIT=$(git rev-parse --short=7 HEAD)
+IMAGE_TAG="v0.1.${COMMIT_NUMBER}-${CURRENT_COMMIT}"
+
+docker tag quay.io/app-sre/configuration-anomaly-detection:${IMAGE_TAG} quay.io/app-sre/configuration-anomaly-detection:${CURRENT_COMMIT}
+docker push quay.io/app-sre/configuration-anomaly-detection:${CURRENT_COMMIT}


### PR DESCRIPTION
This commit introduces a build_deploy.sh script that triggers the boilerplate
build, retags the image and pushes the image with a new tag