### PR TITLE
OSD-12961; OSD-12957 - Integrate Limited Support into CAD's CHGM logic

### DIFF
--- a/pkg/pagerduty/errors.go
+++ b/pkg/pagerduty/errors.go
@@ -56,6 +56,57 @@ func (IncidentNotFoundErr) Is(target error) bool {
 	return ok
 }
 
+// ServiceNotFoundErr wraps the errors returned when PagerDuty services cannot be retrieved
+type ServiceNotFoundErr struct {
+	Err error
+}
+
+// Error prints the wrapped and original error
+func (s ServiceNotFoundErr) Error() string {
+	err := fmt.Errorf("the given service was not found: %w", s.Err)
+	return err.Error()
+}
+
+// Is indicates whether the supplied error is a ServiceNotFoundErr
+func (ServiceNotFoundErr) Is(target error) bool {
+	_, ok := target.(ServiceNotFoundErr)
+	return ok
+}
+
+// IntegrationNotFoundErr wraps the errors returned when a PagerDuty service's integration cannot be found
+type IntegrationNotFoundErr struct {
+	Err error
+}
+
+// Error prints the wrapped and original error
+func (i IntegrationNotFoundErr) Error() string {
+	err := fmt.Errorf("the given integration was not found: %w", i.Err)
+	return err.Error()
+}
+
+// Is indicates whether the supplied error is an IntegrationNotFoundErr
+func (IntegrationNotFoundErr) Is(target error) bool {
+	_, ok := target.(IntegrationNotFoundErr)
+	return ok
+}
+
+// CreateEventErr wraps the errors returned when failing to create a PagerDuty event
+type CreateEventErr struct {
+	Err error
+}
+
+// Error prints the wrapped and original error
+func (c CreateEventErr) Error() string {
+	err := fmt.Errorf("failed to create event: %w", c.Err)
+	return err.Error()
+}
+
+// Is indicates whether the supplied error is a CreateEventErr
+func (CreateEventErr) Is(target error) bool {
+	_, ok := target.(CreateEventErr)
+	return ok
+}
+
 // AlertBodyExternalCastErr denotes the fact the alert's body field could not be converted correctly
 type AlertBodyExternalCastErr struct {
 	FailedProperty     string

--- a/pkg/services/chgm/chgm_test.go
+++ b/pkg/services/chgm/chgm_test.go
@@ -15,11 +15,11 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
-var _ = Describe("Chgm", func() {
+var _ = Describe("ChgmTriggered", func() {
 	Describe("AreAllInstancesRunning", func() {
 
 		// this is a var but I use it as a const
-		var fakeErr = fmt.Errorf("test")
+		var fakeErr = fmt.Errorf("test triggered")
 		var (
 			mockCtrl          *gomock.Controller
 			mockClient        *mock.MockService
@@ -52,7 +52,7 @@ var _ = Describe("Chgm", func() {
 				// Arrange
 				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(nil, fakeErr)
 				// Act
-				_, gotErr := isRunning.InvestigateInstances("")
+				_, gotErr := isRunning.InvestigateStoppedInstances("")
 				// Assert
 				Expect(gotErr).To(HaveOccurred())
 			})
@@ -64,7 +64,7 @@ var _ = Describe("Chgm", func() {
 				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(nil, fakeErr)
 				// Act
-				_, gotErr := isRunning.InvestigateInstances("")
+				_, gotErr := isRunning.InvestigateStoppedInstances("")
 				// Assert
 				Expect(gotErr).To(HaveOccurred())
 			})
@@ -78,7 +78,7 @@ var _ = Describe("Chgm", func() {
 
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return(nil, fakeErr)
 				// Act
-				_, gotErr := isRunning.InvestigateInstances("")
+				_, gotErr := isRunning.InvestigateStoppedInstances("")
 				// Assert
 				Expect(gotErr).To(HaveOccurred())
 			})
@@ -91,7 +91,7 @@ var _ = Describe("Chgm", func() {
 				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
 				// Act
-				got, gotErr := isRunning.InvestigateInstances("")
+				got, gotErr := isRunning.InvestigateStoppedInstances("")
 				// Assert
 				Expect(gotErr).ToNot(HaveOccurred())
 				Expect(got.UserAuthorized).To(BeTrue())
@@ -106,7 +106,7 @@ var _ = Describe("Chgm", func() {
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return(nil, fakeErr)
 				// Act
-				_, gotErr := isRunning.InvestigateInstances("")
+				_, gotErr := isRunning.InvestigateStoppedInstances("")
 				// Assert
 				Expect(gotErr).To(HaveOccurred())
 			})
@@ -120,7 +120,7 @@ var _ = Describe("Chgm", func() {
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return(nil, fakeErr)
 				// Act
-				_, gotErr := isRunning.InvestigateInstances("")
+				_, gotErr := isRunning.InvestigateStoppedInstances("")
 				// Assert
 				Expect(gotErr).To(HaveOccurred())
 			})
@@ -145,7 +145,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{}, nil)
 					// Act
-					_, gotErr := isRunning.InvestigateInstances("")
+					_, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).To(HaveOccurred())
 				})
@@ -161,7 +161,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					_, gotErr := isRunning.InvestigateInstances("")
+					_, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).To(HaveOccurred())
 				})
@@ -177,7 +177,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					_, gotErr := isRunning.InvestigateInstances("")
+					_, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).To(HaveOccurred())
 				})
@@ -193,7 +193,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					_, gotErr := isRunning.InvestigateInstances("")
+					_, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).To(HaveOccurred())
 				})
@@ -211,7 +211,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					_, gotErr := isRunning.InvestigateInstances("")
+					_, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).To(HaveOccurred())
 				})
@@ -227,7 +227,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					_, gotErr := isRunning.InvestigateInstances("")
+					_, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).To(HaveOccurred())
 				})
@@ -244,7 +244,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					got, gotErr := isRunning.InvestigateInstances("")
+					got, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).NotTo(HaveOccurred())
 					Expect(got.UserAuthorized).To(BeTrue())
@@ -261,7 +261,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					got, gotErr := isRunning.InvestigateInstances("")
+					got, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).NotTo(HaveOccurred())
 					Expect(got.UserAuthorized).To(BeTrue())
@@ -277,7 +277,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					got, gotErr := isRunning.InvestigateInstances("")
+					got, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).NotTo(HaveOccurred())
 					Expect(got.UserAuthorized).To(BeFalse())
@@ -294,7 +294,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					got, gotErr := isRunning.InvestigateInstances("")
+					got, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).NotTo(HaveOccurred())
 					Expect(got.UserAuthorized).To(BeFalse())
@@ -311,7 +311,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					got, gotErr := isRunning.InvestigateInstances("")
+					got, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).NotTo(HaveOccurred())
 					Expect(got.UserAuthorized).To(BeFalse())
@@ -328,7 +328,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					got, gotErr := isRunning.InvestigateInstances("")
+					got, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).NotTo(HaveOccurred())
 					Expect(got.UserAuthorized).To(BeFalse())
@@ -345,7 +345,7 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					got, gotErr := isRunning.InvestigateInstances("")
+					got, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).NotTo(HaveOccurred())
 					Expect(got.UserAuthorized).To(BeFalse())
@@ -362,11 +362,161 @@ var _ = Describe("Chgm", func() {
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
-					got, gotErr := isRunning.InvestigateInstances("")
+					got, gotErr := isRunning.InvestigateStoppedInstances("")
 					// Assert
 					Expect(gotErr).NotTo(HaveOccurred())
 					Expect(got.UserAuthorized).To(BeTrue())
 				})
+			})
+		})
+	})
+})
+
+var _ = Describe("ChgmResolved", func(){
+	Describe("AreAllInstancesRunning", func(){
+
+		var fakeErr = fmt.Errorf("test resolved")
+		var (
+			mockCtrl *gomock.Controller
+			mockClient *mock.MockService
+			isRunning chgm.Client
+			cluster *v1.Cluster
+			clusterDeployment hivev1.ClusterDeployment
+			infraID string
+
+			instance ec2.Instance
+		)
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+			mockClient = mock.NewMockService(mockCtrl)
+			isRunning = chgm.Client{Service: mockClient}
+			var err error
+			// Must explicitly set all node types for GetNodeCount() to work in these tests
+			cluster, err = v1.NewCluster().Nodes(v1.NewClusterNodes().Compute(0).Master(1).Infra(0)).State(v1.ClusterStateReady).Build()
+			Expect(err).ToNot(HaveOccurred())
+			clusterDeployment = hivev1.ClusterDeployment{
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{
+						InfraID: "12345",
+					},
+				},
+			}
+			infraID = clusterDeployment.Spec.ClusterMetadata.InfraID
+			instance = ec2.Instance{InstanceId: aws.String("12345")}
+		})
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+		When("the cluster state is undefined", func(){
+			It("should return an error", func() {
+				statelessCluster, err := v1.NewCluster().ID("statelessCluster").Build()
+				Expect(err).ToNot(HaveOccurred())
+				statelessDeployment := hivev1.ClusterDeployment{
+					Spec: hivev1.ClusterDeploymentSpec{
+						ClusterMetadata: &hivev1.ClusterMetadata{
+							InfraID: "statelessCluster",
+							ClusterID: "statelessCluster",
+						},
+					},
+				}
+				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(statelessCluster, nil)
+				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(statelessCluster.ID())).Return(&statelessDeployment, nil)
+
+				_, gotErr := isRunning.InvestigateStartedInstances("")
+				Expect(gotErr).To(HaveOccurred())
+			})
+		})
+		When("the cluster is uninstalling", func(){
+			It("should not investigate the cluster", func(){
+				uninstallingCluster, err := v1.NewCluster().ID("uninstallingCluster").State(v1.ClusterStateUninstalling).Build()
+				Expect(err).ToNot(HaveOccurred())
+				uninstallingClusterDeployment := hivev1.ClusterDeployment{
+					Spec: hivev1.ClusterDeploymentSpec{
+						ClusterMetadata: &hivev1.ClusterMetadata{
+							InfraID: "uninstallingCluster",
+							ClusterID: "uninstallingCluster",
+						},
+					},
+				}
+
+				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(uninstallingCluster, nil)
+				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(uninstallingCluster.ID())).Return(&uninstallingClusterDeployment, nil)
+
+				got, gotErr := isRunning.InvestigateStartedInstances("uninstallingCluster")
+				Expect(gotErr).ToNot(HaveOccurred())
+				Expect(got.ClusterNotEvaluated).To(BeTrue())
+				Expect(got.ClusterState).To(Equal(v1.ClusterStateUninstalling))
+			})
+		})
+		When("ListNonRunningInstances fails", func(){
+			It("should receive the correct InfraID and bubble the error", func() {
+				// Arrange
+				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
+				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return(nil, fakeErr)
+				// Act
+				_, gotErr := isRunning.InvestigateStartedInstances("")
+				// Assert
+				Expect(gotErr).To(HaveOccurred())
+			})
+		})
+		When("there are stopped instances", func(){
+			It("should succeed and return that non-running instances were found", func() {
+				// Arrange
+				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
+				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+				// Act
+				got, gotErr := isRunning.InvestigateStartedInstances("")
+				// Assert
+				Expect(gotErr).ToNot(HaveOccurred())
+				Expect(got.Error).ToNot(BeEmpty())
+				Expect(got.UserAuthorized).To(BeTrue())
+			})
+		})
+		When("ListRunningInstances fails", func(){
+			It("should receive the correct InfraID and bubble the error", func(){
+				// Arrange
+				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
+				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
+				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return(nil, fakeErr)
+				// Act
+				_, gotErr := isRunning.InvestigateStartedInstances("")
+				// Assert
+				Expect(gotErr).To(HaveOccurred())
+			})
+		})
+		When("the machine count does not equal the expected node count", func(){
+			It("should succeed and return that insuffient machines were found", func(){
+				// Arrange
+				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
+				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
+				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
+				// Act
+				got, gotErr := isRunning.InvestigateStartedInstances("")
+				// Assert
+				Expect(gotErr).ToNot(HaveOccurred())
+				Expect(got.Error).ToNot(BeEmpty())
+				Expect(got.UserAuthorized).To(BeTrue())
+			})
+		})
+		When("the cluster appears to be healthy again", func() {
+			It("should succeed and return that no issues were found", func() {
+				// Arrange
+				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
+				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
+				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+				// Act
+				got, gotErr := isRunning.InvestigateStartedInstances("")
+				// Assert
+				Expect(gotErr).ToNot(HaveOccurred())
+				Expect(got.Error).To(BeEmpty())
+				Expect(got.UserAuthorized).To(BeTrue())
+				Expect(got.AllInstances).ToNot(BeZero())
+				Expect(got.NonRunningInstances).To(BeEmpty())
 			})
 		})
 	})

--- a/pkg/services/chgm/mock/interfaces.go
+++ b/pkg/services/chgm/mock/interfaces.go
@@ -11,8 +11,8 @@ import (
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	v10 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
-	v11 "github.com/openshift/hive/apis/hive/v1"
+	pagerduty "github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
+	v10 "github.com/openshift/hive/apis/hive/v1"
 )
 
 // MockService is a mock of Service interface.
@@ -52,11 +52,70 @@ func (mr *MockServiceMockRecorder) AddNote(incidentID, noteContent interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNote", reflect.TypeOf((*MockService)(nil).AddNote), incidentID, noteContent)
 }
 
+// CreateNewAlert mocks base method.
+func (m *MockService) CreateNewAlert(description string, details interface{}, serviceID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNewAlert", description, details, serviceID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateNewAlert indicates an expected call of CreateNewAlert.
+func (mr *MockServiceMockRecorder) CreateNewAlert(description, details, serviceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewAlert", reflect.TypeOf((*MockService)(nil).CreateNewAlert), description, details, serviceID)
+}
+
+// DeleteCCAMLimitedSupportReason mocks base method.
+func (m *MockService) DeleteCCAMLimitedSupportReason(clusterID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCCAMLimitedSupportReason", clusterID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteCCAMLimitedSupportReason indicates an expected call of DeleteCCAMLimitedSupportReason.
+func (mr *MockServiceMockRecorder) DeleteCCAMLimitedSupportReason(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCCAMLimitedSupportReason", reflect.TypeOf((*MockService)(nil).DeleteCCAMLimitedSupportReason), clusterID)
+}
+
+// DeleteCHGMLimitedSupportReason mocks base method.
+func (m *MockService) DeleteCHGMLimitedSupportReason(clusterID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCHGMLimitedSupportReason", clusterID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteCHGMLimitedSupportReason indicates an expected call of DeleteCHGMLimitedSupportReason.
+func (mr *MockServiceMockRecorder) DeleteCHGMLimitedSupportReason(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCHGMLimitedSupportReason", reflect.TypeOf((*MockService)(nil).DeleteCHGMLimitedSupportReason), clusterID)
+}
+
+// ExtractServiceIDFromPayload mocks base method.
+func (m *MockService) ExtractServiceIDFromPayload(payloadFilePath string, reader pagerduty.FileReader) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtractServiceIDFromPayload", payloadFilePath, reader)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExtractServiceIDFromPayload indicates an expected call of ExtractServiceIDFromPayload.
+func (mr *MockServiceMockRecorder) ExtractServiceIDFromPayload(payloadFilePath, reader interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractServiceIDFromPayload", reflect.TypeOf((*MockService)(nil).ExtractServiceIDFromPayload), payloadFilePath, reader)
+}
+
 // GetClusterDeployment mocks base method.
-func (m *MockService) GetClusterDeployment(clusterID string) (*v11.ClusterDeployment, error) {
+func (m *MockService) GetClusterDeployment(clusterID string) (*v10.ClusterDeployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterDeployment", clusterID)
-	ret0, _ := ret[0].(*v11.ClusterDeployment)
+	ret0, _ := ret[0].(*v10.ClusterDeployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -169,17 +228,17 @@ func (mr *MockServiceMockRecorder) PollInstanceStopEventsFor(instances, retryTim
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollInstanceStopEventsFor", reflect.TypeOf((*MockService)(nil).PollInstanceStopEventsFor), instances, retryTimes)
 }
 
-// SendCHGMServiceLog mocks base method.
-func (m *MockService) SendCHGMServiceLog(cluster *v1.Cluster) (*v10.LogEntry, error) {
+// PostCHGMLimitedSupportReason mocks base method.
+func (m *MockService) PostCHGMLimitedSupportReason(clusterID string) (*v1.LimitedSupportReason, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendCHGMServiceLog", cluster)
-	ret0, _ := ret[0].(*v10.LogEntry)
+	ret := m.ctrl.Call(m, "PostCHGMLimitedSupportReason", clusterID)
+	ret0, _ := ret[0].(*v1.LimitedSupportReason)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SendCHGMServiceLog indicates an expected call of SendCHGMServiceLog.
-func (mr *MockServiceMockRecorder) SendCHGMServiceLog(cluster interface{}) *gomock.Call {
+// PostCHGMLimitedSupportReason indicates an expected call of PostCHGMLimitedSupportReason.
+func (mr *MockServiceMockRecorder) PostCHGMLimitedSupportReason(clusterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCHGMServiceLog", reflect.TypeOf((*MockService)(nil).SendCHGMServiceLog), cluster)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostCHGMLimitedSupportReason", reflect.TypeOf((*MockService)(nil).PostCHGMLimitedSupportReason), clusterID)
 }


### PR DESCRIPTION
Completes: https://issues.redhat.com/browse/OSD-12961; https://issues.redhat.com/browse/OSD-12957

---

These changes add logic to update the Limited Support status for a cluster based on the state of it's Cluster Has Gone Missing (CHGM) alert. 

When the CHGM alert fires initially, CAD evaluates the cluster and determines whether the alert was caused by a customer action. In cases where this is determined to be the case, the cluster is placed into Limited Support. Otherwise, the alert is forwarded based on the environment's PagerDuty escalation policy.

When the CHGM alert resolves, CAD once again evaluates the cluster and determines whether it is sufficiently healthy to be removed from Limited Support. This investigation consists of the following: 1) checking that all EC2 instances owned by the cluster in the customer's VPC are running, and 2) whether the number of EC2 instances in the customer's VPC matches the expected number in OCM (ensuring the customer has not deleted a machine). 
  - If the cluster passes the investigation, all Limited Support reasons, both CHGM and CCAM, matching the templates used by CAD are removed. (That is, limited support reasons added to the cluster manually are not guaranteed to be removed by CAD at this time.) 
  - If a cluster does not pass investigation, an alert is created on the environment's deadmanssnitch service using an integration called `Dead Man's Snitch` (the service for each environment is determined via the webhook payload). 

For `resolved` incidents in particular, most actions are retried until they succeed. This is purposeful, to prevent clusters from remaining in Limited Support due to a transient error (ie- PagerDuty throttling, AWS region down) when investigating them or removing a LS reason. 

In all cases (alert triggering or resolving), if CAD is unable to login to the cluster's AWS environment due to a missing support role, the Cloud Credentials Are Missing (CCAM) Limited Support reason is sent and no further action is taken. (As mentioned above, if this LS reason is sent when the alert triggers, but is found to be fixed when the alert is resolved, then that LS reason is removed as well). It's expected that customers will follow the normal LS workflow to remove this reason from their clusters if CAD does not do so.