### PR TITLE
OSD-14629 - CAD node/instance count check can misfire

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -174,6 +174,16 @@ func (c Client) GetClusterDeployment(clusterID string) (*hivev1.ClusterDeploymen
 	return cd, nil
 }
 
+// GetClusterMachinePools get the machine pools for a given cluster
+func (c Client) GetClusterMachinePools(clusterID string) ([]*v1.MachinePool, error) {
+    response, err := c.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).MachinePools().List().Page(1).Size(-1).Send()
+    if err != nil {
+        return nil, err
+    }
+    return response.Items().Slice(), nil
+}
+
+
 // getClusterResource allows to load different cluster resources
 func (c Client) getClusterResource(clusterID string, resourceKey string) (string, error) {
 	response, err := c.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).Resources().Live().Get().Send()

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -166,9 +166,9 @@ func (i InvestigateInstancesOutput) String() string {
 		msg += fmt.Sprintf("\nIssuerUserName: '%v' \n", i.User.IssuerUserName)
 	}
 	msg += fmt.Sprintf("\nNumber of non running instances: '%v' \n", len(i.NonRunningInstances))
-    msg += fmt.Sprintf("\nNumber of running instances:\n\tMaster: '%v'\n\tInfra: '%v'\n\tWorker: '%v'",
+    msg += fmt.Sprintf("\nNumber of running instances:\n\tMaster: '%v'\n\tInfra: '%v'\n\tWorker: '%v'\n",
         i.RunningInstances.Master, i.RunningInstances.Infra, i.RunningInstances.Worker)
-    msg += fmt.Sprintf("\nNumber of expected instances:\n\tMaster: '%v'\n\tInfra: '%v'\n\tMin Worker: '%v'\n\tMax Worker: '%v'",
+    msg += fmt.Sprintf("\nNumber of expected instances:\n\tMaster: '%v'\n\tInfra: '%v'\n\tMin Worker: '%v'\n\tMax Worker: '%v'\n",
         i.ExpectedInstances.Master, i.ExpectedInstances.Infra, i.ExpectedInstances.MinWorker, i.ExpectedInstances.MaxWorker)
 	var ids []string
 	for _, nonRunningInstance := range i.NonRunningInstances {
@@ -373,9 +373,6 @@ func (c Client) investigateStartedInstances() (InvestigateInstancesOutput, error
 	if runningNodesCount.Infra != expectedNodesCount.Infra {
 		return InvestigateInstancesOutput{UserAuthorized: true, Error: "number of running infra node instances does not match the expected infra node count: quota may be insufficient or irreplaceable machines have been terminated"}, nil
 	}
-	// if runningNodesCount.Worker >= expectedNodesCount.MinWorker && runningNodesCount.Worker <= expectedNodesCount.MaxWorker {
-	// 	return InvestigateInstancesOutput{UserAuthorized: true, Error: "number of running instances does not match the expected node count: quota may be insufficient or irreplaceable machines have been terminated"}, nil
-	// }
 
 	output := InvestigateInstancesOutput{
 		NonRunningInstances: stoppedInstances,

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -373,9 +373,9 @@ func (c Client) investigateStartedInstances() (InvestigateInstancesOutput, error
 	if runningNodesCount.Infra != expectedNodesCount.Infra {
 		return InvestigateInstancesOutput{UserAuthorized: true, Error: "number of running infra node instances does not match the expected infra node count: quota may be insufficient or irreplaceable machines have been terminated"}, nil
 	}
-	if runningNodesCount.Worker >= expectedNodesCount.MinWorker && runningNodesCount.Worker <= expectedNodesCount.MaxWorker {
-		return InvestigateInstancesOutput{UserAuthorized: true, Error: "number of running instances does not match the expected node count: quota may be insufficient or irreplaceable machines have been terminated"}, nil
-	}
+	// if runningNodesCount.Worker >= expectedNodesCount.MinWorker && runningNodesCount.Worker <= expectedNodesCount.MaxWorker {
+	// 	return InvestigateInstancesOutput{UserAuthorized: true, Error: "number of running instances does not match the expected node count: quota may be insufficient or irreplaceable machines have been terminated"}, nil
+	// }
 
 	output := InvestigateInstancesOutput{
 		NonRunningInstances: stoppedInstances,
@@ -431,12 +431,15 @@ func (c Client) GetRunningNodesCount(infraID string) (*RunningNodesCount, error)
     for _, instance := range instances {
         for _, t := range instance.Tags {
             if *t.Key == "Name" {
-                if strings.Contains(*t.Value, "master") {
+                switch {
+                case strings.Contains(*t.Value, "master"):
                     runningNodesCount.Master++
-                } else if strings.Contains(*t.Value, "infra") {
+                case strings.Contains(*t.Value, "infra"):
                     runningNodesCount.Infra++
-                } else if strings.Contains(*t.Value, "worker") {
+                case strings.Contains(*t.Value, "worker"):
                     runningNodesCount.Worker++
+                default:
+                    continue
                 }
             }
         }

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -264,7 +264,7 @@ func (c Client) investigateStoppedInstances() (InvestigateInstancesOutput, error
 
 	runningNodesCount, err := c.GetRunningNodesCount(infraID)
 	if err != nil {
-		return InvestigateInstancesOutput{UserAuthorized: true, Error: "no non running instances found, terminated instances may have already expired"}, nil
+		return InvestigateInstancesOutput{}, fmt.Errorf("could not retrieve running cluster nodes while investigating stopped instances for %s: %w", infraID, err)
 	}
 
 	// evaluate number of all supposed nodes
@@ -419,7 +419,7 @@ func (c Client) RemoveCCAMLimitedSupport(externalID string) (bool, error) {
 func (c Client) GetRunningNodesCount(infraID string) (*RunningNodesCount, error) {
     instances, err := c.ListRunningInstances(infraID) 
 	if err != nil {
-		return nil, fmt.Errorf("could not retrieve running instances while counting running nodes %s: %w", infraID, err)
+		return nil, err
 	}
 
     runningNodesCount := &RunningNodesCount{

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -52,6 +52,7 @@ type Service interface {
 	// OCM
 	GetClusterDeployment(clusterID string) (*hivev1.ClusterDeployment, error)
 	GetClusterInfo(identifier string) (*v1.Cluster, error)
+	GetClusterMachinePools(clusterID string) ([]*v1.MachinePool, error)
 	PostCHGMLimitedSupportReason(clusterID string) (*v1.LimitedSupportReason, error)
 	DeleteCHGMLimitedSupportReason(clusterID string) (bool, error)
 	DeleteCCAMLimitedSupportReason(clusterID string) (bool, error)
@@ -125,10 +126,26 @@ type UserInfo struct {
 	IssuerUserName string
 }
 
+// RunningNodesCount holds the number of actual running nodes
+type RunningNodesCount struct {
+    Master int
+    Infra  int
+    Worker int
+}
+
+// ExpectedNodesCount holds the number of expected running nodes
+type ExpectedNodesCount struct {
+    Master    int
+    Infra     int
+    MinWorker int
+    MaxWorker int
+}
+
 // InvestigateInstancesOutput is the result of the InvestigateInstances command
 type InvestigateInstancesOutput struct {
 	NonRunningInstances  []*ec2.Instance
-	AllInstances         int
+	RunningInstances     RunningNodesCount
+	ExpectedInstances    ExpectedNodesCount
 	User                 UserInfo
 	UserAuthorized       bool
 	ClusterState         v1.ClusterState
@@ -149,9 +166,10 @@ func (i InvestigateInstancesOutput) String() string {
 		msg += fmt.Sprintf("\nIssuerUserName: '%v' \n", i.User.IssuerUserName)
 	}
 	msg += fmt.Sprintf("\nNumber of non running instances: '%v' \n", len(i.NonRunningInstances))
-	if i.AllInstances >= 0 {
-		msg += fmt.Sprintf("\nSupposed cluster size: '%d' \n", i.AllInstances)
-	}
+    msg += fmt.Sprintf("\nNumber of running instances:\n\tMaster: '%v'\n\tInfra: '%v'\n\tWorker: '%v'",
+        i.RunningInstances.Master, i.RunningInstances.Infra, i.RunningInstances.Worker)
+    msg += fmt.Sprintf("\nNumber of expected instances:\n\tMaster: '%v'\n\tInfra: '%v'\n\tMin Worker: '%v'\n\tMax Worker: '%v'",
+        i.ExpectedInstances.Master, i.ExpectedInstances.Infra, i.ExpectedInstances.MinWorker, i.ExpectedInstances.MaxWorker)
 	var ids []string
 	for _, nonRunningInstance := range i.NonRunningInstances {
 		// TODO: add also the StateTransitionReason to the output if needed
@@ -245,12 +263,22 @@ func (c Client) investigateStoppedInstances() (InvestigateInstancesOutput, error
 	}
 
 	// evaluate number of all supposed nodes
-	nodeCount := c.GetNodeCount()
+	expectedNodesCount, err := c.GetExpectedNodesCount()
+	if err != nil {
+        // TODO
+	}
+
+	// evaluate the number of actual running nodes
+	runningNodesCount, err := c.GetRunningNodesCount()
+	if err != nil {
+        // TODO
+	}
 
 	output := InvestigateInstancesOutput{
 		NonRunningInstances: stoppedInstances,
 		UserAuthorized:      true,
-		AllInstances:        nodeCount,
+		RunningInstances:  *runningNodesCount,
+		ExpectedInstances: *expectedNodesCount,
 	}
 	for _, event := range stoppedInstancesEvents {
 		// fmt.Printf("the event is %#v\n", event)
@@ -329,20 +357,29 @@ func (c Client) investigateStartedInstances() (InvestigateInstancesOutput, error
 		return InvestigateInstancesOutput{UserAuthorized: true, Error: "non running instances found: cluster has not fully started or has excess machines"}, nil
 	}
 
-	// Verify cluster has expected number of nodes
-	nodeCount := c.GetNodeCount()
-	runningInstances, err := c.ListRunningInstances(infraID)
+	// evaluate number of all supposed nodes
+	expectedNodesCount, err := c.GetExpectedNodesCount()
 	if err != nil {
-		return InvestigateInstancesOutput{}, fmt.Errorf("could not retrieve running instances for %s: %w", infraID, err)
+        // TODO
 	}
-	if len(runningInstances) != nodeCount {
+
+	// evaluate the number of actual running nodes
+	runningNodesCount, err := c.GetRunningNodesCount()
+	if err != nil {
+        // TODO
+	}
+
+	// TODO check for master nodes count
+	// TODO check infra for infra nodes count
+	if runningNodesCount.Worker >= expectedNodesCount.MinWorker && runningNodesCount.Worker <= expectedNodesCount.MaxWorker {
 		return InvestigateInstancesOutput{UserAuthorized: true, Error: "number of running instances does not match the expected node count: quota may be insufficient or irreplaceable machines have been terminated"}, nil
 	}
 
 	output := InvestigateInstancesOutput{
 		NonRunningInstances: stoppedInstances,
 		UserAuthorized:      true,
-		AllInstances:        nodeCount,
+        ExpectedInstances:   *expectedNodesCount,
+        RunningInstances:    *runningNodesCount,
 	}
 	return output, nil
 }
@@ -376,31 +413,104 @@ func (c Client) RemoveCCAMLimitedSupport(externalID string) (bool, error) {
 	return c.DeleteCCAMLimitedSupportReason(c.cluster.ID())
 }
 
-// GetNodeCount returns the total number of all nodes that are supposed to be in the cluster
+// TODO
+func (c Client) GetRunningNodesCount() (*RunningNodesCount, error) {
+    runningNodesCount := &RunningNodesCount{}
+    return runningNodesCount, nil
+}
+
+// GetExpectedNodesCount returns the mininum number of nodes that are supposed to be in the cluster
 // We do not use nodes.GetTotal() here, because total seems to be always 0.
-func (c Client) GetNodeCount() int {
+func (c Client) GetExpectedNodesCount() (*ExpectedNodesCount, error) {
 	nodes, ok := c.cluster.GetNodes()
 	if !ok {
 		// We do not error out here, because we do not want to fail the whole run, because of one missing metric
 		fmt.Printf("node data is missing, dumping cluster object: %#v", c.cluster)
-		return -1 // we set nodeCount to -1. This is equal to "metric missing"
+		return nil, fmt.Errorf("Failed to retrieve cluster node data")
 	}
 	masterCount, ok := nodes.GetMaster()
 	if !ok {
 		fmt.Printf("master node data is missing, dumping cluster object: %#v", c.cluster)
-		return -1 // we set nodeCount to -1. This is equal to "metric missing"
+		return nil, fmt.Errorf("Failed to retrieve master node data")
 	}
 	infraCount, ok := nodes.GetInfra()
 	if !ok {
 		fmt.Printf("infra node data is missing, dumping cluster object: %#v", c.cluster)
-		return -1 // we set nodeCount to -1. This is equal to "metric missing"
+		return nil, fmt.Errorf("Failed to retrieve infra node data")
 	}
-	computeCount, ok := nodes.GetCompute()
-	if !ok {
-		fmt.Printf("infra node data is missing, dumping cluster object: %#v", c.cluster)
-		return -1 // we set nodeCount to -1. This is equal to "metric missing"
-	}
-	return masterCount + infraCount + computeCount
+
+    minWorkerCount, maxWorkerCount := 0, 0
+	computeCount, computeCountOk := nodes.GetCompute()
+	if computeCountOk {
+	    minWorkerCount += computeCount
+	    maxWorkerCount += computeCount
+    }
+    autoscaleCompute, autoscaleComputeOk := nodes.GetAutoscaleCompute()
+    if autoscaleComputeOk {
+        minReplicasCount, ok := autoscaleCompute.GetMinReplicas()
+        if !ok {
+            fmt.Printf("autoscale min replicas data is missing, dumping cluster object: %v#", c.cluster)
+            return nil, fmt.Errorf("Failed to retrieve min replicas from autoscale compute data")
+        }
+
+        maxReplicasCount, ok := autoscaleCompute.GetMaxReplicas()
+        if !ok {
+            fmt.Printf("autoscale max replicas data is missing, dumping cluster object: %v#", c.cluster)
+            return nil, fmt.Errorf("Failed to retrieve max replicas from autoscale compute data")
+        }
+
+        minWorkerCount += minReplicasCount
+        maxWorkerCount += maxReplicasCount
+    }
+    if !computeCountOk && !autoscaleComputeOk {
+        fmt.Printf("compute and autoscale compute data are missing, dumping cluster object: %v#", c.cluster)
+        return nil, fmt.Errorf("Failed to retrieve cluster compute and autoscale compute data")
+    }
+
+    poolMinWorkersCount, poolMaxWorkersCount := 0, 0
+    machinePools, err := c.GetClusterMachinePools(c.cluster.ID())
+    if err != nil {
+		fmt.Printf("machine pools data is missing, dumping cluster object: %#v", c.cluster)
+		return nil, fmt.Errorf("Failed to retrieve machine pools data")
+    }
+    for _, pool := range machinePools {
+        replicasCount, replicasCountOk := pool.GetReplicas()
+        if replicasCountOk {
+            poolMinWorkersCount += replicasCount
+            poolMaxWorkersCount += replicasCount
+        }
+
+        autoscaling, autoscalingOk := pool.GetAutoscaling()
+        if autoscalingOk {
+            minReplicasCount, ok := autoscaling.GetMinReplicas()
+            if !ok {
+                fmt.Printf("min replicas data is missing from autoscaling pool, dumping pool object: %v#", pool)
+                return nil, fmt.Errorf("Failed to retrieve min replicas data from autoscaling pool")
+            }
+
+            maxReplicasCount, ok := autoscaling.GetMaxReplicas()
+            if !ok {
+                fmt.Printf("min replicas data is missing from autoscaling pool, dumping pool object: %v#", pool)
+                return nil, fmt.Errorf("Failed to retrieve max replicas data from autoscaling pool")
+            }
+
+            poolMinWorkersCount += minReplicasCount
+            poolMaxWorkersCount += maxReplicasCount
+        }
+
+        if !replicasCountOk && !autoscalingOk {
+            fmt.Printf("pool replicas and autoscaling data are missing from autoscaling pool, dumping pool object: %v#", pool)
+            return nil, fmt.Errorf("Failed to retrieve replicas and autoscaling data from autoscaling pool")
+        }
+    }
+
+    nodeCount := &ExpectedNodesCount {
+        Master: masterCount,
+        Infra: infraCount,
+        MinWorker: minWorkerCount + poolMinWorkersCount,
+        MaxWorker: maxWorkerCount + poolMaxWorkersCount,
+    }
+	return nodeCount, nil
 }
 
 // EscalateAlert will ensure that an incident informs a SRE.

--- a/pkg/services/chgm/chgm_test.go
+++ b/pkg/services/chgm/chgm_test.go
@@ -382,6 +382,7 @@ var _ = Describe("ChgmResolved", func() {
 			isRunning         chgm.Client
 			cluster           *v1.Cluster
 			clusterDeployment hivev1.ClusterDeployment
+			machinePools      []*v1.MachinePool
 			infraID           string
 
 			instance ec2.Instance
@@ -504,6 +505,7 @@ var _ = Describe("ChgmResolved", func() {
 				// Arrange
 				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				mockClient.EXPECT().NonCADLimitedSupportExists(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return(nil, fakeErr)
@@ -518,6 +520,7 @@ var _ = Describe("ChgmResolved", func() {
 				// Arrange
 				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				mockClient.EXPECT().NonCADLimitedSupportExists(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
@@ -534,6 +537,7 @@ var _ = Describe("ChgmResolved", func() {
 				// Arrange
 				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				mockClient.EXPECT().NonCADLimitedSupportExists(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
@@ -543,7 +547,6 @@ var _ = Describe("ChgmResolved", func() {
 				Expect(gotErr).ToNot(HaveOccurred())
 				Expect(got.Error).To(BeEmpty())
 				Expect(got.UserAuthorized).To(BeTrue())
-				Expect(got.AllInstances).ToNot(BeZero())
 				Expect(got.NonRunningInstances).To(BeEmpty())
 			})
 		})

--- a/pkg/services/chgm/chgm_test.go
+++ b/pkg/services/chgm/chgm_test.go
@@ -26,6 +26,7 @@ var _ = Describe("ChgmTriggered", func() {
 			isRunning         chgm.Client
 			cluster           *v1.Cluster
 			clusterDeployment hivev1.ClusterDeployment
+			machinePools      []*v1.MachinePool
 			infraID           string
 			instance          ec2.Instance
 		)
@@ -34,7 +35,7 @@ var _ = Describe("ChgmTriggered", func() {
 			mockClient = mock.NewMockService(mockCtrl)
 			isRunning = chgm.Client{Service: mockClient}
 			var err error
-			cluster, err = v1.NewCluster().ID("12345").Nodes(v1.NewClusterNodes().Total(1)).Build()
+			cluster, err = v1.NewCluster().ID("12345").Nodes(v1.NewClusterNodes().Master(1).Infra(0).Compute(0)).Build()
 			Expect(err).ToNot(HaveOccurred())
 			clusterDeployment = hivev1.ClusterDeployment{
 				Spec: hivev1.ClusterDeploymentSpec{
@@ -156,7 +157,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(``)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -172,7 +175,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(`{}`)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -188,7 +193,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(`{`)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -204,7 +211,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(`{}`)
 					cloudTrailResource := cloudtrail.Resource{ResourceName: aws.String("123456")}
 					event.Resources = []*cloudtrail.Resource{&cloudTrailResource}
@@ -222,7 +231,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(`{"eventVersion":"1.07"}`)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -238,7 +249,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.Username = aws.String(fmt.Sprintf("%s-openshift-machine-api-aws-abcd", infraID))
 					event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08"}`)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
@@ -256,7 +269,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.Username = aws.String("osdManagedAdmin-abcd")
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -273,7 +288,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
 					// Act
@@ -289,7 +306,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{}}`)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -306,7 +325,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{"type":"IAMUser"}}`)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -323,7 +344,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{"type":"AssumedRole", "sessionContext":{"sessionIssuer":{"type":"test"}}}}`)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -340,7 +363,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{"type":"AssumedRole", "sessionContext":{"sessionIssuer":{"type":"Role", "userName": "654321"}}}}`)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -357,7 +382,9 @@ var _ = Describe("ChgmTriggered", func() {
 					// Arrange
 					mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 					mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
+                    mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 					mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
+					mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 					event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{"type":"AssumedRole", "sessionContext":{"sessionIssuer":{"type":"Role", "userName": "OrganizationAccountAccessRole"}}}}`)
 					mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 
@@ -386,6 +413,7 @@ var _ = Describe("ChgmResolved", func() {
 			infraID           string
 
 			instance ec2.Instance
+			instanceTag       ec2.Tag
 		)
 		BeforeEach(func() {
 			mockCtrl = gomock.NewController(GinkgoT())
@@ -403,7 +431,13 @@ var _ = Describe("ChgmResolved", func() {
 				},
 			}
 			infraID = clusterDeployment.Spec.ClusterMetadata.InfraID
-			instance = ec2.Instance{InstanceId: aws.String("12345")}
+            instanceTag.SetKey("Name")
+            instanceTag.SetValue("cluter-test-gzq47-master-0")
+			instance = ec2.Instance{
+			    InstanceId: aws.String("12345"),
+                Tags: []*ec2.Tag{&instanceTag},
+
+			}
 		})
 		AfterEach(func() {
 			mockCtrl.Finish()
@@ -505,7 +539,6 @@ var _ = Describe("ChgmResolved", func() {
 				// Arrange
 				mockClient.EXPECT().GetClusterInfo(gomock.Any()).Return(cluster, nil)
 				mockClient.EXPECT().GetClusterDeployment(gomock.Eq(cluster.ID())).Return(&clusterDeployment, nil)
-				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				mockClient.EXPECT().NonCADLimitedSupportExists(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return(nil, fakeErr)

--- a/pkg/services/chgm/mock/interfaces.go
+++ b/pkg/services/chgm/mock/interfaces.go
@@ -141,6 +141,21 @@ func (mr *MockServiceMockRecorder) GetClusterInfo(identifier interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterInfo", reflect.TypeOf((*MockService)(nil).GetClusterInfo), identifier)
 }
 
+// GetClusterMachinePools mocks base method.
+func (m *MockService) GetClusterMachinePools(clusterID string) ([]*v1.MachinePool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterMachinePools", clusterID)
+	ret0, _ := ret[0].([]*v1.MachinePool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterMachinePools indicates an expected call of GetClusterMachinePools.
+func (mr *MockServiceMockRecorder) GetClusterMachinePools(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMachinePools", reflect.TypeOf((*MockService)(nil).GetClusterMachinePools), clusterID)
+}
+
 // GetEscalationPolicy mocks base method.
 func (m *MockService) GetEscalationPolicy() string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Updated the node count check to differentiate between master, infra and worker. Included the machine pools workers in the workers count.
The investigation of started instance gives an error only if there's a mismatch in the count of master or infra nodes.