### PR TITLE
Increase timeout for golang ci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,9 @@
 run:
   # Our CI expects a vendor directory, hence we have to use -mod=readonly here as well.
   modules-download-mode: readonly
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 5m
 
 issues:
   # on default, golangci-lint excludes gosec. Hence, we have to

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,9 +7,6 @@ issues:
   # explicitly disable the exclude-use-default: https://github.com/golangci/golangci-lint/issues/1504
   exclude-use-default: false
 
-# individual linter configs go here
-linters-settings:
-
 # default linters are enabled `golangci-lint help linters`
 linters:
   disable-all: true


### PR DESCRIPTION
**Why?**

Linter timeout (default 1 min) currently fails. 

**What?**

Increase linter timeout.