### PR TITLE
fix: remove AWS token depletion

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -366,20 +366,18 @@ func (c Client) ListAllTerminatedInstances() ([]*cloudtrail.Event, error) {
 }
 
 func (c Client) listAllInstancesAttribute(att *cloudtrail.LookupAttribute) ([]*cloudtrail.Event, error) {
+	// We only look up events that are not older than 2 hours
+	since := time.Now().Add(time.Duration(-2) * time.Hour)
+	// We only look up 1000 events maximum
+	var maxResults int64 = 1000
 	in := &cloudtrail.LookupEventsInput{
 		LookupAttributes: []*cloudtrail.LookupAttribute{att},
+		MaxResults:       &maxResults,
+		StartTime:        &since,
 	}
-	var events []*cloudtrail.Event
-	for {
-		out, err := c.CloudTrailClient.LookupEvents(in)
-		if err != nil {
-			return nil, err
-		}
-		nextToken := out.NextToken
-		events = append(events, out.Events...)
-		if nextToken == nil {
-			break
-		}
+	out, err := c.CloudTrailClient.LookupEvents(in)
+	if err != nil {
+		return nil, err
 	}
-	return events, nil
+	return out.Events, nil
 }

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -153,26 +153,6 @@ var _ = Describe("Aws", func() {
 				},
 			}
 		})
-		When("the events are listed on several pages", func() {
-			It("makes several calls to get all pages", func() {
-				nrPages := 10
-				token := awsSDK.String("pointerToNext")
-				lookupEventOut.NextToken = token
-				i := 1
-				mockCloudTrailClient.EXPECT().LookupEvents(gomock.Any()).DoAndReturn(
-					func(input *cloudtrail.LookupEventsInput) (*cloudtrail.LookupEventsOutput, error) {
-						if i == nrPages {
-							lookupEventOut.NextToken = nil
-						}
-						i++
-						return lookupEventOut, nil
-					}).Times(nrPages)
-
-				c, err := client.ListAllInstanceStopEvents()
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(c)).Should(Equal(nrPages))
-			})
-		})
 		When("the full list is on one page", func() {
 			It("the values are returned and the cloudtrail api is called just once", func() {
 				mockCloudTrailClient.EXPECT().LookupEvents(gomock.Any()).Return(lookupEventOut, nil).Times(1)


### PR DESCRIPTION
Amazon AWS tokens are used for API throttling. Every call to an API endpoint
costs us one token. Before this commit, our listAllInstancesAttribute
exhausted all our available AWS tokens, this lead to AWS throttling us.

The new function does only ONE request instead of one request for every token.
In this request we gather a maximum of 1000 results for a 2hour timeframe.
This should be enough for us to handle CHGM alerts