### PR TITLE
fix: improve logging for CCAM

### DIFF
--- a/cadctl/cmd/cluster-missing/cluster-missing.go
+++ b/cadctl/cmd/cluster-missing/cluster-missing.go
@@ -93,6 +93,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	customerAwsClient, err := arClient.AssumeSupportRoleChain(externalClusterID, cssJumprole, supportRole)
 	if err != nil {
+		fmt.Println("Assuming role failed, potential CCAM alert. Investigating... error: ", err.Error())
 		// if assumeSupportRoleChain fails, we will evaluate if the credentials are missing
 		ccamClient := ccam.Client{
 			Service: ccam.Provider{


### PR DESCRIPTION
This improves logging for cluster credentials are missing alerts.