### PR TITLE
fix: don't overwrite unauthorized user data

### DIFF
--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -286,11 +286,19 @@ func (c Client) investigateStoppedInstances() (InvestigateInstancesOutput, error
 			UserName:       *event.Username,
 			IssuerUserName: userDetails.UserIdentity.SessionContext.SessionIssuer.UserName,
 		}
+
 		if !isUserAllowedToStop(*event.Username, output.User.IssuerUserName, userDetails, infraID) {
 			output.UserAuthorized = false
+
+			// Return early with `output` containing the first unauthorized user.
+			// This prevents overwriting the `Output.User` fields in the next loop.
+			return output, nil
 		}
 	}
 
+	// Return the last `stoppedInstanceEvent` `UserInfo`, ideally we would want to return 
+	// all users that stopped events, not just the last one. But in the case it's authorized, 
+	// it's not too much of an issue to just keep one of the authorized users. 
 	return output, nil
 }
 


### PR DESCRIPTION
**Why?**
When checking the cloudtrail events of unauthorized users, we iterate through them and set the `output.UserAuthorized = false` flag. However, even after finding an unauthorized user, we keep on looping and overwrite the `output.User` data. This results in `output` containing the wrong user along with the unauthorized flag, which makes logs and the pagerduty notes point investigators in the wrong direction.

**What?**
Return early once we find an unauthorized user, as to not overwrite the `output` data.

I think we definitely need a total revamp of `output` and the way we print it. Go ctx comes to mind to easily add data on the fly and pass it through the whole investigation ;) However, I don't want to interfere to much with the currently pending PRs, so I'm keeping this fix as small as possible.