### PR TITLE
Limited CHGM alert resolve investigations to clusters that have the CHGM LS reason

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -161,13 +161,12 @@ func (c Client) GetClusterDeployment(clusterID string) (*hivev1.ClusterDeploymen
 
 // GetClusterMachinePools get the machine pools for a given cluster
 func (c Client) GetClusterMachinePools(clusterID string) ([]*v1.MachinePool, error) {
-    response, err := c.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).MachinePools().List().Page(1).Size(-1).Send()
-    if err != nil {
-        return nil, err
-    }
-    return response.Items().Slice(), nil
+	response, err := c.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).MachinePools().List().Page(1).Size(-1).Send()
+	if err != nil {
+		return nil, err
+	}
+	return response.Items().Slice(), nil
 }
-
 
 // getClusterResource allows to load different cluster resources
 func (c Client) getClusterResource(clusterID string, resourceKey string) (string, error) {
@@ -268,8 +267,8 @@ func (c Client) DeleteLimitedSupportReasons(ls LimitedSupportReason, clusterID s
 	return nil
 }
 
-// LimitedSupportReasonsExist indicates whether any LS reasons exist on a given cluster
-func (c Client) LimitedSupportReasonsExist(clusterID string) (bool, error) {
+// IsInLimitedSupport indicates whether any LS reasons exist on a given cluster
+func (c Client) IsInLimitedSupport(clusterID string) (bool, error) {
 	reasons, err := c.listLimitedSupportReasons(clusterID)
 	if err != nil {
 		return false, fmt.Errorf("failed to list existing limited support reasons: %w", err)
@@ -285,7 +284,7 @@ func (c Client) LimitedSupportReasonsExist(clusterID string) (bool, error) {
 func (c Client) UnrelatedLimitedSupportExists(ls LimitedSupportReason, clusterID string) (bool, error) {
 	reasons, err := c.listLimitedSupportReasons(clusterID)
 	if err != nil {
-		return false, fmt.Errorf("failed to list current limited support reasons: %w", err)
+		return false, fmt.Errorf("UnrelatedLimitedSupportExists: failed to list current limited support reasons: %w", err)
 	}
 	if len(reasons) == 0 {
 		return false, nil
@@ -293,7 +292,27 @@ func (c Client) UnrelatedLimitedSupportExists(ls LimitedSupportReason, clusterID
 
 	for _, reason := range reasons {
 		if !c.reasonsMatch(ls, reason) {
-			fmt.Printf("cluster is in limited support for unrelated reason: %s\n", reason.Summary())
+			fmt.Printf("UnrelatedLimitedSupportExists: cluster is in limited support for unrelated reason: %s\n", reason.Summary())
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// LimitedSupportReasonExists takes a cluster id and limited support reason
+// Returns true if the limited support reason exists on the cluster
+func (c Client) LimitedSupportReasonExists(ls LimitedSupportReason, clusterID string) (bool, error) {
+	reasons, err := c.listLimitedSupportReasons(clusterID)
+	if err != nil {
+		return false, fmt.Errorf("LimitedSupportReasonExists: failed to list current limited support reasons: %w", err)
+	}
+	if len(reasons) == 0 {
+		return false, nil
+	}
+
+	for _, reason := range reasons {
+		if c.reasonsMatch(ls, reason) {
+			fmt.Printf("LimitedSupportReasonExists: cluster is in limited support for reason: %s\n", reason.Summary())
 			return true, nil
 		}
 	}

--- a/pkg/services/chgm/chgm_test.go
+++ b/pkg/services/chgm/chgm_test.go
@@ -98,7 +98,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&masterInstance, &infraInstance}, nil)
 				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				// TODO discuss to which degree we want to mock
 				mockClient.EXPECT().SilenceAlert(gomock.Any())
@@ -123,7 +123,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{}, nil)
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&masterInstance, &infraInstance}, nil)
 				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
 				gotErr := isRunning.Triggered()
 				// Assert
@@ -163,7 +163,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{"type":"AssumedRole", "sessionContext":{"sessionIssuer":{"type":"Role", "userName": "654321"}}}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
 
@@ -181,7 +181,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"PRINCIPALID_REDACTED:1234567789","arn":"arn:aws:sts::1234:assumed-role/cluster-name-n9o7-openshift-machine-api-aws-cloud-credentials/1234567789","accountId":"1234","accessKeyId":"REDACTED","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"PRINCIPALID_REDACTED","arn":"arn:aws:iam::1234:role/cluster-name-n9o7-openshift-machine-api-aws-cloud-credentials","accountId":"1234","userName":"cluster-name-n9o7-openshift-machine-api-aws-cloud-credentials"},"webIdFederationData":{"federatedProvider":"arn:aws:iam::1234:oidc-provider/rh-oidc.s3.us-east-1.amazonaws.com/redacted","attributes":{}},"attributes":{"creationDate":"2023-02-21T04:54:56Z","mfaAuthenticated":"false"}}},"eventTime":"2023-02-21T04:54:56Z","eventSource":"ec2.amazonaws.com","eventName":"TerminateInstances","awsRegion":"ap-southeast-1","sourceIPAddress":"192.168.0.0","userAgent":"aws-sdk-go/1.43.20 (go1.18.7; linux; amd64) openshift.io cluster-api-provider-aws/4.11.0-202301051515.p0.ga796a77.assembly.stream","requestParameters":{"instancesSet":{"items":[{"instanceId":"i-08020c19123456789"}]}},"responseElements":{"requestId":"b8c78d9a-51de-4910-123456789","instancesSet":{"items":[{"instanceId":"i-08020c19123456789","currentState":{"code":32,"name":"shutting-down"},"previousState":{"code":32,"name":"shutting-down"}}]}},"requestID":"b8c78d9a-51de-4910-123456789","eventID":"5455f882-a4db-4505-bea6-123456789","readOnly":false,"eventType":"AwsApiCall","managementEvent":true,"recipientAccountId":"1234","eventCategory":"Management","tlsDetails":{"tlsVersion":"TLSv1.2","cipherSuite":"ECDHE-RSA-AES128-GCM-SHA256","clientProvidedHostHeader":"ec2.ap-southeast-1.amazonaws.com"}}`)
 				event.Username = aws.String("1234567789") // ID of the initial jumprole account
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
@@ -195,7 +195,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{"type":"AssumedRole", "sessionContext":{"sessionIssuer":{"type":"Role", "userName": "OrganizationAccountAccessRole"}}}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
@@ -210,7 +210,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"redacted:1234567","arn":"arn:aws:sts::1234567:assumed-role/ManagedOpenShift-Installer-Role/1234567","accountId":"1234567","accessKeyId":"redacted","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"redacted","arn":"arn:aws:iam::1234567:role/ManagedOpenShift-Installer-Role","accountId":"1234567","userName":"ManagedOpenShift-Installer-Role"},"webIdFederationData":{},"attributes":{"creationDate":"2023-02-21T04:33:06Z","mfaAuthenticated":"false"}}},"eventTime":"2023-02-21T04:33:09Z","eventSource":"ec2.amazonaws.com","eventName":"TerminateInstances","awsRegion":"ap-southeast-1","sourceIPAddress":"192.0.0.1","userAgent":"APN/1.0 HashiCorp/1.0 Terraform/1.0.11 (+https://www.terraform.io) terraform-provider-aws/dev (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go/1.43.9 (go1.18.7; linux; amd64) HashiCorp-terraform-exec/0.16.1","requestParameters":{"instancesSet":{"items":[{"instanceId":"i-0c123456"}]}},"responseElements":{"requestId":"bd3900cb-1234567","instancesSet":{"items":[{"instanceId":"i-0c123456","currentState":{"code":32,"name":"shutting-down"},"previousState":{"code":16,"name":"running"}}]}},"requestID":"bd3900cb-1234567","eventID":"7064eae0-1234567","readOnly":false,"eventType":"AwsApiCall","managementEvent":true,"recipientAccountId":"1234","eventCategory":"Management","tlsDetails":{"tlsVersion":"TLSv1.2","cipherSuite":"ECDHE-RSA-AES128-GCM-SHA256","clientProvidedHostHeader":"ec2.ap-southeast-1.amazonaws.com"}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
@@ -224,7 +224,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				event.Username = aws.String("osdManagedAdmin-abcd")
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
@@ -238,7 +238,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
 
@@ -253,7 +253,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"REDACTED:OCM","arn":"arn:aws:sts::1234:assumed-role/testuser/OCM","accountId":"1234","accessKeyId":"REDACTED","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"REDACTED","arn":"arn:aws:iam::1234:role/testuser","accountId":"1234","userName":"testuser"},"webIdFederationData":{},"attributes":{"creationDate":"2023-02-21T04:08:01Z","mfaAuthenticated":"false"}}},"eventTime":"2023-02-21T04:10:40Z","eventSource":"ec2.amazonaws.com","eventName":"TerminateInstances","awsRegion":"ap-southeast-1","sourceIPAddress":"192.168.0.0","userAgent":"aws-sdk-go-v2/1.17.3 os/linux lang/go/1.19.5 md/GOOS/linux md/GOARCH/amd64 api/ec2/1.25.0","requestParameters":{"instancesSet":{"items":[{"instanceId":"i-00c1f1234567"}]}},"responseElements":{"requestId":"credacted","instancesSet":{"items":[{"instanceId":"i-00c1f1234567","currentState":{"code":32,"name":"shutting-down"},"previousState":{"code":16,"name":"running"}}]}},"requestID":"credacted","eventID":"e55a8a64-9949-47a9-9fff-12345678","readOnly":false,"eventType":"AwsApiCall","managementEvent":true,"recipientAccountId":"1234","eventCategory":"Management","tlsDetails":{"tlsVersion":"TLSv1.2","cipherSuite":"ECDHE-RSA-AES128-GCM-SHA256","clientProvidedHostHeader":"ec2.ap-southeast-1.amazonaws.com"}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
 
@@ -268,7 +268,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{"type":"AssumedRole", "sessionContext":{"sessionIssuer":{"type":"test"}}}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
 
@@ -282,7 +282,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
 
@@ -298,7 +298,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
 
@@ -314,7 +314,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{"type":"IAMUser"}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().LimitedSupportReasonsExist(gomock.Eq(cluster.ID())).Return(false, nil)
+				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
 
@@ -413,7 +413,7 @@ var _ = Describe("chgm", func() {
 						},
 					},
 				}
-
+				mockClient.EXPECT().LimitedSupportReasonExists(gomock.Eq(chgmLimitedSupport), gomock.Eq("uninstallingCluster")).Return(true, nil)
 				mockClient.EXPECT().AddNote(gomock.Any()).Return(nil)
 				gotErr := isRunning.Resolved()
 				Expect(gotErr).ToNot(HaveOccurred())
@@ -422,6 +422,7 @@ var _ = Describe("chgm", func() {
 		When("the cluster is in limited support for an unrelated reason", func() {
 			It("should not investigate the cluster", func() {
 				// Arrange
+				mockClient.EXPECT().LimitedSupportReasonExists(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(true, nil)
 				mockClient.EXPECT().UnrelatedLimitedSupportExists(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(true, nil)
 				mockClient.EXPECT().AddNote(gomock.Any()).Return(nil)
 				// Act
@@ -433,6 +434,7 @@ var _ = Describe("chgm", func() {
 		When("UnrelatedLimitedSupportReasonExists fails", func() {
 			It("should alert primary for an investigation failure", func() {
 				// Arrange
+				mockClient.EXPECT().LimitedSupportReasonExists(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(true, nil)
 				mockClient.EXPECT().UnrelatedLimitedSupportExists(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(false, fakeErr)
 				// Should we mock the alerts here?
 				mockClient.EXPECT().AddNote(gomock.Any()).Return(nil)
@@ -447,6 +449,7 @@ var _ = Describe("chgm", func() {
 		When("ListRunningInstances fails", func() {
 			It("should alert primary for an investigation failure", func() {
 				// Arrange
+				mockClient.EXPECT().LimitedSupportReasonExists(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(true, nil)
 				mockClient.EXPECT().UnrelatedLimitedSupportExists(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return(nil, fakeErr)
 				mockClient.EXPECT().AddNote(gomock.Any()).Return(nil)
@@ -462,6 +465,7 @@ var _ = Describe("chgm", func() {
 			It("should complete and remove the chgm limited support reason", func() {
 				// Arrange
 				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
+				mockClient.EXPECT().LimitedSupportReasonExists(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(true, nil)
 				mockClient.EXPECT().UnrelatedLimitedSupportExists(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&masterInstance, &infraInstance}, nil)
 				mockClient.EXPECT().DeleteLimitedSupportReasons(chgmLimitedSupport, "")

--- a/pkg/services/chgm/mock/interfaces.go
+++ b/pkg/services/chgm/mock/interfaces.go
@@ -109,19 +109,34 @@ func (mr *MockServiceMockRecorder) GetServiceID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceID", reflect.TypeOf((*MockService)(nil).GetServiceID))
 }
 
-// LimitedSupportReasonsExist mocks base method.
-func (m *MockService) LimitedSupportReasonsExist(clusterID string) (bool, error) {
+// IsInLimitedSupport mocks base method.
+func (m *MockService) IsInLimitedSupport(clusterID string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LimitedSupportReasonsExist", clusterID)
+	ret := m.ctrl.Call(m, "IsInLimitedSupport", clusterID)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LimitedSupportReasonsExist indicates an expected call of LimitedSupportReasonsExist.
-func (mr *MockServiceMockRecorder) LimitedSupportReasonsExist(clusterID interface{}) *gomock.Call {
+// IsInLimitedSupport indicates an expected call of IsInLimitedSupport.
+func (mr *MockServiceMockRecorder) IsInLimitedSupport(clusterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LimitedSupportReasonsExist", reflect.TypeOf((*MockService)(nil).LimitedSupportReasonsExist), clusterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsInLimitedSupport", reflect.TypeOf((*MockService)(nil).IsInLimitedSupport), clusterID)
+}
+
+// LimitedSupportReasonExists mocks base method.
+func (m *MockService) LimitedSupportReasonExists(ls ocm.LimitedSupportReason, clusterID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LimitedSupportReasonExists", ls, clusterID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LimitedSupportReasonExists indicates an expected call of LimitedSupportReasonExists.
+func (mr *MockServiceMockRecorder) LimitedSupportReasonExists(ls, clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LimitedSupportReasonExists", reflect.TypeOf((*MockService)(nil).LimitedSupportReasonExists), ls, clusterID)
 }
 
 // ListNonRunningInstances mocks base method.


### PR DESCRIPTION
**What?**

- Limited CAD CHGM resolve investigation to clusters that CAD put into LS itself, as we everything else is a NOOP for CAD. 
- Renamed `LimitedSupportReasonExists` to `IsInLimitedSupport` to make the function names less confusing

**Why?**

This change allows us to use less resources for CAD pipelines and removes unnecessary long pipeline runs.

https://redhat-internal.slack.com/archives/C04PN0YCWGL/p1676498065888859?thread_ts=1676463360.065339&cid=C04PN0YCWGL