### PR TITLE
Additional bugfixes for CAD-LS integration

### DIFF
--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -84,15 +84,16 @@ func (c Client) Evaluate(awsError error, externalClusterID string, incidentID st
 	if err != nil {
 		return fmt.Errorf("couldn't determine if limited support reason already exists: %w", err)
 	}
-	if lsExists {
+	if !lsExists {
+		ls, err := c.PostCCAMLimitedSupportReason(c.cluster.ID())
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Added the following Limited Support reason to cluster: %#v\n", *ls)
+	} else {
 		fmt.Println("Avoided reposting duplicate CCAM limited support reason")
-		return nil
 	}
 
-	ls, err := c.PostCCAMLimitedSupportReason(c.cluster.ID())
-	if err == nil {
-		fmt.Printf("Added the following Limited Support reason to cluster: %#v\n", *ls)
-	}
 	return c.silenceAlert(incidentID, fmt.Sprintf("Cluster %s incident silenced", externalClusterID))
 }
 

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -55,6 +55,7 @@ type Service interface {
 	PostCHGMLimitedSupportReason(clusterID string) (*v1.LimitedSupportReason, error)
 	DeleteCHGMLimitedSupportReason(clusterID string) (bool, error)
 	DeleteCCAMLimitedSupportReason(clusterID string) (bool, error)
+	CHGMLimitedSupportExists(clusterID string) (bool, error)
 	// PD
 	AddNote(incidentID string, noteContent string) error
 	ExtractServiceIDFromPayload(payloadFilePath string, reader pagerduty.FileReader) (string, error)

--- a/pkg/services/chgm/mock/interfaces.go
+++ b/pkg/services/chgm/mock/interfaces.go
@@ -52,6 +52,21 @@ func (mr *MockServiceMockRecorder) AddNote(incidentID, noteContent interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNote", reflect.TypeOf((*MockService)(nil).AddNote), incidentID, noteContent)
 }
 
+// CHGMLimitedSupportExists mocks base method.
+func (m *MockService) CHGMLimitedSupportExists(clusterID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CHGMLimitedSupportExists", clusterID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CHGMLimitedSupportExists indicates an expected call of CHGMLimitedSupportExists.
+func (mr *MockServiceMockRecorder) CHGMLimitedSupportExists(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CHGMLimitedSupportExists", reflect.TypeOf((*MockService)(nil).CHGMLimitedSupportExists), clusterID)
+}
+
 // CreateNewAlert mocks base method.
 func (m *MockService) CreateNewAlert(description string, details interface{}, serviceID string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
These changes do the following:
- Avoid duplicating CHGM LS reasons if the cluster already has one
- Allow CCAM alerts to be silenced, even if a cluster already has a CCAM alert