### PR TITLE
fix(Dockerfile): security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /opt
 RUN git update-index --refresh; make CGO_ENABLED=0 cadctl-install-local-force
 
 
-FROM quay.io/app-sre/ubi8-ubi-minimal:8.6-751 as runner
+FROM quay.io/app-sre/ubi8-ubi-minimal:8.6-854 as runner
 
 COPY --from=builder /opt/cadctl/cadctl /bin/cadctl
 


### PR DESCRIPTION
This commit is supposed to fix vulnerabilities in our current CAD generation
depending on ubi 8.6

Fixes: [OSD-12602](https://issues.redhat.com/browse/OSD-12602)