### PR TITLE
fix: do not set namespace in rolebindings

### DIFF
--- a/hack/update-template/main.go
+++ b/hack/update-template/main.go
@@ -165,13 +165,6 @@ func fixRoleOrClusterRoleBinding(fileAsMap map[interface{}]interface{}) error {
 	if !hasSubjects {
 		return fmt.Errorf("subjects doesn't exist")
 	}
-	for subjectIndex, subject := range subjects {
-		extractedSubject, canConvertExtractedSubject := subject.(map[interface{}]interface{})
-		if !canConvertExtractedSubject {
-			return fmt.Errorf("could not convert a subject item in index '%d' field into `map[interface{}]interface{}`: '%v'", subjectIndex, reflect.TypeOf(subject))
-		}
-		extractedSubject["namespace"] = "${NAMESPACE_NAME}"
-	}
 	fileAsMap["subjects"] = subjects
 	return nil
 }

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -124,7 +124,6 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: cad-sa
-    namespace: ${NAMESPACE_NAME}
 - apiVersion: v1
   kind: Secret
   metadata:
@@ -270,4 +269,3 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: cad-tekton-pruner
-    namespace: ${NAMESPACE_NAME}


### PR DESCRIPTION
We cannot dynamically set namespaces within app-sre/interface, hence
try to remove them from the rolebinding completely and just let
k8s deploy it into the correct namespace

Fixes: [OSD-11954](https://issues.redhat.com//browse/OSD-11954)