### PR TITLE
OSD-15569 : Add CCS/nonCCS differentiation

### DIFF
--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -257,7 +257,6 @@ func (c *Client) isUserAllowedToStop(username, issuerUsername string, userDetail
 		"ManagedOpenShift-Support-", // ROSA- non-STS - SRE work
 	}
 
-	fmt.Println(c.Cluster.CCS().Enabled())
 	// Check cluster flavor, as 'OrganizationAccountAccessRole' is SRE for non-CCS and the user for ROSA
 	if !c.Cluster.CCS().Enabled() {
 		allowedRolesPartialStrings = append(allowedRolesPartialStrings, "OrganizationAccountAccessRole")

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -227,7 +227,7 @@ func (c *Client) investigateRestoredCluster() (res InvestigateInstancesOutput, e
 // isUserAllowedToStop verifies if a user is allowed to stop/terminate instances
 // For this, we use a whitelist of partial strings that can be SRE
 // based on findings in https://issues.redhat.com/browse/OSD-16042
-func isUserAllowedToStop(username, issuerUsername string, userDetails CloudTrailEventRaw, infraID string) bool {
+func (c *Client) isUserAllowedToStop(username, issuerUsername string, userDetails CloudTrailEventRaw, infraID string) bool {
 
 	// Users are represented by Username in cloudtrail events
 	allowedUsersPartialStrings := []string{
@@ -252,10 +252,15 @@ func isUserAllowedToStop(username, issuerUsername string, userDetails CloudTrail
 		// 'openshift-machine-api-aws' is a role for STS, and a user for ROSA non-STS and non-CCS
 		"openshift-machine-api-aws", // Infra nodes/Autoscaling
 
-		"-Installer-Role",               // ROSA-STS - install/uninstall node run/terminate
-		"-Support-Role",                 // ROSA-STS - SRE work
-		"ManagedOpenShift-Support-",     // ROSA- non-STS - SRE work
-		"OrganizationAccountAccessRole", // This is SRE for on-CCS, and the user for ROSA - we consider cluster flavor with https://issues.redhat.com/browse/OSD-15569
+		"-Installer-Role",           // ROSA-STS - install/uninstall node run/terminate
+		"-Support-Role",             // ROSA-STS - SRE work
+		"ManagedOpenShift-Support-", // ROSA- non-STS - SRE work
+	}
+
+	fmt.Println(c.Cluster.CCS().Enabled())
+	// Check cluster flavor, as 'OrganizationAccountAccessRole' is SRE for non-CCS and the user for ROSA
+	if !c.Cluster.CCS().Enabled() {
+		allowedRolesPartialStrings = append(allowedRolesPartialStrings, "OrganizationAccountAccessRole")
 	}
 
 	for _, partialRoleString := range allowedRolesPartialStrings {
@@ -399,7 +404,7 @@ func (c *Client) investigateStoppedInstances() (InvestigateInstancesOutput, erro
 			IssuerUserName: userDetails.UserIdentity.SessionContext.SessionIssuer.UserName,
 		}
 
-		if !isUserAllowedToStop(*event.Username, output.User.IssuerUserName, userDetails, infraID) {
+		if !c.isUserAllowedToStop(*event.Username, output.User.IssuerUserName, userDetails, infraID) {
 			output.UserAuthorized = false
 
 			// Return early with `output` containing the first unauthorized user.


### PR DESCRIPTION
The role 'OrganizationAccountAccessRole' is used by SRE in case of non CCS clusters and by the user otherwise.
This PR changes the isUserAllowedToStop function to respect the clusters flavor and return false when 'OrganizationAccountAccessRole' was used on a CCS cluster.
