### PR TITLE
OHSS-14525 Removal of leaver shibumi from owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,13 +4,11 @@ reviewers:
 - Tessg22
 - ninabauer
 - rafael-azevedo
-- shibumi
 approvers:
 - Makdaam
 - Nikokolas3270
 - Tessg22
 - ninabauer
 - rafael-azevedo
-- shibumi
 maintainers:
 - rafael-azevedo

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/go-openapi/swag v0.19.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
-	github.com/golang/glog v1.0.0
+	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect


### PR DESCRIPTION
Step [12.3.3 ](https://github.com/openshift/ops-sop/blob/master/security/leaver_process.asciidoc#1233-review-users-owners-permissions) of the leaver process SOP includes removal from our openshift repos. Hence, this PR serves the removal of Christian Rebischke.