### PR TITLE
Don't silence resolved alerts

### DIFF
--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -496,9 +496,15 @@ func (c *Client) updatePagerduty(notes, escalationPolicy string) error {
 			return fmt.Errorf("failed to attach notes to CHGM incident: %w", err)
 		}
 	}
-	fmt.Printf("Move to escalation policy: %s", escalationPolicy)
+	fmt.Printf("Moving to escalation policy: %s\n", escalationPolicy)
 	err := c.MoveToEscalationPolicy(escalationPolicy)
 	if err != nil {
+		// Changing the escalation policy of a resolved alert results in an error such as:
+		// HTTP response failed with status code 400, message: Invalid Input Provided (code: 2001): Incident Already Resolved
+		if strings.Contains(err.Error(), "Incident Already Resolved") {
+			fmt.Printf("Skipped moving alert to escalation policy '%s', alert is already resolved.\n", escalationPolicy)
+			return nil
+		}
 		return fmt.Errorf("failed to change incident escalation policy: %w", err)
 	}
 	return nil

--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -101,13 +101,13 @@ func (c Client) Evaluate(awsError error, externalClusterID string, incidentID st
 	if lsExists {
 		fmt.Printf("Cluster is already in limited support for '%s', skipping sending it again.\n", ccamLimitedSupport.Summary)
 		return nil
-	} else {
-		err = c.PostLimitedSupportReason(ccamLimitedSupport, c.Cluster.ID())
-		if err != nil {
-			return fmt.Errorf("could not post limited support reason for %s: %w", c.Cluster.Name(), err)
-		}
-		return c.SilenceAlert(fmt.Sprintf("Added the following Limited Support reason to cluster: %#v\n", ccamLimitedSupport))
 	}
+
+	err = c.PostLimitedSupportReason(ccamLimitedSupport, c.Cluster.ID())
+	if err != nil {
+		return fmt.Errorf("could not post limited support reason for %s: %w", c.Cluster.Name(), err)
+	}
+	return c.SilenceAlert(fmt.Sprintf("Added the following Limited Support reason to cluster: %#v\n", ccamLimitedSupport))
 }
 
 // RemoveLimitedSupport will remove any CCAM limited support reason from the cluster,

--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -97,17 +97,13 @@ func (c Client) Evaluate(awsError error, externalClusterID string, incidentID st
 	if err != nil {
 		return fmt.Errorf("couldn't determine if limited support reason already exists: %w", err)
 	}
-
-	if lsExists {
-		fmt.Printf("Cluster is already in limited support for '%s', skipping sending it again.\n", ccamLimitedSupport.Summary)
-		return nil
+	if !lsExists {
+		err = c.PostLimitedSupportReason(ccamLimitedSupport, c.Cluster.ID())
+		if err != nil {
+			return fmt.Errorf("could not post limited support reason for %s: %w", c.Cluster.Name(), err)
+		}
 	}
-
-	err = c.PostLimitedSupportReason(ccamLimitedSupport, c.Cluster.ID())
-	if err != nil {
-		return fmt.Errorf("could not post limited support reason for %s: %w", c.Cluster.Name(), err)
-	}
-	return c.SilenceAlert(fmt.Sprintf("Added the following Limited Support reason to cluster: %#v\n", ccamLimitedSupport))
+	return c.SilenceAlert(fmt.Sprintf("Cluster has limited support for '%s'. Silencing alert.\n", ccamLimitedSupport.Summary))
 }
 
 // RemoveLimitedSupport will remove any CCAM limited support reason from the cluster,

--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -97,14 +97,16 @@ func (c Client) Evaluate(awsError error, externalClusterID string, incidentID st
 	if err != nil {
 		return fmt.Errorf("couldn't determine if limited support reason already exists: %w", err)
 	}
-	if !lsExists {
+
+	if lsExists {
+		return nil
+	} else {
 		err = c.PostLimitedSupportReason(ccamLimitedSupport, c.Cluster.ID())
 		if err != nil {
 			return fmt.Errorf("could not post limited support reason for %s: %w", c.Cluster.Name(), err)
 		}
-
+		return c.SilenceAlert(fmt.Sprintf("Added the following Limited Support reason to cluster: %#v\n", ccamLimitedSupport))
 	}
-	return c.SilenceAlert(fmt.Sprintf("Added the following Limited Support reason to cluster: %#v\n", ccamLimitedSupport))
 }
 
 // RemoveLimitedSupport will remove any CCAM limited support reason from the cluster,

--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -99,6 +99,7 @@ func (c Client) Evaluate(awsError error, externalClusterID string, incidentID st
 	}
 
 	if lsExists {
+		fmt.Printf("Cluster is already in limited support for '%s', skipping sending it again.\n", ccamLimitedSupport.Summary)
 		return nil
 	} else {
 		err = c.PostLimitedSupportReason(ccamLimitedSupport, c.Cluster.ID())

--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -97,13 +97,17 @@ func (c Client) Evaluate(awsError error, externalClusterID string, incidentID st
 	if err != nil {
 		return fmt.Errorf("couldn't determine if limited support reason already exists: %w", err)
 	}
+
+	note := fmt.Sprintf("Cluster already has limited support for '%s'. Silencing alert.\n", ccamLimitedSupport.Summary)
+
 	if !lsExists {
 		err = c.PostLimitedSupportReason(ccamLimitedSupport, c.Cluster.ID())
 		if err != nil {
 			return fmt.Errorf("could not post limited support reason for %s: %w", c.Cluster.Name(), err)
 		}
+		note = fmt.Sprintf("Added the following Limited Support reason to cluster: %#v. Silencing alert.\n", ccamLimitedSupport)
 	}
-	return c.SilenceAlert(fmt.Sprintf("Cluster has limited support for '%s'. Silencing alert.\n", ccamLimitedSupport.Summary))
+	return c.SilenceAlert(note)
 }
 
 // RemoveLimitedSupport will remove any CCAM limited support reason from the cluster,


### PR DESCRIPTION
**Why?**

CAD tried to silence alerts that are already resolved.

**What?**

CAD doesn't try to silence alerts that are already resolved anymore (for CCAM).