### PR TITLE
fix: change schedule for pruner cronjob

### DIFF
--- a/deploy/tekton-pruner.yaml
+++ b/deploy/tekton-pruner.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - args:
-                - 'tkn pipelinerun delete --keep=100 -f'
+                - 'tkn pipelinerun delete --keep=20 -f'
               command:
                 - /bin/sh
                 - -c
@@ -31,7 +31,7 @@ spec:
           serviceAccountName: cad-tekton-pruner
           terminationGracePeriodSeconds: 30
       ttlSecondsAfterFinished: 3600
-  schedule: 0 8 * * *
+  schedule: 0 * * * *
   successfulJobsHistoryLimit: 3
   suspend: false
 ---

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -199,7 +199,7 @@ objects:
           spec:
             containers:
             - args:
-              - tkn pipelinerun delete --keep=100 -f
+              - tkn pipelinerun delete --keep=20 -f
               command:
               - /bin/sh
               - -c
@@ -215,7 +215,7 @@ objects:
             serviceAccountName: cad-tekton-pruner
             terminationGracePeriodSeconds: 30
         ttlSecondsAfterFinished: 3600
-    schedule: 0 8 * * *
+    schedule: 0 * * * *
     successfulJobsHistoryLimit: 3
     suspend: false
 - apiVersion: v1


### PR DESCRIPTION
Running the cronjob just once per day makes it difficult to debug failed jobs.
Let's change this to every hour and keeping just 20 cad-check pods.