### PR TITLE
fix(chgm): Clean up PD notes when fields are empty

### DIFF
--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -146,7 +146,7 @@ func (i InvestigateInstancesOutput) String() string {
 		msg += fmt.Sprintf("\nThe amount of all instances is: '%d' \n", i.AllInstances)
 	}
 	if i.ServiceLog.Summary() == "" {
-		msg += fmt.Sprintf("\nServiceLog Sent: 'None' \n")
+		msg += "\nServiceLog Sent: 'None' \n"
 	} else {
 		msg += fmt.Sprintf("\nServiceLog Sent: '%+v' \n", i.ServiceLog.Summary())
 	}

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -127,8 +127,12 @@ func (i InvestigateInstancesOutput) String() string {
 	msg := ""
 	msg += fmt.Sprintf("Is user authorized: '%v' \n", i.UserAuthorized)
 	// TODO: check if %v is the best formatting for UserInfo
-	msg += fmt.Sprintf("\nUserName : '%v' \n", i.User.UserName)
-	msg += fmt.Sprintf("\nIssuerUserName: '%v' \n", i.User.IssuerUserName)
+	if i.User.UserName != "" {
+		msg += fmt.Sprintf("\nUserName : '%v' \n", i.User.UserName)
+	}
+	if i.User.IssuerUserName != "" {
+		msg += fmt.Sprintf("\nIssuerUserName: '%v' \n", i.User.IssuerUserName)
+	}
 	msg += fmt.Sprintf("\nThe amount of non running instances is: '%v' \n", len(i.NonRunningInstances))
 	var ids []string
 	for _, nonRunningInstance := range i.NonRunningInstances {
@@ -141,7 +145,11 @@ func (i InvestigateInstancesOutput) String() string {
 	if i.AllInstances >= 0 {
 		msg += fmt.Sprintf("\nThe amount of all instances is: '%d' \n", i.AllInstances)
 	}
-	msg += fmt.Sprintf("\nServiceLog Sent: '%+v' \n", i.ServiceLog.Summary())
+	if i.ServiceLog.Summary() == "" {
+		msg += fmt.Sprintf("\nServiceLog Sent: 'None' \n")
+	} else {
+		msg += fmt.Sprintf("\nServiceLog Sent: '%+v' \n", i.ServiceLog.Summary())
+	}
 	if i.Error != "" {
 		msg += fmt.Sprintf("\nErrors: '%v' \n", i.Error)
 	}


### PR DESCRIPTION
[OSD-11939](https://issues.redhat.com//browse/OSD-11939)

Updates the notes so the UserName and IssuerUserName fields are not printed when empty. The ServiceLog Sent field will display 'None' when empty.