### PR TITLE
fix: make notes more specific when no SL is sent

### DIFF
--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -156,7 +156,7 @@ func (i InvestigateInstancesOutput) String() string {
 		msg += fmt.Sprintf("\nInstance IDs: '%v' \n", ids)
 	}
 	if i.ServiceLog.Summary() == "" {
-		msg += "\nServiceLog Sent: 'None' \n"
+		msg += "\nServiceLog Sent: 'No ServiceLog sent. Manual SRE investigation is needed.' \n"
 	} else {
 		msg += fmt.Sprintf("\nServiceLog Sent: '%+v' \n", i.ServiceLog.Summary())
 	}


### PR DESCRIPTION
To reduce confusion when no SL is sent, specifically state that manual SRE investigation is needed.