### PR TITLE
fix(deploy): Rename role and role-binding

### DIFF
--- a/deploy/serviceaccount.yaml
+++ b/deploy/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: cad-eventlistener-role
+  name: cad-pipelinerun-role
   namespace: configuration-anomaly-detection
 rules:
   - apiGroups:
@@ -30,12 +30,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cad-eventlistener-rolebinding
+  name: cad-pipelinerun-rolebinding
   namespace: configuration-anomaly-detection
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cad-eventlistener-role
+  name: cad-pipelinerun-role
 subjects:
   - kind: ServiceAccount
     name: cad-sa

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -95,7 +95,7 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
-    name: cad-eventlistener-role
+    name: cad-pipelinerun-role
   rules:
   - apiGroups:
     - ""
@@ -115,11 +115,11 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
-    name: cad-eventlistener-rolebinding
+    name: cad-pipelinerun-rolebinding
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
-    name: cad-eventlistener-role
+    name: cad-pipelinerun-role
   subjects:
   - kind: ServiceAccount
     name: cad-sa


### PR DESCRIPTION
The role and role-binding are for the pipelinerun and not for the eventListener. Let us rename them accordingly.