### PR TITLE
Adding error propagation to PD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test:
 
 .PHONY: lint
 lint: bin/golangci-lint lint-only-hack
-	GOLANGCI_LINT_CACHE=$(shell mktemp -d) ./bin/golangci-lint run
+	GOLANGCI_LINT_CACHE=$(shell mktemp -d) ./bin/golangci-lint run --timeout 120s
 
 .PHONY: lint-only-hack
 lint-only-hack: bin/golangci-lint

--- a/cadctl/cmd/cluster-missing/cluster-missing.go
+++ b/cadctl/cmd/cluster-missing/cluster-missing.go
@@ -18,9 +18,10 @@ package clustermissing
 
 import (
 	"fmt"
-	"github.com/openshift/configuration-anomaly-detection/pkg/services/ccam"
 	"os"
 	"path/filepath"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/services/ccam"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	ocm "github.com/openshift/configuration-anomaly-detection/pkg/ocm"
@@ -117,6 +118,11 @@ func run(cmd *cobra.Command, args []string) error {
 
 	res, err := chgmClient.InvestigateInstances(externalClusterID)
 	if err != nil {
+		fmt.Printf("Inconclusive, alerting SRE, InvestigateInstances failed on %s: %v\n", externalClusterID, err)
+		escerr := chgmClient.EscalateAlert(incidentID, fmt.Sprintf("CAD Investigation on %s failed: %v", externalClusterID, err))
+		if escerr != nil {
+			return fmt.Errorf("could not escalate the alert %s: %w while: %v", incidentID, escerr, err)
+		}
 		return fmt.Errorf("InvestigateInstances failed on %s: %w", externalClusterID, err)
 	}
 


### PR DESCRIPTION
 so that the SRE on-call knows that CAD won't enrich the issue without looking into pod logs.
Example issue that can be avoided in the future https://issues.redhat.com/browse/OSD-11710

Imports rearranged by linter.
