### PR TITLE
fix: osdmanagedadmin user prefix

### DIFF
--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -102,7 +102,7 @@ func isUserAllowedToStop(username, issuerUsername string, userDetails CloudTrail
 	}
 
 	// I wanted to keep this an if statement, but golangci-lint didn't allow me :(
-	if strings.HasPrefix(username, "osdManagedAdmin-") {
+	if strings.HasPrefix(username, "osdManagedAdmin") {
 		return true
 	}
 


### PR DESCRIPTION
[OSD-15256](https://issues.redhat.com//browse/OSD-15256)

The osdmanagedadmin user does not always contain a suffix, sometimes it can be just "osdmanagedadmin". This fixes the authorized user check.