### PR TITLE
Add cloud provider check before chgm investigation

### DIFF
--- a/cadctl/cmd/cluster-missing/cluster-missing.go
+++ b/cadctl/cmd/cluster-missing/cluster-missing.go
@@ -85,9 +85,9 @@ func run(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("ClusterExternalID is: %s\n", externalClusterID)
 
-	cloudProvider, err := ocmClient.GetCloudProvider(externalClusterID)
+	cloudProvider, err := ocmClient.GetCloudProviderID(externalClusterID)
 	if err != nil {
-		return fmt.Errorf("GetCloudProvider failed on: %w", err)
+		return err
 	} else if cloudProvider != "aws" {
 		return fmt.Errorf("cloudprovider is not supported: %s", cloudProvider)
 	}
@@ -310,19 +310,19 @@ func evaluateRestoredCluster(chgmClient chgm.Client, externalClusterID string) e
 
 // retryUntilServiceObtained attempts to retrieve the serviceID from the PD payload, retrying until successful
 func retryUntilServiceObtained(chgmClient chgm.Client) string {
-		// Retrieve the service to alert on, retrying until we succeed
-		serviceID, err := chgmClient.ExtractServiceIDFromPayload(payloadPath, pagerduty.RealFileReader{})
-		retries := 1
-		for err != nil {
-			fmt.Printf("Failed to retrieve service from PagerDuty, retrying (attempt %d). Error encountered: %v\n", retries, err)
+	// Retrieve the service to alert on, retrying until we succeed
+	serviceID, err := chgmClient.ExtractServiceIDFromPayload(payloadPath, pagerduty.RealFileReader{})
+	retries := 1
+	for err != nil {
+		fmt.Printf("Failed to retrieve service from PagerDuty, retrying (attempt %d). Error encountered: %v\n", retries, err)
 
-			// Sleep for a time, based on the number of retries (up to 300 seconds)
-			sleepBeforeRetrying(retries, 300)
-			retries++
+		// Sleep for a time, based on the number of retries (up to 300 seconds)
+		sleepBeforeRetrying(retries, 300)
+		retries++
 
-			serviceID, err = chgmClient.ExtractServiceIDFromPayload(payloadPath, pagerduty.RealFileReader{})
-		}
-		return serviceID
+		serviceID, err = chgmClient.ExtractServiceIDFromPayload(payloadPath, pagerduty.RealFileReader{})
+	}
+	return serviceID
 }
 
 // sleepBeforeRetrying sleeps with an exponential backoff based on the current retry, up to the given maximum sleep time.

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -182,8 +182,8 @@ func (c Client) getClusterResource(clusterID string, resourceKey string) (string
 	return response.Body().Resources()[resourceKey], nil
 }
 
-// GetCloudProvider returns the cloud provider name for a given cluster as a string
-func (c Client) GetCloudProvider(identifier string) (string, error) {
+// GetCloudProviderID returns the cloud provider name for a given cluster as a string
+func (c Client) GetCloudProviderID(identifier string) (string, error) {
 	cluster, err := c.GetClusterInfo(identifier)
 	if err != nil {
 		return "", fmt.Errorf("GetClusterInfo failed on: %w", err)


### PR DESCRIPTION
Cad currently only supports aws clusters and throws errors like this on gcp.
```
Assuming role failed, potential CCAM alert. Investigating... error:  3 failed to assume into jump-role: RequestError: send request failed
caused by: Post "https://sts.us-east1.amazonaws.com/": dial tcp: lookup sts.us-east1.amazonaws.com on 10.120.0.10:53: no such host
Error: credentials are there, error is different: 3 failed to assume into jump-role: RequestError: send request failed
caused by: Post "https://sts.us-east1.amazonaws.com/": dial tcp: lookup sts.us-east1.amazonaws.com on 10.120.0.10:53: no such host
```

This PR adds a check for the clusters cloud provider and throws a clear error message in case it is not 'aws'.
```
Incident ID is: Q2YUU901Z5FKY7
Error: cloudprovider is not supported: gcp
```

Closes:
- https://issues.redhat.com/browse/OSD-13417