### PR TITLE
fix: Exit and return success when posting CCAM limited support

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -105,6 +105,11 @@ func run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// If jumpRoles does not return an aws.Client and there was no error
+	// then cluster is in limited support for missing cloud credentials
+	if customerAwsClient == (aws.Client{}) {
+		return nil
+	}
 
 	investigationClient := investigation.Client{}
 


### PR DESCRIPTION
Quick fix for a bug introduced with the refactor.
After putting a cluster in limited support for ccam there was no return statement, failing on a subsequent call to non existent aws.Client and failing the pipeline.

Now it should return nil when it put a cluster in ccam limited support and end the run correctly.