### PR TITLE
fix: set new tekton-cli image

### DIFF
--- a/deploy/tekton-pruner.yaml
+++ b/deploy/tekton-pruner.yaml
@@ -19,7 +19,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-              image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:ce87cc7c6c52bc7438b1fbc303e13517100cecf6e852cd7308f9f82de9fef2cc
+              image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:e1fa47811f156e48a61741aabe73ef85078960567822a4b23c174c0d9b4d0ee6
               imagePullPolicy: IfNotPresent
               name: tekton-resource-pruner
               terminationMessagePath: /dev/termination-log

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -203,7 +203,7 @@ objects:
               command:
               - /bin/sh
               - -c
-              image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:ce87cc7c6c52bc7438b1fbc303e13517100cecf6e852cd7308f9f82de9fef2cc
+              image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:e1fa47811f156e48a61741aabe73ef85078960567822a4b23c174c0d9b4d0ee6
               imagePullPolicy: IfNotPresent
               name: tekton-resource-pruner
               terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
This sets a new tekton-cli image and fixes the 404 not found error.

Fixes: [OSD-11909](https://issues.redhat.com//browse/OSD-11909)