### PR TITLE
Make resolve investigation logging less confusing

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -154,6 +154,8 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	eventType := pdClient.GetEventType()
+	fmt.Printf("Starting investigation for %s with event type %s\n", alertType, eventType)
+
 	switch eventType {
 	case pagerduty.IncidentTriggered:
 		return investigationClient.Investigation.Triggered()

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -141,12 +141,14 @@ func (c *Client) Resolved() error {
 
 	// Investigation completed, but the state in OCM indicated the cluster didn't need investigation
 	if res.ClusterNotEvaluated {
-		fmt.Printf("Cluster has state '%s' in OCM, and so investigation is not need\n", res.ClusterState)
+		investigationNotNeededNote := fmt.Sprintf("Cluster has state '%s' in OCM, and so investigation is not needed:\n", res.ClusterState)
+		fmt.Printf("Adding note: %s", investigationNotNeededNote)
+
 		err = utils.WithRetries(func() error {
-			return c.AddNote(res.String())
+			return c.AddNote(investigationNotNeededNote)
 		})
 		if err != nil {
-			fmt.Printf("Failed to add notes to incident: %s\n", res.String())
+			fmt.Printf("Failed to add note '%s' to incident: %s\n", investigationNotNeededNote, err)
 			return nil
 		}
 		return nil


### PR DESCRIPTION
**Why**?

See https://redhat.pagerduty.com/incidents/Q3DIQB8OOFEBVS/timeline

We don't clarify what CAD does in the note, it looks like a second investigation.