### PR TITLE
Keep pipelines for a week

### DIFF
--- a/deploy/tekton-pruner.yaml
+++ b/deploy/tekton-pruner.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - args:
-                - 'tkn pipelinerun delete --keep=20 -f'
+                - "tkn pipelinerun delete --keep=50 -f"
               command:
                 - /bin/sh
                 - -c
@@ -31,7 +31,7 @@ spec:
           serviceAccountName: cad-tekton-pruner
           terminationGracePeriodSeconds: 30
       ttlSecondsAfterFinished: 3600
-  schedule: 0 * * * *
+  schedule: 0 0 * * 3
   successfulJobsHistoryLimit: 3
   suspend: false
 ---

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -223,7 +223,7 @@ objects:
             serviceAccountName: cad-tekton-pruner
             terminationGracePeriodSeconds: 30
         ttlSecondsAfterFinished: 3600
-    schedule: 0 0 * * WED
+    schedule: 0 0 * * 3
     successfulJobsHistoryLimit: 3
     suspend: false
 - apiVersion: v1

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -207,7 +207,7 @@ objects:
           spec:
             containers:
             - args:
-              - tkn pipelinerun delete --keep=20 -f
+              - tkn pipelinerun delete --keep=50 -f
               command:
               - /bin/sh
               - -c
@@ -223,7 +223,7 @@ objects:
             serviceAccountName: cad-tekton-pruner
             terminationGracePeriodSeconds: 30
         ttlSecondsAfterFinished: 3600
-    schedule: 0 * * * *
+    schedule: 0 0 * * WED
     successfulJobsHistoryLimit: 3
     suspend: false
 - apiVersion: v1


### PR DESCRIPTION
**What?**

Keep tekton pipelines for a week instead of pruning everything but the last 20 every hour.

**Why?**

We need access to pipeline run logs and don't want them to be pruned away before investigating.