### PR TITLE
Fix pipeline id and logging

### DIFF
--- a/deploy/pipeline.yaml
+++ b/deploy/pipeline.yaml
@@ -31,5 +31,7 @@ spec:
       params:
         - name: payload
           value: $(params.payload)
+        - name: pipeline-name
+          value: $(context.pipelineRun.name)
       taskRef:
         name: cad-checks

--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -7,6 +7,9 @@ spec:
     - name: payload
       type: string
       description: Json string of the event data
+    - name: pipeline-name
+      type: string
+      description: The pipelinerun name
   steps:
     - name: check-infrastructure
       # this sha is broken, should fix when we onboard
@@ -23,7 +26,7 @@ spec:
           $(params.payload)
           EOF
           # run the cadctl command
-          cadctl investigate --payload-path $file
+          PIPELINE_NAME=$(params.pipeline-name) cadctl investigate --payload-path $file
       # envFrom should pull all the secret information as envvars, so key names should be uppercase
       envFrom:
         - secretRef:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -80,6 +80,8 @@ objects:
       params:
       - name: payload
         value: $(params.payload)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
       taskRef:
         name: cad-checks
 - apiVersion: v1
@@ -168,6 +170,9 @@ objects:
     - description: Json string of the event data
       name: payload
       type: string
+    - description: The pipelinerun name
+      name: pipeline-name
+      type: string
     steps:
     - args:
       - |-
@@ -178,7 +183,7 @@ objects:
         $(params.payload)
         EOF
         # run the cadctl command
-        cadctl investigate --payload-path $file
+        PIPELINE_NAME=$(params.pipeline-name) cadctl investigate --payload-path $file
       command:
       - /bin/bash
       - -c

--- a/pkg/services/logging/logging.go
+++ b/pkg/services/logging/logging.go
@@ -20,65 +20,74 @@ func InitLogger(logLevelString string, clusterID string) *zap.SugaredLogger {
 		log.Fatalln("Invalid log level:", logLevelString)
 	}
 
-	pipelineRunID := os.Getenv("PIPELINE_RUN_ID")
-	if pipelineRunID == "" {
+	pipelineName := os.Getenv("PIPELINE_NAME")
+	if pipelineName == "" {
 		fmt.Println("Warning: Unable to retrieve the pipeline ID on logger creation. Continuing with empty value.")
 	}
 
-	config := zap.NewProductionEncoderConfig()
-	config.EncodeTime = zapcore.RFC3339TimeEncoder
-	consoleEncoder := zapcore.NewJSONEncoder(config)
-	core := zapcore.NewTee(zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), logLevel))
-	return zap.New(core).With(zap.Field{Key: "cluster_id", Type: zapcore.StringType, String: clusterID},
-		zap.Field{Key: "pipeline_id", Type: zapcore.StringType, String: pipelineRunID}).Sugar()
+	config := zap.NewProductionConfig()
+	config.EncoderConfig.TimeKey = "timestamp"
+	config.Level = logLevel
+	config.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+	config.EncoderConfig.StacktraceKey = "" // to hide stacktrace info
+
+	logger, err := config.Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	logger.With(zap.Field{Key: "cluster_id", Type: zapcore.StringType, String: clusterID},
+		zap.Field{Key: "pipeline_name", Type: zapcore.StringType, String: pipelineName})
+
+	return logger.Sugar()
 }
 
 // Info wraps zap's SugaredLogger.Info()
 func Info(args ...interface{}) {
-	RawLogger.Info(args)
+	RawLogger.Info(args...)
 }
 
 // Debug wraps zap's SugaredLogger.Debug()
 func Debug(args ...interface{}) {
-	RawLogger.Debug(args)
+	RawLogger.Debug(args...)
 }
 
 // Warn wraps zap's SugaredLogger.Warn()
 func Warn(args ...interface{}) {
-	RawLogger.Warn(args)
+	RawLogger.Warn(args...)
 }
 
 // Error wraps zap's SugaredLogger.Error()
 func Error(args ...interface{}) {
-	RawLogger.Error(args)
+	RawLogger.Error(args...)
 }
 
 // Fatal wraps zap's SugaredLogger.Fatal()
 func Fatal(args ...interface{}) {
-	RawLogger.Fatal(args)
+	RawLogger.Fatal(args...)
 }
 
 // Infof wraps zap's SugaredLogger.Infof()
 func Infof(template string, args ...interface{}) {
-	RawLogger.Infof(template, args)
+	RawLogger.Infof(template, args...)
 }
 
 // Debugf wraps zap's SugaredLogger.Debugf()
 func Debugf(template string, args ...interface{}) {
-	RawLogger.Debugf(template, args)
+	RawLogger.Debugf(template, args...)
 }
 
 // Warnf wraps zap's SugaredLogger.Warnf()
 func Warnf(template string, args ...interface{}) {
-	RawLogger.Warnf(template, args)
+	RawLogger.Warnf(template, args...)
 }
 
 // Errorf wraps zap's SugaredLogger.Errorf()
 func Errorf(template string, args ...interface{}) {
-	RawLogger.Errorf(template, args)
+	RawLogger.Errorf(template, args...)
 }
 
 // Fatalf wraps zap's SugaredLogger.Fatalf()
 func Fatalf(template string, args ...interface{}) {
-	RawLogger.Fatalf(template, args)
+	RawLogger.Fatalf(template, args...)
 }

--- a/pkg/services/networkverifier/networkverifier.go
+++ b/pkg/services/networkverifier/networkverifier.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	"github.com/openshift/configuration-anomaly-detection/pkg/services/logging"
 
 	"github.com/openshift/osd-network-verifier/pkg/proxy"
 	"github.com/openshift/osd-network-verifier/pkg/verifier"
@@ -104,7 +105,7 @@ const (
 
 // RunNetworkVerifier runs the network verifier tool to check for network misconfigurations
 func (c Client) RunNetworkVerifier(externalClusterID string) (result VerifierResult, failures string, name error) { // TODO
-	fmt.Printf("Running Network Verifier...\n")
+	logging.Info("Running Network Verifier...")
 	err := c.populateStructWith(externalClusterID)
 	if err != nil {
 		return Undefined, "", fmt.Errorf("failed to populate struct in runNetworkVerifier in networkverifier step: %w", err)
@@ -138,8 +139,8 @@ func (c Client) RunNetworkVerifier(externalClusterID string) (result VerifierRes
 		return Undefined, "", fmt.Errorf("failed to get Subnets: %w", err)
 	}
 
-	fmt.Printf("Using Security Group ID: %s\n", securityGroupID)
-	fmt.Printf("Using SubnetID: %s\n", subnet)
+	logging.Infof("Using Security Group ID: %s", securityGroupID)
+	logging.Infof("Using SubnetID: %s", subnet)
 
 	// setup non cloud config options
 	validateEgressInput := verifier.ValidateEgressInput{
@@ -162,12 +163,12 @@ func (c Client) RunNetworkVerifier(externalClusterID string) (result VerifierRes
 		SecurityGroupId: securityGroupID,
 	}
 
-	awsVerifier, err := awsverifier.NewAwsVerifier(credentials.AccessKeyID, credentials.SecretAccessKey, credentials.SessionToken, c.Cluster.Region().ID(), "", true)
+	awsVerifier, err := awsverifier.NewAwsVerifier(credentials.AccessKeyID, credentials.SecretAccessKey, credentials.SessionToken, c.Cluster.Region().ID(), "", false)
 	if err != nil {
 		return Undefined, "", fmt.Errorf("could not build awsVerifier %v", err)
 	}
 
-	fmt.Printf("Using region: %s\n", c.Cluster.Region().ID())
+	logging.Infof("Using region: %s", c.Cluster.Region().ID())
 
 	out := verifier.ValidateEgress(awsVerifier, validateEgressInput)
 


### PR DESCRIPTION
**What?**
- Fixes passing of parameter pack to zapLogger (previously the passing resulted in extra brackets `[]` for log messages)
- Converts leftover print statements to logged messages

- Pipeline name should now properly be passed down to the taskrun by tekton

**Why?**
https://issues.redhat.com/browse/OSD-16113