### PR TITLE
Log limited support reason for all limited support posts

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -197,6 +197,8 @@ func (c Client) GetCloudProviderID(identifier string) (string, error) {
 
 // PostLimitedSupportReason allows to post a generic limited support reason to a cluster
 func (c Client) PostLimitedSupportReason(limitedSupportReason LimitedSupportReason, clusterID string) error {
+	fmt.Printf("Sending limited support reason: %s\n", limitedSupportReason.Summary)
+
 	ls, err := c.newLimitedSupportReasonBuilder(limitedSupportReason).Build()
 	if err != nil {
 		return fmt.Errorf("could not create post request: %w", err)

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -107,9 +107,9 @@ func (c *Client) Triggered() error {
 		return c.UpdateAndEscalateAlert(res.String())
 	}
 	res.LimitedSupportReason = chgmLimitedSupport
+
 	// The node shutdown was the customer
 	// Put into limited support, silence and update incident notes
-	fmt.Printf("Sending limited support reason: %s\n", chgmLimitedSupport.Summary)
 	return utils.WithRetries(func() error {
 		return c.PostLimitedSupport(res.String())
 	})


### PR DESCRIPTION
**Why?**

LS post logging was outside of the LS post function, moved it to the function to make sure we always log it.