### PR TITLE
refactor: simplify regex + minor refactoring

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	stopInstanceDateRegex = regexp.MustCompile(`\(([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.*)\)`)
+	stopInstanceDateRegex = regexp.MustCompile(`\((\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.*)\)`)
 )
 
 //go:generate mockgen --build_flags=--mod=readonly -destination mock/stsmock.go -package $GOPACKAGE github.com/aws/aws-sdk-go/service/sts/stsiface STSAPI
@@ -173,7 +173,7 @@ func (c Client) listInstancesWithFilter(filters []*ec2.Filter) ([]*ec2.Instance,
 		Filters: filters,
 	}
 
-	instances := []*ec2.Instance{}
+	var instances []*ec2.Instance
 	for {
 		out, err := c.Ec2Client.DescribeInstances(in)
 		if err != nil {

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -129,7 +129,7 @@ func (i InvestigateInstancesOutput) String() string {
 	msg += fmt.Sprintf("\nUserName : '%v' \n", i.User.UserName)
 	msg += fmt.Sprintf("\nIssuerUserName: '%v' \n", i.User.IssuerUserName)
 	msg += fmt.Sprintf("\nThe amount of non running instances is: '%v' \n", len(i.NonRunningInstances))
-	ids := []string{}
+	var ids []string
 	for _, nonRunningInstance := range i.NonRunningInstances {
 		// TODO: add also the StateTransitionReason to the output if needed
 		ids = append(ids, *nonRunningInstance.InstanceId)
@@ -144,7 +144,7 @@ func (i InvestigateInstancesOutput) String() string {
 	return msg
 }
 
-func (c *Client) populateStuctWith(externalID string) error {
+func (c *Client) populateStructWith(externalID string) error {
 	if c.cluster == nil {
 		cluster, err := c.GetClusterInfo(externalID)
 		if err != nil {
@@ -169,7 +169,7 @@ func (c *Client) populateStuctWith(externalID string) error {
 // InvestigateInstances will check all the instances for the cluster are running.
 // in case they are not it will make sure the stopped instances are correctly at this state.
 func (c *Client) InvestigateInstances(externalID string) (InvestigateInstancesOutput, error) {
-	err := c.populateStuctWith(externalID)
+	err := c.populateStructWith(externalID)
 	if err != nil {
 		return InvestigateInstancesOutput{}, fmt.Errorf("could not populate the struct: %w", err)
 	}


### PR DESCRIPTION
This commit refactors a few positions in the code that triggers the GoLand linter.