### PR TITLE
Limited support for CHGM and CCAM

### DIFF
--- a/cadctl/cmd/cluster-missing/cluster-missing.go
+++ b/cadctl/cmd/cluster-missing/cluster-missing.go
@@ -18,9 +18,10 @@ package clustermissing
 
 import (
 	"fmt"
-	"github.com/openshift/configuration-anomaly-detection/pkg/services/ccam"
 	"os"
 	"path/filepath"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/services/ccam"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	ocm "github.com/openshift/configuration-anomaly-detection/pkg/ocm"
@@ -131,18 +132,26 @@ func run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Println("Sending CHGM ServiceLog...")
-	log, err := chgmClient.SendServiceLog()
-	if err != nil {
-		return fmt.Errorf("failed sending service log before silencing the alert: %w", err)
-	}
-	res.ServiceLog = log
+	// fmt.Println("Sending CHGM ServiceLog...")
+	// log, err := chgmClient.SendServiceLog()
+	// if err != nil {
+	// 	return fmt.Errorf("failed sending service log before silencing the alert: %w", err)
+	// }
+	// res.ServiceLog = log
 
-	fmt.Println("Silencing Alert...")
-	err = chgmClient.SilenceAlert(incidentID, res.String())
+	// Post CHGM limited support
+	fmt.Println("Sending CHGM limited support reason")
+	reason, err := chgmClient.PostLimitedSupport()
 	if err != nil {
-		return fmt.Errorf("assigning the incident to Silent Test did not work: %w", err)
+		return fmt.Errorf("failed posting limited support reason: %w", err)
 	}
+	res.LimitedSupportReason = reason
+
+	// fmt.Println("Silencing Alert...")
+	// err = chgmClient.SilenceAlert(incidentID, res.String())
+	// if err != nil {
+	// 	return fmt.Errorf("assigning the incident to Silent Test did not work: %w", err)
+	// }
 	// written this way so I can quickly detect if res is true of false
 	fmt.Println("USER INITIATED SHUTDOWN")
 

--- a/pkg/services/chgm/mock/interfaces.go
+++ b/pkg/services/chgm/mock/interfaces.go
@@ -183,3 +183,18 @@ func (mr *MockServiceMockRecorder) SendCHGMServiceLog(cluster interface{}) *gomo
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCHGMServiceLog", reflect.TypeOf((*MockService)(nil).SendCHGMServiceLog), cluster)
 }
+
+// PostCHGMLimitedSupportReason mocks base method.
+func (m *MockService) PostCHGMLimitedSupportReason(clusterID string) (*v1.LimitedSupportReason, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostCHGMLimitedSupportReason", clusterID)
+	ret0, _ := ret[0].(*v1.LimitedSupportReason)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostCHGMLimitedSupportReason indicated an expected call of PostCHGMLimitedSupportReason.
+func (mr *MockServiceMockRecorder) PostCHGMLimitedSupportReason(cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostCHGMLimitedSupportReason", reflect.TypeOf((*MockService)(nil).PostCHGMLimitedSupportReason), cluster)
+}


### PR DESCRIPTION
PR adds logic for CAD to automatically put clusters with ClusterHasGoneMissing and ClusterCredentialsAreMissing. Currently, these clusters are being sent ServiceLog and have the alert sent to user Silent Test. 