### PR TITLE
fix: use tkn-client image in quay

### DIFF
--- a/deploy/tekton-pruner.yaml
+++ b/deploy/tekton-pruner.yaml
@@ -19,7 +19,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-              image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:e1fa47811f156e48a61741aabe73ef85078960567822a4b23c174c0d9b4d0ee6
+              image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-cli-tkn-rhel8@sha256:e1fa47811f156e48a61741aabe73ef85078960567822a4b23c174c0d9b4d0ee6
               imagePullPolicy: IfNotPresent
               name: tekton-resource-pruner
               terminationMessagePath: /dev/termination-log
@@ -30,8 +30,6 @@ spec:
           serviceAccount: cad-tekton-pruner
           serviceAccountName: cad-tekton-pruner
           terminationGracePeriodSeconds: 30
-          imagePullSecrets:
-            - name: registry-redhat-io-pull-secret
       ttlSecondsAfterFinished: 3600
   schedule: 0 8 * * *
   successfulJobsHistoryLimit: 3

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -203,14 +203,12 @@ objects:
               command:
               - /bin/sh
               - -c
-              image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:e1fa47811f156e48a61741aabe73ef85078960567822a4b23c174c0d9b4d0ee6
+              image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-cli-tkn-rhel8@sha256:e1fa47811f156e48a61741aabe73ef85078960567822a4b23c174c0d9b4d0ee6
               imagePullPolicy: IfNotPresent
               name: tekton-resource-pruner
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: FallbackToLogsOnError
             dnsPolicy: ClusterFirst
-            imagePullSecrets:
-            - name: registry-redhat-io-pull-secret
             restartPolicy: OnFailure
             schedulerName: default-scheduler
             serviceAccount: cad-tekton-pruner


### PR DESCRIPTION
Remove the image pull secret and use the image in quay.io instead.

Related to: [OSD-11910](https://issues.redhat.com//browse/OSD-11910)