### PR TITLE
Minor refactor on pagerduty.go

### DIFF
--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -487,7 +487,7 @@ func (c *Client) SilenceAlert() error {
 	return c.MoveToEscalationPolicy(c.GetSilentEscalationPolicy())
 }
 
-// SilenceAlert annotates the PagerDuty alert with the given notes and silences it by
+// SilenceAlertWithNote annotates the PagerDuty alert with the given notes and silences it by
 // assigning the "Silent Test" escalation policy
 func (c *Client) SilenceAlertWithNote(notes string) error {
 	return c.addNoteAndEscalate(notes, c.GetSilentEscalationPolicy())
@@ -498,7 +498,7 @@ func (c *Client) EscalateAlert() error {
 	return c.MoveToEscalationPolicy(c.GetOnCallEscalationPolicy())
 }
 
-// EscalateAlert annotates the PagerDuty alert with the given notes and escalates it by
+// EscalateAlertWithNote annotates the PagerDuty alert with the given notes and escalates it by
 // assigning to the on call escalation policy
 func (c *Client) EscalateAlertWithNote(notes string) error {
 	return c.addNoteAndEscalate(notes, c.GetOnCallEscalationPolicy())

--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -53,10 +53,9 @@ type Service interface {
 	// PD
 	AddNote(noteContent string) error
 	CreateNewAlert(newAlert pagerduty.NewAlert, serviceID string) error
-	SilenceAlert(notes string) error
+	SilenceAlertWithNote(notes string) error
 	MoveToEscalationPolicy(escalationPolicyID string) error
-	GetEscalationPolicy() string
-	GetSilentPolicy() string
+	GetOnCallEscalationPolicy() string
 	GetServiceID() string
 }
 
@@ -107,7 +106,7 @@ func (c Client) Evaluate(awsError error, externalClusterID string, incidentID st
 		}
 		note = fmt.Sprintf("Added the following Limited Support reason to cluster: %#v. Silencing alert.\n", ccamLimitedSupport)
 	}
-	return c.SilenceAlert(note)
+	return c.SilenceAlertWithNote(note)
 }
 
 // RemoveLimitedSupport will remove any CCAM limited support reason from the cluster,

--- a/pkg/services/chgm/chgm_test.go
+++ b/pkg/services/chgm/chgm_test.go
@@ -101,7 +101,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				// TODO discuss to which degree we want to mock
-				mockClient.EXPECT().SilenceAlert(gomock.Any())
+				mockClient.EXPECT().SilenceAlertWithNote(gomock.Any())
 
 				gotErr := isRunning.Triggered()
 
@@ -111,7 +111,7 @@ var _ = Describe("chgm", func() {
 		When("Triggered errors", func() {
 			It("should update the incident notes and escalate to primary", func() {
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Any()).Return(nil, fakeErr)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 
@@ -124,7 +124,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&masterInstance, &infraInstance}, nil)
 				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 				gotErr := isRunning.Triggered()
 				// Assert
 				Expect(gotErr).ToNot(HaveOccurred())
@@ -137,7 +137,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return(nil, fakeErr)
 
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).ToNot(HaveOccurred())
@@ -150,7 +150,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				mockClient.EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]*ec2.Instance{&instance}, nil)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{}, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 				// Act
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).ToNot(HaveOccurred())
@@ -165,7 +165,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
-				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
 
 				// Act
 				gotErr := isRunning.Triggered()
@@ -182,7 +182,7 @@ var _ = Describe("chgm", func() {
 				event.Username = aws.String("1234567789") // ID of the initial jumprole account
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -196,7 +196,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08", "userIdentity":{"type":"AssumedRole", "sessionContext":{"sessionIssuer":{"type":"Role", "userName": "OrganizationAccountAccessRole"}}}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -221,7 +221,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
-				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -236,7 +236,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"redacted:1234567","arn":"arn:aws:sts::1234567:assumed-role/ManagedOpenShift-Installer-Role/1234567","accountId":"1234567","accessKeyId":"redacted","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"redacted","arn":"arn:aws:iam::1234567:role/ManagedOpenShift-Installer-Role","accountId":"1234567","userName":"ManagedOpenShift-Installer-Role"},"webIdFederationData":{},"attributes":{"creationDate":"2023-02-21T04:33:06Z","mfaAuthenticated":"false"}}},"eventTime":"2023-02-21T04:33:09Z","eventSource":"ec2.amazonaws.com","eventName":"TerminateInstances","awsRegion":"ap-southeast-1","sourceIPAddress":"192.0.0.1","userAgent":"APN/1.0 HashiCorp/1.0 Terraform/1.0.11 (+https://www.terraform.io) terraform-provider-aws/dev (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go/1.43.9 (go1.18.7; linux; amd64) HashiCorp-terraform-exec/0.16.1","requestParameters":{"instancesSet":{"items":[{"instanceId":"i-0c123456"}]}},"responseElements":{"requestId":"bd3900cb-1234567","instancesSet":{"items":[{"instanceId":"i-0c123456","currentState":{"code":32,"name":"shutting-down"},"previousState":{"code":16,"name":"running"}}]}},"requestID":"bd3900cb-1234567","eventID":"7064eae0-1234567","readOnly":false,"eventType":"AwsApiCall","managementEvent":true,"recipientAccountId":"1234","eventCategory":"Management","tlsDetails":{"tlsVersion":"TLSv1.2","cipherSuite":"ECDHE-RSA-AES128-GCM-SHA256","clientProvidedHostHeader":"ec2.ap-southeast-1.amazonaws.com"}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -250,7 +250,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"redacted:1234567","arn":"arn:aws:sts::1234567:assumed-role/customprefix-Installer-Role/1234567","accountId":"1234567","accessKeyId":"redacted","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"redacted","arn":"arn:aws:iam::1234567:role/customprefix-Installer-Role","accountId":"1234567","userName":"customprefix-Installer-Role"},"webIdFederationData":{},"attributes":{"creationDate":"2023-02-21T04:33:06Z","mfaAuthenticated":"false"}}},"eventTime":"2023-02-21T04:33:09Z","eventSource":"ec2.amazonaws.com","eventName":"TerminateInstances","awsRegion":"ap-southeast-1","sourceIPAddress":"192.0.0.1","userAgent":"APN/1.0 HashiCorp/1.0 Terraform/1.0.11 (+https://www.terraform.io) terraform-provider-aws/dev (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go/1.43.9 (go1.18.7; linux; amd64) HashiCorp-terraform-exec/0.16.1","requestParameters":{"instancesSet":{"items":[{"instanceId":"i-0c123456"}]}},"responseElements":{"requestId":"bd3900cb-1234567","instancesSet":{"items":[{"instanceId":"i-0c123456","currentState":{"code":32,"name":"shutting-down"},"previousState":{"code":16,"name":"running"}}]}},"requestID":"bd3900cb-1234567","eventID":"7064eae0-1234567","readOnly":false,"eventType":"AwsApiCall","managementEvent":true,"recipientAccountId":"1234","eventCategory":"Management","tlsDetails":{"tlsVersion":"TLSv1.2","cipherSuite":"ECDHE-RSA-AES128-GCM-SHA256","clientProvidedHostHeader":"ec2.ap-southeast-1.amazonaws.com"}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -264,7 +264,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"redacted:1234567","arn":"arn:aws:sts::1234567:assumed-role/ManagedOpenShift-Support-v3218/1234567","accountId":"1234567","accessKeyId":"redacted","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"redacted","arn":"arn:aws:iam::1234567:role/ManagedOpenShift-Support-v3218","accountId":"1234567","userName":"ManagedOpenShift-Support-v3218"},"webIdFederationData":{},"attributes":{"creationDate":"2023-02-21T04:33:06Z","mfaAuthenticated":"false"}}},"eventTime":"2023-02-21T04:33:09Z","eventSource":"ec2.amazonaws.com","eventName":"TerminateInstances","awsRegion":"ap-southeast-1","sourceIPAddress":"192.0.0.1","userAgent":"APN/1.0 HashiCorp/1.0 Terraform/1.0.11 (+https://www.terraform.io) terraform-provider-aws/dev (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go/1.43.9 (go1.18.7; linux; amd64) HashiCorp-terraform-exec/0.16.1","requestParameters":{"instancesSet":{"items":[{"instanceId":"i-0c123456"}]}},"responseElements":{"requestId":"bd3900cb-1234567","instancesSet":{"items":[{"instanceId":"i-0c123456","currentState":{"code":32,"name":"shutting-down"},"previousState":{"code":16,"name":"running"}}]}},"requestID":"bd3900cb-1234567","eventID":"7064eae0-1234567","readOnly":false,"eventType":"AwsApiCall","managementEvent":true,"recipientAccountId":"1234","eventCategory":"Management","tlsDetails":{"tlsVersion":"TLSv1.2","cipherSuite":"ECDHE-RSA-AES128-GCM-SHA256","clientProvidedHostHeader":"ec2.ap-southeast-1.amazonaws.com"}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -278,7 +278,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = aws.String(`{"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"redacted:1234567","arn":"arn:aws:sts::1234567:assumed-role/johnnycustom-Support-Role/1234567","accountId":"1234567","accessKeyId":"redacted","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"redacted","arn":"arn:aws:iam::1234567:role/johnnycustom-Support-Role","accountId":"1234567","userName":"johnnycustom-Support-Role"},"webIdFederationData":{},"attributes":{"creationDate":"2023-02-21T04:33:06Z","mfaAuthenticated":"false"}}},"eventTime":"2023-02-21T04:33:09Z","eventSource":"ec2.amazonaws.com","eventName":"TerminateInstances","awsRegion":"ap-southeast-1","sourceIPAddress":"192.0.0.1","userAgent":"APN/1.0 HashiCorp/1.0 Terraform/1.0.11 (+https://www.terraform.io) terraform-provider-aws/dev (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go/1.43.9 (go1.18.7; linux; amd64) HashiCorp-terraform-exec/0.16.1","requestParameters":{"instancesSet":{"items":[{"instanceId":"i-0c123456"}]}},"responseElements":{"requestId":"bd3900cb-1234567","instancesSet":{"items":[{"instanceId":"i-0c123456","currentState":{"code":32,"name":"shutting-down"},"previousState":{"code":16,"name":"running"}}]}},"requestID":"bd3900cb-1234567","eventID":"7064eae0-1234567","readOnly":false,"eventType":"AwsApiCall","managementEvent":true,"recipientAccountId":"1234","eventCategory":"Management","tlsDetails":{"tlsVersion":"TLSv1.2","cipherSuite":"ECDHE-RSA-AES128-GCM-SHA256","clientProvidedHostHeader":"ec2.ap-southeast-1.amazonaws.com"}}`)
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -292,7 +292,7 @@ var _ = Describe("chgm", func() {
 				event.Username = aws.String("osdManagedAdmin-abcd")
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -306,7 +306,7 @@ var _ = Describe("chgm", func() {
 				event.Username = aws.String("osdCcsAdmin")
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -320,7 +320,7 @@ var _ = Describe("chgm", func() {
 				event.Username = aws.String("test-openshift-machine-api-aws-test")
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -335,7 +335,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
-				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -350,7 +350,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
-				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -365,7 +365,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
-				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -379,7 +379,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
-				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -395,7 +395,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
-				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -411,7 +411,7 @@ var _ = Describe("chgm", func() {
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
 				mockClient.EXPECT().IsInLimitedSupport(gomock.Eq(cluster.ID())).Return(false, nil)
 				mockClient.EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
-				mockClient.EXPECT().SilenceAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -426,7 +426,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrail.Resource{ResourceName: aws.String("123456")}
 				event.Resources = []*cloudtrail.Resource{&cloudTrailResource}
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -441,7 +441,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrail.Resource{ResourceName: aws.String("123456")}
 				event.Resources = []*cloudtrail.Resource{&cloudTrailResource}
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{}, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -456,7 +456,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrail.Resource{ResourceName: aws.String("123456")}
 				event.Resources = []*cloudtrail.Resource{&cloudTrailResource}
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -471,7 +471,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrail.Resource{ResourceName: aws.String("123456")}
 				event.Resources = []*cloudtrail.Resource{&cloudTrailResource}
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -486,7 +486,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrail.Resource{ResourceName: aws.String("123456")}
 				event.Resources = []*cloudtrail.Resource{&cloudTrailResource}
 				mockClient.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]*cloudtrail.Event{&event}, nil)
-				mockClient.EXPECT().UpdateAndEscalateAlert(gomock.Any()).Return(nil)
+				mockClient.EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
 
 				gotErr := isRunning.Triggered()
 				Expect(gotErr).NotTo(HaveOccurred())

--- a/pkg/services/chgm/mock/interfaces.go
+++ b/pkg/services/chgm/mock/interfaces.go
@@ -80,6 +80,20 @@ func (mr *MockServiceMockRecorder) DeleteLimitedSupportReasons(ls, clusterID int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLimitedSupportReasons", reflect.TypeOf((*MockService)(nil).DeleteLimitedSupportReasons), ls, clusterID)
 }
 
+// EscalateAlertWithNote mocks base method.
+func (m *MockService) EscalateAlertWithNote(notes string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EscalateAlertWithNote", notes)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EscalateAlertWithNote indicates an expected call of EscalateAlertWithNote.
+func (mr *MockServiceMockRecorder) EscalateAlertWithNote(notes interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EscalateAlertWithNote", reflect.TypeOf((*MockService)(nil).EscalateAlertWithNote), notes)
+}
+
 // GetClusterMachinePools mocks base method.
 func (m *MockService) GetClusterMachinePools(clusterID string) ([]*v1.MachinePool, error) {
 	m.ctrl.T.Helper()
@@ -198,18 +212,18 @@ func (mr *MockServiceMockRecorder) PostLimitedSupportReason(limitedSupportReason
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostLimitedSupportReason", reflect.TypeOf((*MockService)(nil).PostLimitedSupportReason), limitedSupportReason, clusterID)
 }
 
-// SilenceAlert mocks base method.
-func (m *MockService) SilenceAlert(notes string) error {
+// SilenceAlertWithNote mocks base method.
+func (m *MockService) SilenceAlertWithNote(notes string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SilenceAlert", notes)
+	ret := m.ctrl.Call(m, "SilenceAlertWithNote", notes)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SilenceAlert indicates an expected call of SilenceAlert.
-func (mr *MockServiceMockRecorder) SilenceAlert(notes interface{}) *gomock.Call {
+// SilenceAlertWithNote indicates an expected call of SilenceAlertWithNote.
+func (mr *MockServiceMockRecorder) SilenceAlertWithNote(notes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SilenceAlert", reflect.TypeOf((*MockService)(nil).SilenceAlert), notes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SilenceAlertWithNote", reflect.TypeOf((*MockService)(nil).SilenceAlertWithNote), notes)
 }
 
 // UnrelatedLimitedSupportExists mocks base method.
@@ -225,18 +239,4 @@ func (m *MockService) UnrelatedLimitedSupportExists(ls ocm.LimitedSupportReason,
 func (mr *MockServiceMockRecorder) UnrelatedLimitedSupportExists(ls, clusterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnrelatedLimitedSupportExists", reflect.TypeOf((*MockService)(nil).UnrelatedLimitedSupportExists), ls, clusterID)
-}
-
-// UpdateAndEscalateAlert mocks base method.
-func (m *MockService) UpdateAndEscalateAlert(notes string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAndEscalateAlert", notes)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateAndEscalateAlert indicates an expected call of UpdateAndEscalateAlert.
-func (mr *MockServiceMockRecorder) UpdateAndEscalateAlert(notes interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAndEscalateAlert", reflect.TypeOf((*MockService)(nil).UpdateAndEscalateAlert), notes)
 }


### PR DESCRIPTION
**What?**

- Renamed variables
- Added helper functions for future work, clarified what the functions do in their names
- Remove additional wrapper for `moveToEscalationPolicy`