### PR TITLE
Increase pipeline quota to 1000

### DIFF
--- a/deploy/resource-quota.yaml
+++ b/deploy/resource-quota.yaml
@@ -4,4 +4,4 @@ metadata:
   name: pipelinerun-counts
 spec:
   hard:
-    count/pipelineruns.tekton.dev: "100"
+    count/pipelineruns.tekton.dev: "1000"

--- a/openshift/PipelinePruning.md
+++ b/openshift/PipelinePruning.md
@@ -14,4 +14,4 @@ This command will delete all PipelineRuns except for the last 20.
 
 For doing this, the cronjob needs permissions, these permissions are set in a role, defined in  [template.yaml](template.yaml) as well.
 
-Note, that we have also defined a ResourceQuota that limits the PipelineRuns to a maximum number of 100.
+Note, that we have also defined a ResourceQuota that limits the PipelineRuns to a maximum number of 1000. This does not mean concurrent runs but all the runs that exist for that pipeline.

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -88,6 +88,7 @@ objects:
     name: pipelinerun-counts
   spec:
     hard:
+    # This does not mean concurrent runs
       count/pipelineruns.tekton.dev: "1000"
 - apiVersion: v1
   kind: ServiceAccount

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -88,7 +88,7 @@ objects:
     name: pipelinerun-counts
   spec:
     hard:
-      count/pipelineruns.tekton.dev: "100"
+      count/pipelineruns.tekton.dev: "1000"
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -88,7 +88,6 @@ objects:
     name: pipelinerun-counts
   spec:
     hard:
-    # This does not mean concurrent runs
       count/pipelineruns.tekton.dev: "1000"
 - apiVersion: v1
   kind: ServiceAccount


### PR DESCRIPTION
Since we keep runs longer after the change in https://github.com/openshift/configuration-anomaly-detection/pull/151 
we need to also increase the quota.

We ran into this issue on stage today where CAD was unable to spawn new runs, checking the event listener, we could see quota errors and deleting some PipelineRuns manually fixed the issue.

