### PR TITLE
OSD-13901 - Use heredocs when generating payload to avoid quoting errors

### DIFF
--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -19,7 +19,9 @@ spec:
           # save the payload to a file
           folder=$(mktemp -d)
           file=${folder}/payload.json
-          echo '$(params.payload)' > $file
+          cat << EOF > $file
+          '$(params.payload)'
+          EOF
           # run the cadctl command
           cadctl cluster-missing --payload-path $file
       # envFrom should pull all the secret information as envvars, so key names should be uppercase

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -174,7 +174,9 @@ objects:
         # save the payload to a file
         folder=$(mktemp -d)
         file=${folder}/payload.json
-        echo '$(params.payload)' > $file
+        cat << EOF > $file
+        '$(params.payload)'
+        EOF
         # run the cadctl command
         cadctl cluster-missing --payload-path $file
       command:


### PR DESCRIPTION
Completes: https://issues.redhat.com/browse/OSD-13901

---

These changes modify the payload generation logic, to avoid evaluating the quoting used within.

This is necessary because the string `Dead Man's Snitch` frequently appears in these payloads. When there's an odd number of these present in the data, bash interprets this as a mismatched quotation and the cluster evaluation never starts. 