### PR TITLE
fix: cluster.Region().Name() returns an empty string

### DIFF
--- a/pkg/services/assumerole/assumerole.go
+++ b/pkg/services/assumerole/assumerole.go
@@ -58,7 +58,7 @@ func (c Client) AssumeSupportRoleChain(identifier, ccsJumpRole, supportRole stri
 	if err != nil {
 		return aws.Client{}, fmt.Errorf("1 failed to get the cluster details :%w", err)
 	}
-	region := cluster.Region().Name()
+	region := cluster.Region().ID()
 	internalID := cluster.ID()
 
 	tempClient, err := c.AssumeRole(ccsJumpRole, region)


### PR DESCRIPTION
hence we have to use ID() to retrieve the correct region the cluster.

Fixes: [OSD-11734](https://issues.redhat.com//browse/OSD-11734)