### PR TITLE
fix: add more permissions to the cronjob

### DIFF
--- a/deploy/tekton-pruner.yaml
+++ b/deploy/tekton-pruner.yaml
@@ -51,6 +51,9 @@ rules:
       - pods
     verbs:
       - delete
+      - get
+      - watch
+      - list
   - apiGroups:
       - tekton.dev
     resources:
@@ -58,6 +61,9 @@ rules:
       - taskruns
     verbs:
       - delete
+      - list
+      - get
+      - watch
   - apiGroups:
       - batch
     resources:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -233,6 +233,9 @@ objects:
     - pods
     verbs:
     - delete
+    - get
+    - watch
+    - list
   - apiGroups:
     - tekton.dev
     resources:
@@ -240,6 +243,9 @@ objects:
     - taskruns
     verbs:
     - delete
+    - list
+    - get
+    - watch
   - apiGroups:
     - batch
     resources:


### PR DESCRIPTION
The cronjobs needs at least permissions to list pipelineruns.
I have added get and watch as well.