### PR TITLE
Add note for unsupported infra

### DIFF
--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -4,7 +4,6 @@ package ccam
 import (
 	"fmt"
 	"regexp"
-	"time"
 
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
@@ -112,13 +111,13 @@ func (c Client) Evaluate(awsError error, externalClusterID string, incidentID st
 // if it fails to do so, it will try to alert primary
 // Run this after cloud credentials are confirmed
 func (c Client) RemoveLimitedSupport() error {
-	err := utils.Retry(utils.DefaultRetries, time.Second*2, func() error {
+	err := utils.WithRetries(func() error {
 		return c.DeleteLimitedSupportReasons(ccamLimitedSupport, c.Cluster.ID())
 	})
 	if err != nil {
-		fmt.Printf("Failed '%d' times to remove CCAM Limited support reason from cluster. Attempting to alert Primary.\n", utils.DefaultRetries)
+		fmt.Println("Failed to remove CCAM Limited support reason from cluster. Attempting to alert Primary.")
 		originalErr := err
-		err := utils.Retry(utils.DefaultRetries, time.Second*2, func() error {
+		err := utils.WithRetries(func() error {
 			return c.CreateNewAlert(c.buildAlertForCCAM(originalErr), c.GetServiceID())
 		})
 		if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,17 +5,22 @@ import (
 	"time"
 )
 
-// DefaultRetries is the default value of retries
-const DefaultRetries = 10
+// WithRetries runs a function with up to 10 retries on error
+func WithRetries(fn func() error) error {
+	const defaultRetries = 10
+	const defaultInitialBackoff = time.Second * 2
 
-// Retry will retry a function with a backoff
-func Retry(count int, sleep time.Duration, fn func() error) error {
+	return WithRetriesConfigurable(defaultRetries, defaultInitialBackoff, fn)
+}
+
+// WithRetriesConfigurable runs a function with a configurable retry count and backoff interval on error
+func WithRetriesConfigurable(count int, initialBackoff time.Duration, fn func() error) error {
 	var err error
 	for i := 0; i < count; i++ {
 		if i > 0 {
 			fmt.Printf("Retry %d: %s \n", i, err.Error())
-			time.Sleep(sleep)
-			sleep *= 2
+			time.Sleep(initialBackoff)
+			initialBackoff *= 2
 		}
 		err = fn()
 		if err == nil {


### PR DESCRIPTION
**What?**

- refactor retries function to remove duplicate defaults and global variables (commit 1)
- Add pagerduty note when infrastructure is unsupported for investigation (commit 2)

**Why?**

- General maintainance
- Make it clear why CAD didn't run on a CHGM for GCP clusters