### PR TITLE
fix: remove namespaces

### DIFF
--- a/deploy/pipeline-trigger.yaml
+++ b/deploy/pipeline-trigger.yaml
@@ -12,7 +12,6 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
   name: cad-check-trigger-template
-  namespace: configuration-anomaly-detection
   annotations:
     triggers.tekton.dev/old-escape-quotes: "true"
 spec:
@@ -25,7 +24,6 @@ spec:
       kind: PipelineRun
       metadata:
         name: cad-check-$(uid)
-        namespace: configuration-anomaly-detection
       spec:
         timeout: 30m
         serviceAccountName: cad-sa
@@ -40,7 +38,6 @@ apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
   name: cad-pipe-listener
-  namespace: configuration-anomaly-detection
 spec:
   interceptors:
     - ref:
@@ -59,7 +56,6 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: EventListener
 metadata:
   name: cad-event-listener
-  namespace: configuration-anomaly-detection
   annotations:
     triggers.tekton.dev/old-escape-quotes: "true"
 spec:

--- a/deploy/pipeline.yaml
+++ b/deploy/pipeline.yaml
@@ -20,7 +20,6 @@ apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: cad-checks-pipeline
-  namespace: configuration-anomaly-detection
 spec:
   params:
     - name: payload

--- a/deploy/serviceaccount.yaml
+++ b/deploy/serviceaccount.yaml
@@ -2,13 +2,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cad-sa
-  namespace: configuration-anomaly-detection
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cad-pipelinerun-role
-  namespace: configuration-anomaly-detection
 rules:
   - apiGroups:
       - ""
@@ -31,7 +29,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cad-pipelinerun-rolebinding
-  namespace: configuration-anomaly-detection
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/task-cad-checks-secrets-aws.yaml
+++ b/deploy/task-cad-checks-secrets-aws.yaml
@@ -7,7 +7,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cad-aws-credentials
-  namespace: configuration-anomaly-detection
 type: Opaque
 stringData:
   AWS_ACCESS_KEY_ID: CHANGEME

--- a/deploy/task-cad-checks-secrets-ocm-client.yaml
+++ b/deploy/task-cad-checks-secrets-ocm-client.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cad-ocm-client-secret
-  namespace: configuration-anomaly-detection
 type: Opaque
 stringData:
   CAD_OCM_CLIENT_ID: CHANGEME

--- a/deploy/task-cad-checks-secrets-pd.yaml
+++ b/deploy/task-cad-checks-secrets-pd.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cad-pd-token
-  namespace: configuration-anomaly-detection
 type: Opaque
 stringData:
   CAD_ESCALATION_POLICY: CHANGEME

--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: cad-checks
-  namespace: configuration-anomaly-detection
 spec:
   params:
     - name: payload

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -33,7 +33,6 @@ objects:
       kind: PipelineRun
       metadata:
         name: cad-check-$(uid)
-        namespace: configuration-anomaly-detection
       spec:
         params:
         - name: payload


### PR DESCRIPTION
We shall not specify namespaces, because otherwise it's impossible to deploy to cad and cad-stage namespaces with the different pipelines.

For dev deployments we can either do `oc apply -f -n cad` or set the current project as context in oc
via `oc project cad`.