### PR TITLE
fix(aws): Change ListStoppedInstances to ListNonRunningInstances

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -136,8 +136,8 @@ func (c Client) ListRunningInstances(infraID string) ([]*ec2.Instance, error) {
 	return c.listInstancesWithFilter(filters)
 }
 
-// ListStoppedInstances lists all stopped instances that belong to a cluster
-func (c Client) ListStoppedInstances(infraID string) ([]*ec2.Instance, error) {
+// ListNonRunningInstances lists all non running instances that belong to a cluster
+func (c Client) ListNonRunningInstances(infraID string) ([]*ec2.Instance, error) {
 	filters := []*ec2.Filter{
 		{
 			Name:   aws.String("tag:kubernetes.io/cluster/" + infraID),


### PR DESCRIPTION
ListStoppedInstances updated to ListNonRunningInstances to reflect that it is not only stopped instances.

[OSD-11731](https://issues.redhat.com//browse/OSD-11731)