### PR TITLE
iterate over pages on pageinated ListInstance results for aws pkg

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -179,13 +179,13 @@ func (c Client) listInstancesWithFilter(filters []*ec2.Filter) ([]*ec2.Instance,
 		if err != nil {
 			return []*ec2.Instance{}, err
 		}
-		nextToken := out.NextToken
 		for _, res := range out.Reservations {
 			instances = append(instances, res.Instances...)
 		}
-		if nextToken == nil {
+		if out.NextToken == nil {
 			break
 		}
+		in.NextToken = out.NextToken
 	}
 	return instances, nil
 }


### PR DESCRIPTION
was looking over some of the old code, I wrote...
and believe to found a bug, that will cause an infinity loop of calling the AWS API for the case the instances are returned on several pages.  
The nextToken has to be stored in the Request, as it is done [here](https://github.com/evalphobia/aws-sdk-go-wrapper/blob/0ad241a2f698d46f056aee89f79dc5624cd5cdba/cloudtrail/client.go#L64).

Great to see though that things are still going forward with CAD. 

