### PR TITLE
Upgrade golangci-lint to v1.52.2 and use local version if existing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gocritic
     - gocyclo
@@ -25,9 +24,7 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - gofmt
     

--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -49,7 +49,7 @@ func init() {
 	InvestigateCmd.Flags().StringVarP(&payloadPath, "payload-path", "p", payloadPath, "the path to the payload")
 }
 
-func run(cmd *cobra.Command, args []string) error {
+func run(_ *cobra.Command, _ []string) error {
 
 	fmt.Println("Running CAD with webhook payload:")
 	payload, err := os.ReadFile(payloadPath)
@@ -89,7 +89,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not initialize ocm client: %w", err)
 	}
 
-	cloudProviderSupported, err := checkCloudProviderSupported(&ocmClient, &pdClient, externalClusterID, []string{"aws"})
+	cloudProviderSupported, err := checkCloudProviderSupported(&ocmClient, externalClusterID, []string{"aws"})
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func jumpRoles(awsClient aws.Client, ocmClient ocm.Client, pdClient pagerduty.Cl
 	if err != nil {
 		fmt.Println("Assuming role failed, potential CCAM alert. Investigating... error: ", err.Error())
 		// if assumeSupportRoleChain fails, we will evaluate if the credentials are missing
-		return aws.Client{}, ccamClient.Evaluate(err, externalClusterID, pdClient.GetIncidentID())
+		return aws.Client{}, ccamClient.Evaluate(err, pdClient.GetIncidentID())
 	}
 	fmt.Println("Got cloud credentials, removing 'Cloud Credentials Are Missing' limited Support reasons if any")
 	return customerAwsClient, ccamClient.RemoveLimitedSupport()
@@ -294,7 +294,7 @@ func GetPDClient(webhookPayload []byte) (pagerduty.Client, error) {
 
 // checkCloudProviderSupported takes a list of supported providers and checks if the
 // cluster to investigate's provider is supported
-func checkCloudProviderSupported(ocmClient *ocm.Client, pdClient *pagerduty.Client, externalClusterID string, supportedProviders []string) (bool, error) {
+func checkCloudProviderSupported(ocmClient *ocm.Client, externalClusterID string, supportedProviders []string) (bool, error) {
 	cloudProvider, err := ocmClient.GetCloudProviderID(externalClusterID)
 	if err != nil {
 		return false, err

--- a/cadctl/main.go
+++ b/cadctl/main.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package main is the main package
 package main
 
 import "github.com/openshift/configuration-anomaly-detection/cadctl/cmd"

--- a/hack/update-template/main.go
+++ b/hack/update-template/main.go
@@ -1,3 +1,4 @@
+// Package main is the main package
 package main
 
 import (

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1,8 +1,9 @@
+// Package aws contains functions related to aws sdk
 package aws
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -88,12 +89,12 @@ func NewClientFromFileCredentials(dir string, region string) (Client, error) {
 	dir = filepath.Clean(dir)
 
 	accessKeyBytesPath := filepath.Clean(path.Join(dir, accessKeyIDFilename))
-	accessKeyBytes, err := ioutil.ReadFile(accessKeyBytesPath)
+	accessKeyBytes, err := os.ReadFile(accessKeyBytesPath)
 	if err != nil {
 		return Client{}, fmt.Errorf("cannot read accessKeyID '%s' from path  %s", accessKeyIDFilename, dir)
 	}
 	secretKeyBytesPath := filepath.Clean(path.Join(dir, secretAccessKeyIDFilename))
-	secretKeyBytes, err := ioutil.ReadFile(secretKeyBytesPath)
+	secretKeyBytes, err := os.ReadFile(secretKeyBytesPath)
 	if err != nil {
 		return Client{}, fmt.Errorf("cannot read secretKeyID '%s' from path  %s", secretAccessKeyIDFilename, dir)
 	}

--- a/pkg/investigation/investigation.go
+++ b/pkg/investigation/investigation.go
@@ -1,3 +1,4 @@
+// Package investigation contains base functions for investigations
 package investigation
 
 import (

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -1,3 +1,4 @@
+// Package ocm contains ocm api related functions
 package ocm
 
 import (

--- a/pkg/ocm/ocm_config.go
+++ b/pkg/ocm/ocm_config.go
@@ -3,7 +3,6 @@ package ocm
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -47,7 +46,7 @@ func Load() (cfg *Config, err error) {
 		return
 	}
 	// #nosec G304
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		err = fmt.Errorf("can't read config file '%s': %v", file, err)
 		return

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -1,3 +1,4 @@
+// Package pagerduty contains wrappers for pagerduty api calls
 package pagerduty
 
 import (

--- a/pkg/services/assumerole/assumerole.go
+++ b/pkg/services/assumerole/assumerole.go
@@ -1,3 +1,4 @@
+// Package assumerole contains functions needed to assumeRole jump into an aws account
 package assumerole
 
 import (

--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -66,7 +66,7 @@ type Client struct {
 }
 
 // New creates a new CCAM client and gets the cluster object from ocm for the internal id
-func New(ocmClient *OcmClient, pdClient *PdClient, externalClusterID string, cluster *v1.Cluster) (Client, error) {
+func New(ocmClient *OcmClient, pdClient *PdClient, cluster *v1.Cluster) (Client, error) {
 	client := Client{
 		Service: Provider{
 			OcmClient: ocmClient,
@@ -87,7 +87,7 @@ func (c Client) checkMissing(err error) bool {
 // Evaluate estimates if the awsError is a cluster credentials are missing error. If it determines that it is,
 // the cluster is placed into limited support, otherwise an error is returned. If the cluster already has a CCAM
 // LS reason, no additional reasons are added and incident is sent to SilentTest.
-func (c Client) Evaluate(awsError error, externalClusterID string, incidentID string) error {
+func (c Client) Evaluate(awsError error, _ string) error {
 	if !c.checkMissing(awsError) {
 		return fmt.Errorf("credentials are there, error is different: %w", awsError)
 	}

--- a/pkg/services/chgm/chgm.go
+++ b/pkg/services/chgm/chgm.go
@@ -1,3 +1,4 @@
+// Package chgm contains functionality for the chgm investigation
 package chgm
 
 import (
@@ -229,7 +230,7 @@ func (c *Client) investigateRestoredCluster() (res InvestigateInstancesOutput, e
 // isUserAllowedToStop verifies if a user is allowed to stop/terminate instances
 // For this, we use a whitelist of partial strings that can be SRE
 // based on findings in https://issues.redhat.com/browse/OSD-16042
-func isUserAllowedToStop(username, issuerUsername string, userDetails CloudTrailEventRaw, infraID string, cluster *v1.Cluster) bool {
+func isUserAllowedToStop(username, issuerUsername string, cluster *v1.Cluster) bool {
 
 	// Users are represented by Username in cloudtrail events
 	allowedUsersPartialStrings := []string{
@@ -405,7 +406,7 @@ func (c *Client) investigateStoppedInstances() (InvestigateInstancesOutput, erro
 			IssuerUserName: userDetails.UserIdentity.SessionContext.SessionIssuer.UserName,
 		}
 
-		if !isUserAllowedToStop(*event.Username, output.User.IssuerUserName, userDetails, infraID, c.Cluster) {
+		if !isUserAllowedToStop(*event.Username, output.User.IssuerUserName, c.Cluster) {
 			output.UserAuthorized = false
 
 			// Return early with `output` containing the first unauthorized user.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,3 +1,4 @@
+// Package utils contains utility functions
 package utils
 
 import (


### PR DESCRIPTION
**What?**

Dynamically downloads golangci-lint v1.52.2. If golangci-lint is already installed, it uses the already installed golang-ci.lint.

This fixes issues when using a higher go version that doesn't fit the previously old hardcoded golangci-lint version of the makefile.

**Why?**

This results in nasty errors and blocks https://issues.redhat.com/browse/OSD-15137 because of a desync in the lint and go version.