### PR TITLE
OSD-13901 - Removed quotes surrounding payload data

### DIFF
--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -20,7 +20,7 @@ spec:
           folder=$(mktemp -d)
           file=${folder}/payload.json
           cat << EOF > $file
-          '$(params.payload)'
+          $(params.payload)
           EOF
           # run the cadctl command
           cadctl cluster-missing --payload-path $file

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -175,7 +175,7 @@ objects:
         folder=$(mktemp -d)
         file=${folder}/payload.json
         cat << EOF > $file
-        '$(params.payload)'
+        $(params.payload)
         EOF
         # run the cadctl command
         cadctl cluster-missing --payload-path $file


### PR DESCRIPTION
Removes single-quotes that were erroneously left in during https://github.com/openshift/configuration-anomaly-detection/pull/136. 