### PR TITLE
feat: implement CCAM (Cluster Credentials Are Missing)

### DIFF
--- a/cadctl/cmd/cluster-missing/cluster-missing.go
+++ b/cadctl/cmd/cluster-missing/cluster-missing.go
@@ -18,6 +18,7 @@ package clustermissing
 
 import (
 	"fmt"
+	"github.com/openshift/configuration-anomaly-detection/pkg/services/ccam"
 	"os"
 	"path/filepath"
 
@@ -92,7 +93,13 @@ func run(cmd *cobra.Command, args []string) error {
 
 	customerAwsClient, err := arClient.AssumeSupportRoleChain(externalClusterID, cssJumprole, supportRole)
 	if err != nil {
-		return fmt.Errorf("could not AssumeSupportRoleChain: %w", err)
+		ccamClient := ccam.Client{
+			Service: ccam.Provider{
+				OcmClient: ocmClient,
+				PdClient:  pdClient,
+			},
+		}
+		return ccamClient.Evaluate(err, externalClusterID, incidentID)
 	}
 
 	// building twice to override the awsClient

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -32,6 +32,14 @@ var chgmServiceLog = slTemplate{
 	InternalOnly: false,
 }
 
+var ccamServiceLog = slTemplate{
+	Severity:     "Error",
+	ServiceName:  "SREManualAction",
+	Summary:      "Action required: Restore missing cloud credentials",
+	Description:  "Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install.",
+	InternalOnly: false,
+}
+
 // Client is the ocm client with which we can run the commands
 // currently we do not need to export the connection or the config, as we create the Client using the New func
 type Client struct {
@@ -199,6 +207,12 @@ func (c Client) GetNodeCount(clusterID string) (int, error) {
 // On success, it will return the sent service log entry.
 func (c Client) SendCHGMServiceLog(cluster *v1.Cluster) (*servicelog.LogEntry, error) {
 	return c.sendServiceLog(c.newServiceLogBuilder(chgmServiceLog), cluster)
+}
+
+// SendCCAMServiceLog allows to send a missing credentials servicelog.
+// On success, it will return the sent service log entry.
+func (c Client) SendCCAMServiceLog(cluster *v1.Cluster) (*servicelog.LogEntry, error) {
+	return c.sendServiceLog(c.newServiceLogBuilder(ccamServiceLog), cluster)
 }
 
 // sendServiceLog allows to send a generic servicelog to a cluster.

--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -1,0 +1,105 @@
+// Package ccam Cluster Credentials Are Missing (CCAM) provides a service for detecting missing cluster credentials
+package ccam
+
+import (
+	"fmt"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	servicelog "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
+	"regexp"
+)
+
+var accessDeniedRegex = regexp.MustCompile(`failed to assume into support-role: AccessDenied`)
+
+// OcmClient is a wrapper around the ocm client, and is used to import the received functions into the Provider
+type OcmClient = ocm.Client
+
+// PdClient is a wrapper around the pagerduty client, and is used to import the received functions into the Provider
+type PdClient = pagerduty.Client
+
+// Provider should have all the functions that ChgmService is implementing
+type Provider struct {
+	// having awsClient and ocmClient this way
+	// allows for all the method receivers defined on them to be passed into the parent struct,
+	// thus making it more composable than just having each func redefined here
+	//
+	// a different solution is to have the structs have unique names to begin with, which makes the code
+	// aws.AwsClient feel a bit redundant
+	OcmClient
+	PdClient
+}
+
+// Service will wrap all the required commands the client needs to run its operations
+type Service interface {
+	// OCM
+	GetClusterInfo(identifier string) (*v1.Cluster, error)
+	SendCCAMServiceLog(cluster *v1.Cluster) (*servicelog.LogEntry, error)
+	GetNodeCount(clusterID string) (int, error)
+	// PD
+	AddNote(incidentID string, noteContent string) error
+	MoveToEscalationPolicy(incidentID string, escalationPolicyID string) error
+	GetEscalationPolicy() string
+	GetSilentPolicy() string
+}
+
+// Client refers to the CCAM client
+type Client struct {
+	Service
+	cluster *v1.Cluster
+}
+
+func (c *Client) populateStructWith(externalID string) error {
+	if c.cluster == nil {
+		cluster, err := c.GetClusterInfo(externalID)
+		if err != nil {
+			return fmt.Errorf("could not retrieve cluster info for %s in CCAM step: %w", externalID, err)
+		}
+		// fmt.Printf("cluster ::: %v\n", cluster)
+		c.cluster = cluster
+	}
+	return nil
+}
+
+// checkMissing checks for missing credentials that are required for assuming
+// into the support-role. If these credentials are missing we can silence the
+// alert and send a service log.
+func (c Client) checkMissing(err error) bool {
+	return accessDeniedRegex.MatchString(err.Error())
+}
+
+// silenceAlert annotates the PagerDuty alert with the given notes and silences it via
+// assigning the "Silent Test" escalation policy
+func (c Client) silenceAlert(incidentID, notes string) error {
+	escalationPolicy := c.GetSilentPolicy()
+	if notes != "" {
+		fmt.Printf("Attaching Note %s\n", notes)
+		err := c.AddNote(incidentID, notes)
+		if err != nil {
+			return fmt.Errorf("failed to attach notes to CCAM incident: %w", err)
+		}
+	}
+	fmt.Printf("Moving Alert to Escalation Policy %s\n", escalationPolicy)
+	err := c.MoveToEscalationPolicy(incidentID, escalationPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to change incident escalation policy in CCAM step: %w", err)
+	}
+	return nil
+}
+
+// Evaluate estimates if the awsError is a cluster credentials are missing error.
+func (c Client) Evaluate(awsError error, externalClusterID string, incidentID string) error {
+	err := c.populateStructWith(externalClusterID)
+	if err != nil {
+		return fmt.Errorf("failed to populate struct in Evaluate in CCAM step: %w", err)
+	}
+
+	if !c.checkMissing(awsError) {
+		return fmt.Errorf("credentials are there, error is different")
+	}
+	log, err := c.SendCCAMServiceLog(c.cluster)
+	if err != nil {
+		return fmt.Errorf("failed to send missing credentials service log: %w", err)
+	}
+	return c.silenceAlert(incidentID, fmt.Sprintf("ServiceLog Sent: '%+v' \n", log.Summary()))
+}

--- a/pkg/services/ccam/ccam_suite_test.go
+++ b/pkg/services/ccam/ccam_suite_test.go
@@ -1,0 +1,13 @@
+package ccam_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCcam(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ccam Suite")
+}

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -279,7 +279,7 @@ func (c Client) updatePagerduty(incidentID, notes, escalationPolicy string) erro
 		fmt.Printf("Attaching Note %s\n", notes)
 		err := c.AddNote(incidentID, notes)
 		if err != nil {
-			return fmt.Errorf("failed to attach notes to incident: %w", err)
+			return fmt.Errorf("failed to attach notes to CHGM incident: %w", err)
 		}
 	}
 	fmt.Printf("Moving Alert to Escalation Policy %s\n", escalationPolicy)


### PR DESCRIPTION
CCAM provides a way to send an alert if the cluster credentials
are missing. This is the case, when the assumeRole call
fails with an "Access Denied" response.

Fixes: [OSD-11736](https://issues.redhat.com//browse/OSD-11736)