### PR TITLE
feat: add resource-pruner cronjob

### DIFF
--- a/deploy/tekton-pruner.yaml
+++ b/deploy/tekton-pruner.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    tektonconfig.operator.tekton.dev/pruner: "true"
+  name: tekton-resource-pruner
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          containers:
+            - args:
+                - 'tkn pipelinerun delete --keep=100 -f'
+              command:
+                - /bin/sh
+                - -c
+              image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:ce87cc7c6c52bc7438b1fbc303e13517100cecf6e852cd7308f9f82de9fef2cc
+              imagePullPolicy: IfNotPresent
+              name: tekton-resource-pruner
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          serviceAccount: cad-tekton-pruner
+          serviceAccountName: cad-tekton-pruner
+          terminationGracePeriodSeconds: 30
+      ttlSecondsAfterFinished: 3600
+  schedule: 0 8 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cad-tekton-pruner
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cad-tekton-pruner-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns
+    verbs:
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cad-tekton-pruner-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cad-pipelinerun-role
+subjects:
+  - kind: ServiceAccount
+    name: cad-tekton-pruner

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -183,3 +183,72 @@ objects:
           name: cad-pd-token
       image: ${REGISTRY_IMG}:${IMAGE_TAG}
       name: check-infrastructure
+- apiVersion: batch/v1
+  kind: CronJob
+  metadata:
+    labels:
+      tektonconfig.operator.tekton.dev/pruner: "true"
+    name: tekton-resource-pruner
+  spec:
+    concurrencyPolicy: Forbid
+    failedJobsHistoryLimit: 1
+    jobTemplate:
+      spec:
+        backoffLimit: 3
+        template:
+          spec:
+            containers:
+            - args:
+              - tkn pipelinerun delete --keep=100 -f
+              command:
+              - /bin/sh
+              - -c
+              image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:ce87cc7c6c52bc7438b1fbc303e13517100cecf6e852cd7308f9f82de9fef2cc
+              imagePullPolicy: IfNotPresent
+              name: tekton-resource-pruner
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+            dnsPolicy: ClusterFirst
+            restartPolicy: OnFailure
+            schedulerName: default-scheduler
+            serviceAccount: cad-tekton-pruner
+            serviceAccountName: cad-tekton-pruner
+            terminationGracePeriodSeconds: 30
+        ttlSecondsAfterFinished: 3600
+    schedule: 0 8 * * *
+    successfulJobsHistoryLimit: 3
+    suspend: false
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: cad-tekton-pruner
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: cad-tekton-pruner-role
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - delete
+  - apiGroups:
+    - tekton.dev
+    resources:
+    - pipelineruns
+    - taskruns
+    verbs:
+    - delete
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: cad-tekton-pruner-role
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: cad-pipelinerun-role
+  subjects:
+  - kind: ServiceAccount
+    name: cad-tekton-pruner
+    namespace: ${NAMESPACE_NAME}


### PR DESCRIPTION
resource pruning is not enabled in the app-sre clusters, and we are not able to annotate
the namespace, hence we are going to use a cronjob for pruning instead.

Please do not merge this. I have to get in contact with app-sre first. This PR is intended as last resort, when everything else is not possible.

Also, I am not sure if the serviceaccount in our namespace has enough permissions to do this. :/ If not this will not work as well.