### PR TITLE
OSD-16112: Improve linting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.go]
+indent_style = tab
+tab_width = 4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,3 +93,7 @@ linters:
     - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library.
     - wastedassign # Finds wasted assignment statements.
     - whitespace # Tool for detection of leading and trailing whitespace
+
+linters-settings:
+  nestif:
+    min-complexity: 10

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,21 +10,86 @@ issues:
   # explicitly disable the exclude-use-default: https://github.com/golangci/golangci-lint/issues/1504
   exclude-use-default: false
 
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  # default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
+  # add a prefix to the output file references; default is no prefix
+  path-prefix: ""
+
+  # sorts results by: filepath, line and column
+  sort-results: false
+
 # default linters are enabled `golangci-lint help linters`
 linters:
   disable-all: true
   enable:
-    - errcheck
-    - gocritic
-    - gocyclo
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    - misspell
-    - revive
-    - staticcheck
-    - typecheck
-    - unused
-    - gofmt
-    
+    ## enabled by default
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - gosimple # specializes in simplifying a code
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # detects when assignments to existing variables are not used
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
+    - unused # checks for unused constants, variables, functions and types
+
+    ## disabled by default
+    - asasalint # Check for pass []any as any in variadic func(...any)
+    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
+    - bidichk # Checks for dangerous unicode character sequences
+    - bodyclose # Checks whether HTTP response body is closed successfully
+    - decorder # Check declaration order and count of types, constants, variables and functions
+    - dupword # Checks for duplicate words in the source code
+    - durationcheck # Check for two durations multiplied together
+    - errchkjson # Checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted.
+    - errname # Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
+    - errorlint # Errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+    - execinquery # Checks query string in Query function which reads your Go src files and warning it finds
+    - exportloopref # Checks for pointers to enclosing loop variables
+    - ginkgolinter # Enforces standards of using ginkgo and gomega
+    - gocheckcompilerdirectives # Checks that go compiler directive comments (//go:) are valid.
+    - goconst # Finds repeated strings that could be replaced by a constant
+    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
+    - gocyclo # Computes and checks the cyclomatic complexity of functions
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - gofumpt # Gofumpt checks whether code was gofumpt-ed.
+    - goheader # Checks is file header matches to pattern
+    - goimports # Check import statements are formatted according to the 'goimport' command. Reformat imports in autofix mode.
+    - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    - gosec # Inspects source code for security problems
+    - grouper # An analyzer to analyze expression groups.
+    - importas # Enforces consistent import aliases
+    - loggercheck # Checks key value pairs for common logger libraries (kitlog,klog,logr,zap).
+    - maintidx # Maintidx measures the maintainability index of each function.
+    - makezero # Finds slice declarations with non-zero initial length
+    - misspell # Finds commonly misspelled English words in comments
+    - nestif # Reports deeply nested if statements
+    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
+    - nilnil # Checks that there is no simultaneous return of nil error and an invalid value.
+    - noctx # Noctx finds sending http request without context.Context
+    - nolintlint # Reports ill-formed or insufficient nolint directives
+    - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL.
+    - prealloc # Finds slice declarations that could potentially be pre-allocated
+    - predeclared # Find code that shadows one of Go's predeclared identifiers
+    - promlinter # Check Prometheus metrics naming via promlint
+    - reassign # Checks that package variables are not reassigned
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
+    - rowserrcheck # Checks whether Err of rows is checked successfully
+    - tenv # Tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
+    - thelper # Thelper detects Go test helpers without t.Helper() call and checks the consistency of test helpers
+    - tparallel # Tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # Remove unnecessary type conversions
+    - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library.
+    - wastedassign # Finds wasted assignment statements.
+    - whitespace # Tool for detection of leading and trailing whitespace

--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -54,7 +54,6 @@ func init() {
 }
 
 func run(_ *cobra.Command, _ []string) error {
-
 	payload, err := os.ReadFile(payloadPath)
 	if err != nil {
 		return fmt.Errorf("failed to read webhook payload: %w", err)
@@ -114,7 +113,6 @@ func run(_ *cobra.Command, _ []string) error {
 	// the investigation level, and we should be GCP or AWSClient based on this.
 	// For now, we can silence alerts for clusters that are already in limited support and not handled by CAD
 	if !cloudProviderSupported {
-
 		// We forward everything CAD doesn't support investigations for to primary, as long as the clusters
 		// aren't in limited support.
 		logging.Info("Cloud provider is not supported, checking for limited support...")
@@ -194,7 +192,6 @@ func run(_ *cobra.Command, _ []string) error {
 
 // jumpRoles will return an aws client or an error after trying to jump into support role
 func jumpRoles(cluster *v1.Cluster, baseAwsClient aws.Client, ocmClient ocm.Client, pdClient pagerduty.Client) (*aws.SdkClient, error) {
-
 	cssJumprole, ok := os.LookupEnv("CAD_AWS_CSS_JUMPROLE")
 	if !ok {
 		return nil, fmt.Errorf("CAD_AWS_CSS_JUMPROLE is missing")
@@ -303,7 +300,7 @@ func checkCloudProviderSupported(ocmClient *ocm.SdkClient, externalClusterID str
 // - app-sre-alertmanager contains an internal ID in the title in the format uhc-<env>-<internal-id>
 // - everything else should adhere to being a separate field in the alert note.
 func parseClusterIDFromAlert(pdClient *pagerduty.SdkClient) (string, error) {
-	clusterID := ""
+	var clusterID string
 	var err error
 
 	switch pdClient.GetServiceName() {

--- a/hack/pre-commit.sh
+++ b/hack/pre-commit.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+GOFILES=$(git diff --cached --name-only --diff-filter=ACM | grep --color=never -E '^.*\.go$')
+
+if [[ ! -z $GOFILES ]]; then
+    printf "Running linter...\n\n"
+    $GOPATH/bin/golangci-lint run -c $ROOT_DIR/.golangci.yml --fix $ROOT_DIR/...
+fi

--- a/hack/update-template/main.go
+++ b/hack/update-template/main.go
@@ -20,21 +20,19 @@ const (
 	outputTemplateFile = "../../openshift/template.yaml"
 )
 
-var (
-	// this holds all the info that is static in the template. update this as needed
-	saasTemplateFile = Template{
-		APIVersion: "template.openshift.io/v1",
-		Kind:       "Template",
-		Metadata: Metadata{
-			Name: "configuration-anomaly-detection-template",
-		},
-		Parameters: []Parameter{
-			{Name: "IMAGE_TAG", Value: "v0.0.0"},
-			{Name: "REGISTRY_IMG", Value: "quay.io/app-sre/configuration-anomaly-detection"},
-			{Name: "NAMESPACE_NAME", Value: "configuration-anomaly-detection"},
-		},
-	}
-)
+// this holds all the info that is static in the template. update this as needed
+var saasTemplateFile = Template{
+	APIVersion: "template.openshift.io/v1",
+	Kind:       "Template",
+	Metadata: Metadata{
+		Name: "configuration-anomaly-detection-template",
+	},
+	Parameters: []Parameter{
+		{Name: "IMAGE_TAG", Value: "v0.0.0"},
+		{Name: "REGISTRY_IMG", Value: "quay.io/app-sre/configuration-anomaly-detection"},
+		{Name: "NAMESPACE_NAME", Value: "configuration-anomaly-detection"},
+	},
+}
 
 func main() {
 	ex, getExecutableErr := os.Executable()
@@ -133,7 +131,7 @@ func main() {
 	// marshal back into bytes
 	saasTemplateFileAsBytes, marshalBackErr := yaml.Marshal(&saasTemplateFile)
 	if marshalBackErr != nil {
-		panic(fmt.Errorf("could not marshal the bigMapping back: %v", marshalBackErr))
+		panic(fmt.Errorf("could not marshal the bigMapping back: %w", marshalBackErr))
 	}
 	// print to stdout just so we know something happened and the code isn't broken
 	fmt.Printf("---\n%s\n", string(saasTemplateFileAsBytes))
@@ -158,6 +156,7 @@ func main() {
 		panic(fmt.Errorf("could not write marshalled data into file '%s': %w", outputFile, writeErr))
 	}
 }
+
 func fixRoleOrClusterRoleBinding(fileAsMap map[interface{}]interface{}) error {
 	subjects, hasSubjects, getNestedSliceErr := mutableNestedSlice(fileAsMap, "subjects")
 	if getNestedSliceErr != nil {

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -32,9 +32,7 @@ const (
 	backoffUpperLimit                = 5 * time.Minute
 )
 
-var (
-	stopInstanceDateRegex = regexp.MustCompile(`\((\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.*)\)`)
-)
+var stopInstanceDateRegex = regexp.MustCompile(`\((\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.*)\)`)
 
 //go:generate mockgen --build_flags=--mod=readonly -destination mock/stsmock.go -package awsmock github.com/aws/aws-sdk-go/service/sts/stsiface STSAPI
 //go:generate mockgen --build_flags=--mod=readonly -destination mock/ec2mock.go -package awsmock github.com/aws/aws-sdk-go/service/ec2/ec2iface EC2API
@@ -336,7 +334,7 @@ func (c *SdkClient) PollInstanceStopEventsFor(instances []*ec2.Instance, retryTi
 		if executionError == nil {
 			return nil, fmt.Errorf("command failed after a pollTimeout of %v: %w", backoffUpperLimit, err)
 		}
-		return nil, fmt.Errorf("command failed after a pollTimeout of %v: %v: %w", backoffUpperLimit, err, executionError)
+		return nil, fmt.Errorf("command failed after a pollTimeout of %v: %v: %w", backoffUpperLimit, err.Error(), executionError)
 	}
 
 	return events, nil
@@ -382,7 +380,6 @@ func populateStopTime(instances []*ec2.Instance) (map[string]time.Time, error) {
 		idToStopTime[instanceID] = extractedTime
 	}
 	return idToStopTime, nil
-
 }
 
 func getTime(rawReason string) (time.Time, error) {

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -33,9 +33,7 @@ var _ = Describe("Aws", func() {
 		}
 	})
 	Describe("When assuming a Role", func() {
-		var (
-			roleARN string
-		)
+		var roleARN string
 		BeforeEach(func() {
 			roleARN = "aws:iam:sts:231254123:test-acc"
 		})
@@ -46,7 +44,8 @@ var _ = Describe("Aws", func() {
 						Credentials: &sts.Credentials{
 							AccessKeyId:     awsSDK.String("testId"),
 							SecretAccessKey: awsSDK.String("testSec"),
-							SessionToken:    awsSDK.String("token")},
+							SessionToken:    awsSDK.String("token"),
+						},
 					}, nil).Times(1)
 				c, err := client.AssumeRole(roleARN, "eu-west-1")
 				Expect(err).ShouldNot(HaveOccurred())
@@ -110,7 +109,7 @@ var _ = Describe("Aws", func() {
 
 				c, err := client.ListInstances("cluster-s3v21l")
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(c)).Should(Equal(nrPages))
+				Expect(c).Should(HaveLen(nrPages))
 			})
 		})
 		When("the full list is on one page", func() {
@@ -118,7 +117,7 @@ var _ = Describe("Aws", func() {
 				mockSdkEc2Client.EXPECT().DescribeInstances(gomock.Any()).Return(describeInstanceOut, nil).Times(1)
 				c, err := client.ListInstances("cluster-s3v21l")
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(c)).Should(Equal(1))
+				Expect(c).Should(HaveLen(1))
 			})
 		})
 		When("the client fails with an arbitrary error", func() {
@@ -127,7 +126,7 @@ var _ = Describe("Aws", func() {
 				c, err := client.ListInstances("cluster-s3v21l")
 				Expect(err).Should(HaveOccurred())
 				Expect(err).Should(Equal(errOcc))
-				Expect(len(c)).Should(Equal(0))
+				Expect(c).Should(BeEmpty())
 			})
 		})
 	})
@@ -158,7 +157,7 @@ var _ = Describe("Aws", func() {
 				mockCloudTrailClient.EXPECT().LookupEvents(gomock.Any()).Return(lookupEventOut, nil).Times(1)
 				c, err := client.ListAllInstanceStopEvents()
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(c)).Should(Equal(1))
+				Expect(c).Should(HaveLen(1))
 			})
 		})
 		When("the client fails with an arbitrary error", func() {
@@ -167,7 +166,7 @@ var _ = Describe("Aws", func() {
 				c, err := client.ListAllInstanceStopEvents()
 				Expect(err).Should(HaveOccurred())
 				Expect(err).Should(Equal(errOcc))
-				Expect(len(c)).Should(Equal(0))
+				Expect(c).Should(BeEmpty())
 			})
 		})
 		Describe("When Polling StoppedInstances events as a unique array", func() {
@@ -224,7 +223,6 @@ var _ = Describe("Aws", func() {
 					Expect(err).Should(MatchError(errOcc))
 				})
 			})
-
 		})
 	})
 })

--- a/pkg/ocm/ocm_config.go
+++ b/pkg/ocm/ocm_config.go
@@ -42,13 +42,13 @@ func Load() (cfg *Config, err error) {
 		return
 	}
 	if err != nil {
-		err = fmt.Errorf("can't check if config file '%s' exists: %v", file, err)
+		err = fmt.Errorf("can't check if config file '%s' exists: %w", file, err)
 		return
 	}
 	// #nosec G304
 	data, err := os.ReadFile(file)
 	if err != nil {
-		err = fmt.Errorf("can't read config file '%s': %v", file, err)
+		err = fmt.Errorf("can't read config file '%s': %w", file, err)
 		return
 	}
 	cfg = &Config{}
@@ -57,7 +57,7 @@ func Load() (cfg *Config, err error) {
 	}
 	err = json.Unmarshal(data, cfg)
 	if err != nil {
-		err = fmt.Errorf("can't parse config file '%s': %v", file, err)
+		err = fmt.Errorf("can't parse config file '%s': %w", file, err)
 		return
 	}
 	return

--- a/pkg/pagerduty/errors.go
+++ b/pkg/pagerduty/errors.go
@@ -1,114 +1,109 @@
 package pagerduty
 
 import (
+	"errors"
 	"fmt"
 )
 
-// InvalidTokenErr wraps the PagerDuty token invalid error
-type InvalidTokenErr struct {
+// InvalidTokenError wraps the PagerDuty token invalid error
+type InvalidTokenError struct {
 	Err error
 }
 
 // Error prints the wrapped error and the original one
-func (i InvalidTokenErr) Error() string {
+func (i InvalidTokenError) Error() string {
 	err := fmt.Errorf("the authToken that was provided is invalid: %w", i.Err)
 	return err.Error()
 }
 
 // Is ignores the internal error, thus making errors.Is work (as by default it compares the internal objects)
-func (InvalidTokenErr) Is(target error) bool {
-	_, ok := target.(InvalidTokenErr)
-	return ok
+func (InvalidTokenError) Is(target error) bool {
+	return errors.Is(target, InvalidTokenError{})
 }
 
-// InvalidInputParamsErr wraps the PagerDuty Invalid parameters error
+// InvalidInputParamsError wraps the PagerDuty Invalid parameters error
 // TODO: the API also returns any other error in here, if this persists, think on renaming to "ClientMisconfiguration"
-type InvalidInputParamsErr struct {
+type InvalidInputParamsError struct {
 	Err error
 }
 
 // Error prints the wrapped error and the original one
-func (i InvalidInputParamsErr) Error() string {
+func (i InvalidInputParamsError) Error() string {
 	err := fmt.Errorf("the escalation policy or incident id are invalid: %w", i.Err)
 	return err.Error()
 }
 
 // Is ignores the internal error, thus making errors.Is work (as by default it compares the internal objects)
-func (InvalidInputParamsErr) Is(target error) bool {
-	_, ok := target.(InvalidInputParamsErr)
-	return ok
+func (InvalidInputParamsError) Is(target error) bool {
+	return errors.Is(target, InvalidInputParamsError{})
 }
 
-// IncidentNotFoundErr wraps the PagerDuty not found error while adding notes to an incident
-type IncidentNotFoundErr struct {
+// IncidentNotFoundError wraps the PagerDuty not found error while adding notes to an incident
+type IncidentNotFoundError struct {
 	Err error
 }
 
 // Error prints the wrapped error and the original one
-func (i IncidentNotFoundErr) Error() string {
+func (i IncidentNotFoundError) Error() string {
 	err := fmt.Errorf("the given incident was not found: %w", i.Err)
 	return err.Error()
 }
 
 // Is ignores the internal error, thus making errors.Is work (as by default it compares the internal objects)
-func (IncidentNotFoundErr) Is(target error) bool {
-	_, ok := target.(IncidentNotFoundErr)
-	return ok
+func (IncidentNotFoundError) Is(target error) bool {
+	return errors.Is(target, IncidentNotFoundError{})
 }
 
-// ServiceNotFoundErr wraps the errors returned when PagerDuty services cannot be retrieved
-type ServiceNotFoundErr struct {
+// ServiceNotFoundError wraps the errors returned when PagerDuty services cannot be retrieved
+type ServiceNotFoundError struct {
 	Err error
 }
 
 // Error prints the wrapped and original error
-func (s ServiceNotFoundErr) Error() string {
+func (s ServiceNotFoundError) Error() string {
 	err := fmt.Errorf("the given service was not found: %w", s.Err)
 	return err.Error()
 }
 
-// Is indicates whether the supplied error is a ServiceNotFoundErr
-func (ServiceNotFoundErr) Is(target error) bool {
-	_, ok := target.(ServiceNotFoundErr)
-	return ok
+// Is indicates whether the supplied error is a ServiceNotFoundError
+func (ServiceNotFoundError) Is(target error) bool {
+	return errors.Is(target, ServiceNotFoundError{})
 }
 
-// IntegrationNotFoundErr wraps the errors returned when a PagerDuty service's integration cannot be found
-type IntegrationNotFoundErr struct {
+// IntegrationNotFoundError wraps the errors returned when a PagerDuty service's integration cannot be found
+type IntegrationNotFoundError struct {
 	Err error
 }
 
 // Error prints the wrapped and original error
-func (i IntegrationNotFoundErr) Error() string {
+func (i IntegrationNotFoundError) Error() string {
 	err := fmt.Errorf("the given integration was not found: %w", i.Err)
 	return err.Error()
 }
 
-// Is indicates whether the supplied error is an IntegrationNotFoundErr
-func (IntegrationNotFoundErr) Is(target error) bool {
-	_, ok := target.(IntegrationNotFoundErr)
-	return ok
+// Is indicates whether the supplied error is an IntegrationNotFoundError
+func (IntegrationNotFoundError) Is(target error) bool {
+	return errors.Is(target, IntegrationNotFoundError{})
 }
 
-// CreateEventErr wraps the errors returned when failing to create a PagerDuty event
-type CreateEventErr struct {
+// CreateEventError wraps the errors returned when failing to create a PagerDuty event
+type CreateEventError struct {
 	Err error
 }
 
 // Error prints the wrapped and original error
-func (c CreateEventErr) Error() string {
+func (c CreateEventError) Error() string {
 	err := fmt.Errorf("failed to create event: %w", c.Err)
 	return err.Error()
 }
 
-// Is indicates whether the supplied error is a CreateEventErr
-func (CreateEventErr) Is(target error) bool {
-	_, ok := target.(CreateEventErr)
-	return ok
+// Is indicates whether the supplied error is a CreateEventError
+func (CreateEventError) Is(target error) bool {
+	return errors.Is(target, CreateEventError{})
 }
 
-// AlertBodyExternalCastErr denotes the fact the alert's body field could not be converted correctly
-type AlertBodyExternalCastErr struct {
+// AlertBodyExternalCastError denotes the fact the alert's body field could not be converted correctly
+type AlertBodyExternalCastError struct {
 	FailedProperty     string
 	ExpectedType       string
 	ActualType         string
@@ -116,7 +111,7 @@ type AlertBodyExternalCastErr struct {
 }
 
 // Error prints data (to conform to the other errors in the package
-func (a AlertBodyExternalCastErr) Error() string {
+func (a AlertBodyExternalCastError) Error() string {
 	err := fmt.Errorf("'%s' field is not '%s' it is '%s', the resource is '%s' ",
 		a.FailedProperty,
 		a.ExpectedType,
@@ -126,85 +121,82 @@ func (a AlertBodyExternalCastErr) Error() string {
 	return err.Error()
 }
 
-// AlertBodyExternalParseErr denotes the fact the alert's body could not be parsed correctly
-type AlertBodyExternalParseErr struct {
+// AlertBodyExternalParseError denotes the fact the alert's body could not be parsed correctly
+type AlertBodyExternalParseError struct {
 	FailedProperty string
 }
 
 // Error prints data (to conform to the other errors in the package
-func (a AlertBodyExternalParseErr) Error() string {
+func (a AlertBodyExternalParseError) Error() string {
 	err := fmt.Errorf("cannot find '%s' in body", a.FailedProperty)
 	return err.Error()
 }
 
-// AlertBodyDoesNotHaveNotesFieldErr denotes the fact the alert's body does not have a notes field
+// AlertBodyDoesNotHaveNotesFieldError denotes the fact the alert's body does not have a notes field
 // this is needed as the extracted notes body is a map[string]interface{} so marshalling it will
 // not always populate the field
-type AlertBodyDoesNotHaveNotesFieldErr struct{}
+type AlertBodyDoesNotHaveNotesFieldError struct{}
 
 // Error prints data (to conform to the other errors in the package
-func (AlertBodyDoesNotHaveNotesFieldErr) Error() string {
+func (AlertBodyDoesNotHaveNotesFieldError) Error() string {
 	err := fmt.Errorf("decoded resource does not have a .details.notes field, stopping")
 	return err.Error()
 }
 
-// AlertNotesDoesNotHaveClusterIDFieldErr denotes the fact the alert's notes does not have a '.cluster_id' field
-type AlertNotesDoesNotHaveClusterIDFieldErr struct{}
+// AlertNotesDoesNotHaveClusterIDFieldError denotes the fact the alert's notes does not have a '.cluster_id' field
+type AlertNotesDoesNotHaveClusterIDFieldError struct{}
 
 // Error prints data (to conform to the other errors in the package
-func (AlertNotesDoesNotHaveClusterIDFieldErr) Error() string {
+func (AlertNotesDoesNotHaveClusterIDFieldError) Error() string {
 	err := fmt.Errorf("decoded internal resource does not have '.cluster_id' field , stopping")
 	return err.Error()
 }
 
-// NotesParseErr wraps the yaml parse errors
-type NotesParseErr struct {
+// NotesParseError wraps the yaml parse errors
+type NotesParseError struct {
 	Err error
 }
 
 // Error prints the wrapped error and the original one
-func (n NotesParseErr) Error() string {
+func (n NotesParseError) Error() string {
 	err := fmt.Errorf("the notes object could not be marshalled into internalCHGMAlertBody: %w", n.Err)
 	return err.Error()
 }
 
 // Is ignores the internal error, thus making errors.Is work (as by default it compares the internal objects)
-func (NotesParseErr) Is(target error) bool {
-	_, ok := target.(NotesParseErr)
-	return ok
+func (NotesParseError) Is(target error) bool {
+	return errors.Is(target, NotesParseError{})
 }
 
-// FileNotFoundErr wraps the filesystem NotFound Error
-type FileNotFoundErr struct {
+// FileNotFoundError wraps the filesystem NotFound Error
+type FileNotFoundError struct {
 	Err      error
 	FilePath string
 }
 
 // Error prints the wrapped error and the original one
-func (f FileNotFoundErr) Error() string {
+func (f FileNotFoundError) Error() string {
 	err := fmt.Errorf("the file '%s' was not found in the filesystem: %w", f.FilePath, f.Err)
 	return err.Error()
 }
 
 // Is ignores the internal error, thus making errors.Is work (as by default it compares the internal objects)
-func (f FileNotFoundErr) Is(target error) bool {
-	_, ok := target.(FileNotFoundErr)
-	return ok
+func (f FileNotFoundError) Is(target error) bool {
+	return errors.Is(target, FileNotFoundError{})
 }
 
-// UnmarshalErr wraps JSON's json.SyntaxError
-type UnmarshalErr struct {
+// UnmarshalError wraps JSON's json.SyntaxError
+type UnmarshalError struct {
 	Err error
 }
 
 // Error prints the wrapped error and the original one
-func (u UnmarshalErr) Error() string {
+func (u UnmarshalError) Error() string {
 	err := fmt.Errorf("could not unmarshal the payloadFile: %w", u.Err)
 	return err.Error()
 }
 
 // Is ignores the internal error, thus making errors.Is work (as by default it compares the internal objects)
-func (u UnmarshalErr) Is(target error) bool {
-	_, ok := target.(UnmarshalErr)
-	return ok
+func (u UnmarshalError) Is(target error) bool {
+	return errors.Is(target, UnmarshalError{})
 }

--- a/pkg/pagerduty/pagerduty_test.go
+++ b/pkg/pagerduty/pagerduty_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Pagerduty", func() {
 				err := p.MoveToEscalationPolicy(escalationPolicyID)
 				// Assert
 				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError(pagerduty.InvalidTokenErr{}))
+				Expect(err).Should(MatchError(pagerduty.InvalidTokenError{}))
 			})
 		})
 
@@ -78,8 +78,7 @@ var _ = Describe("Pagerduty", func() {
 				// Assert
 				Expect(err).Should(HaveOccurred())
 
-				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsErr{}))
-
+				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsError{}))
 			})
 		})
 
@@ -94,14 +93,11 @@ var _ = Describe("Pagerduty", func() {
 				err := p.MoveToEscalationPolicy(escalationPolicyID)
 				// Assert
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(err).Should(BeNil())
 			})
 		})
 	})
 	Describe("AssignToUser", func() {
-		var (
-			userID string
-		)
+		var userID string
 		BeforeEach(func() {
 			userID = "1234"
 		})
@@ -117,7 +113,7 @@ var _ = Describe("Pagerduty", func() {
 				err := p.AssignToUser(userID)
 				// Assert
 				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError(pagerduty.InvalidTokenErr{}))
+				Expect(err).Should(MatchError(pagerduty.InvalidTokenError{}))
 			})
 		})
 
@@ -135,8 +131,7 @@ var _ = Describe("Pagerduty", func() {
 				// Assert
 				Expect(err).Should(HaveOccurred())
 
-				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsErr{}))
-
+				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsError{}))
 			})
 		})
 
@@ -150,9 +145,7 @@ var _ = Describe("Pagerduty", func() {
 				// Act
 				err := p.AssignToUser(userID)
 				// Assert
-				// Assert
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(err).Should(BeNil())
 			})
 		})
 	})
@@ -171,7 +164,7 @@ var _ = Describe("Pagerduty", func() {
 				err := p.AcknowledgeIncident()
 				// Assert
 				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError(pagerduty.InvalidTokenErr{}))
+				Expect(err).Should(MatchError(pagerduty.InvalidTokenError{}))
 			})
 		})
 
@@ -189,8 +182,7 @@ var _ = Describe("Pagerduty", func() {
 				// Assert
 				Expect(err).Should(HaveOccurred())
 
-				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsErr{}))
-
+				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsError{}))
 			})
 		})
 
@@ -205,20 +197,16 @@ var _ = Describe("Pagerduty", func() {
 				err := p.AcknowledgeIncident()
 				// Assert
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(err).Should(BeNil())
 			})
 		})
 	})
 
 	Describe("AddNote", func() {
-		var (
-			noteContent string
-		)
+		var noteContent string
 		BeforeEach(func() {
 			noteContent = "this is a test"
 			// this is the only place that actually required a value to be set for the incidentID
 			incidentID = "1234"
-
 		})
 
 		When("The authentication token that is sent is invalid", func() {
@@ -234,7 +222,7 @@ var _ = Describe("Pagerduty", func() {
 				err := p.AddNote(noteContent)
 				// Assert
 				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError(pagerduty.InvalidTokenErr{}))
+				Expect(err).Should(MatchError(pagerduty.InvalidTokenError{}))
 			})
 		})
 
@@ -252,8 +240,7 @@ var _ = Describe("Pagerduty", func() {
 				// Assert
 				Expect(err).Should(HaveOccurred())
 
-				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsErr{}))
-
+				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsError{}))
 			})
 		})
 
@@ -268,8 +255,7 @@ var _ = Describe("Pagerduty", func() {
 				err := p.AddNote(noteContent)
 				// Assert
 				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError(pagerduty.IncidentNotFoundErr{}))
-
+				Expect(err).Should(MatchError(pagerduty.IncidentNotFoundError{}))
 			})
 		})
 
@@ -284,7 +270,6 @@ var _ = Describe("Pagerduty", func() {
 				err := p.AddNote(noteContent)
 				// Assert
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(err).Should(BeNil())
 			})
 		})
 	})
@@ -307,7 +292,7 @@ var _ = Describe("Pagerduty", func() {
 				_, err := p.GetAlerts()
 				// Assert
 				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError(pagerduty.InvalidTokenErr{}))
+				Expect(err).Should(MatchError(pagerduty.InvalidTokenError{}))
 			})
 		})
 
@@ -325,8 +310,7 @@ var _ = Describe("Pagerduty", func() {
 				// Assert
 				Expect(err).Should(HaveOccurred())
 
-				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsErr{}))
-
+				Expect(err).Should(MatchError(pagerduty.InvalidInputParamsError{}))
 			})
 		})
 
@@ -344,7 +328,7 @@ var _ = Describe("Pagerduty", func() {
 				// Assert
 				Expect(err).Should(HaveOccurred())
 
-				Expect(err).Should(MatchError(pagerduty.IncidentNotFoundErr{}))
+				Expect(err).Should(MatchError(pagerduty.IncidentNotFoundError{}))
 			})
 		})
 
@@ -359,11 +343,9 @@ var _ = Describe("Pagerduty", func() {
 				res, err := p.GetAlerts()
 				// Assert
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(err).Should(BeNil())
 				Expect(res).Should(HaveLen(1))
 				Expect(res[0].ID).Should(Equal("123456"))
 				Expect(res[0].ExternalID).Should(Equal("123456"))
-
 			})
 		})
 	})
@@ -384,27 +366,28 @@ var _ = Describe("Pagerduty", func() {
 					Error:      "",
 					Resolution: "",
 					SOP:        "",
-				}}
+				},
+			}
 		})
 		When("The service cannot be retrieved", func() {
-			It("should return a ServiceNotFoundErr", func() {
+			It("should return a ServiceNotFoundError", func() {
 				err := p.CreateNewAlert(newAlert, serviceID)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(pagerduty.ServiceNotFoundErr{}))
+				Expect(err).To(MatchError(pagerduty.ServiceNotFoundError{}))
 			})
 		})
 		When("The service has no Dead Man's Snitch integrations", func() {
-			It("should return an IntegrationNotFoundErr", func() {
+			It("should return an IntegrationNotFoundError", func() {
 				mux.HandleFunc(fmt.Sprintf("/services/%s", serviceID), func(w http.ResponseWriter, r *http.Request) {
 					fmt.Fprintf(w, `{"service":{"id":"%s","integrations":[]}}`, serviceID)
 				})
 				err := p.CreateNewAlert(newAlert, serviceID)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(pagerduty.IntegrationNotFoundErr{}))
+				Expect(err).To(MatchError(pagerduty.IntegrationNotFoundError{}))
 			})
 		})
 		When("The event creation fails", func() {
-			It("should return a CreateEventErr", func() {
+			It("should return a CreateEventError", func() {
 				mux.HandleFunc(fmt.Sprintf("/services/%s", serviceID), func(w http.ResponseWriter, r *http.Request) {
 					fmt.Fprintf(w, `{"service":{"id":"%s","integrations":[{"id":"%s"}]}}`, serviceID, dmsIntegrationID)
 				})
@@ -413,13 +396,13 @@ var _ = Describe("Pagerduty", func() {
 				})
 				err := p.CreateNewAlert(newAlert, serviceID)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(pagerduty.CreateEventErr{}))
+				Expect(err).To(MatchError(pagerduty.CreateEventError{}))
 			})
 		})
 	})
 	Describe("NewWithToken", func() {
 		When("the payload is empty", func() {
-			It("should fail on UnmarshalErr", func() {
+			It("should fail on UnmarshalError", func() {
 				_, err := pagerduty.NewWithToken(
 					escalationPolicyID,
 					silencePolicyID,
@@ -441,7 +424,7 @@ var _ = Describe("Pagerduty", func() {
 					sdk.WithAPIEndpoint(server.URL),
 					sdk.WithV2EventsAPIEndpoint(server.URL),
 				)
-				Expect(err).Should(MatchError(pagerduty.UnmarshalErr{}))
+				Expect(err).Should(MatchError(pagerduty.UnmarshalError{}))
 			})
 		})
 		When("the payload is missing the event type", func() {
@@ -454,7 +437,7 @@ var _ = Describe("Pagerduty", func() {
 					sdk.WithAPIEndpoint(server.URL),
 					sdk.WithV2EventsAPIEndpoint(server.URL),
 				)
-				Expect(err).Should(MatchError(pagerduty.UnmarshalErr{}))
+				Expect(err).Should(MatchError(pagerduty.UnmarshalError{}))
 			})
 		})
 		When("the payload is missing the data field", func() {
@@ -467,7 +450,7 @@ var _ = Describe("Pagerduty", func() {
 					sdk.WithAPIEndpoint(server.URL),
 					sdk.WithV2EventsAPIEndpoint(server.URL),
 				)
-				Expect(err).Should(MatchError(pagerduty.UnmarshalErr{}))
+				Expect(err).Should(MatchError(pagerduty.UnmarshalError{}))
 			})
 		})
 	})
@@ -479,12 +462,12 @@ var _ = Describe("Pagerduty", func() {
 	// 	})
 
 	// 	When("the '.details' field is of the wrong type", func() {
-	// 		It("should raise a 'AlertBodyExternalCastErr' error", func() {
+	// 		It("should raise a 'AlertBodyExternalCastError' error", func() {
 	// 			// Arrange
 	// 			alertBody = map[string]interface{}{
 	// 				"details": "bad details",
 	// 			}
-	// 			expectedErr := pagerduty.AlertBodyExternalCastErr{
+	// 			expectedErr := pagerduty.AlertBodyExternalCastError{
 	// 				FailedProperty:     ".details",
 	// 				ExpectedType:       "map[string]interface{}",
 	// 				ActualType:         "string",
@@ -498,7 +481,7 @@ var _ = Describe("Pagerduty", func() {
 	// 		})
 	// 	})
 	// 	When("the '.details.notes' field is of the wrong type", func() {
-	// 		It("should raise a 'AlertBodyExternalCastErr' error", func() {
+	// 		It("should raise a 'AlertBodyExternalCastError' error", func() {
 	// 			// Arrange
 	// 			alertBody = map[string]interface{}{
 	// 				"details": map[string]interface{}{
@@ -507,7 +490,7 @@ var _ = Describe("Pagerduty", func() {
 	// 					},
 	// 				},
 	// 			}
-	// 			expectedErr := pagerduty.AlertBodyExternalCastErr{
+	// 			expectedErr := pagerduty.AlertBodyExternalCastError{
 	// 				FailedProperty:     ".details.notes",
 	// 				ExpectedType:       "string",
 	// 				ActualType:         "map[string]interface {}",
@@ -522,7 +505,7 @@ var _ = Describe("Pagerduty", func() {
 	// 	})
 
 	// 	When("the notes field is improperly parsed by the 'yaml' package", func() {
-	// 		It("should raise a 'NotesParseErr' error", func() {
+	// 		It("should raise a 'NotesParseError' error", func() {
 	// 			// Arrange
 	// 			alertBody = map[string]interface{}{
 	// 				"details": map[string]interface{}{
@@ -533,7 +516,7 @@ var _ = Describe("Pagerduty", func() {
 	// 			_, err := p.ExtractIDFromCHGM(alertBody)
 	// 			// Assert
 	// 			Expect(err).Should(HaveOccurred())
-	// 			Expect(err).Should(MatchError(pagerduty.NotesParseErr{}))
+	// 			Expect(err).Should(MatchError(pagerduty.NotesParseError{}))
 	// 		})
 	// 	})
 
@@ -569,7 +552,7 @@ var _ = Describe("Pagerduty", func() {
 					// Act
 					_, err := p.RetrieveExternalClusterID()
 					// Assert
-					Expect(err).Should(MatchError(pagerduty.IncidentNotFoundErr{}))
+					Expect(err).Should(MatchError(pagerduty.IncidentNotFoundError{}))
 				})
 			})
 			When("the payload is valid and the api does have the alert + incident", func() {
@@ -596,15 +579,15 @@ var _ = Describe("Pagerduty", func() {
 					_, err := p.RetrieveExternalClusterID()
 					// Assert
 					Expect(err).Should(HaveOccurred())
-					Expect(err).Should(MatchError(pagerduty.AlertBodyExternalParseErr{FailedProperty: ".details"}))
+					Expect(err).Should(MatchError(pagerduty.AlertBodyExternalParseError{FailedProperty: ".details"}))
 				})
 			})
 			When("the '.details' field is of the wrong type", func() {
-				It("should raise a 'AlertBodyExternalCastErr' error", func() {
+				It("should raise a 'AlertBodyExternalCastError' error", func() {
 					mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {
 						fmt.Fprint(w, `{"alerts":[{"id":"1234","body":{"details":"bad details"}}]}`)
 					})
-					expectedErr := pagerduty.AlertBodyExternalCastErr{
+					expectedErr := pagerduty.AlertBodyExternalCastError{
 						FailedProperty:     ".details",
 						ExpectedType:       "map[string]interface{}",
 						ActualType:         "string",
@@ -616,7 +599,6 @@ var _ = Describe("Pagerduty", func() {
 					Expect(err).Should(HaveOccurred())
 					Expect(err).Should(MatchError(expectedErr))
 				})
-
 			})
 		})
 	})

--- a/pkg/services/ccam/ccam.go
+++ b/pkg/services/ccam/ccam.go
@@ -31,7 +31,6 @@ const accessDeniedError string = "failed to assume into support-role: AccessDeni
 // the cluster is placed into limited support, otherwise an error is returned. If the cluster already has a CCAM
 // LS reason, no additional reasons are added and incident is sent to SilentTest.
 func Evaluate(cluster *v1.Cluster, awsError error, ocmClient ocm.Client, pdClient pagerduty.Client) error {
-
 	logging.Info("Investigating possible missing cloud credentials...")
 
 	// We aren't able to jumpRole because of an error that is different than

--- a/pkg/services/chgm/chgm_test.go
+++ b/pkg/services/chgm/chgm_test.go
@@ -23,7 +23,7 @@ import (
 
 var _ = Describe("chgm", func() {
 	// this is a var but I use it as a const
-	var fakeErr = fmt.Errorf("test triggered")
+	fakeErr := fmt.Errorf("test triggered")
 	var (
 		r                  *investigation.Resources
 		mockCtrl           *gomock.Controller
@@ -40,7 +40,6 @@ var _ = Describe("chgm", func() {
 		event              cloudtrail.Event
 	)
 	BeforeEach(func() {
-
 		logging.InitLogger("fatal", "") // Mute logger for the tests
 
 		mockCtrl = gomock.NewController(GinkgoT())
@@ -93,7 +92,6 @@ var _ = Describe("chgm", func() {
 		r.PdClient = pdmock.NewMockClient(mockCtrl)
 
 		fmt.Println(instance, event)
-
 	})
 	AfterEach(func() {
 		mockCtrl.Finish()
@@ -541,7 +539,6 @@ var _ = Describe("chgm", func() {
 				Expect(gotErr).NotTo(HaveOccurred())
 			})
 		})
-
 	})
 	Describe("Resolved", func() {
 		var err error

--- a/pkg/services/cpd/cpd.go
+++ b/pkg/services/cpd/cpd.go
@@ -34,7 +34,6 @@ func GetCPDAlertInternalID(alertTitle string) (string, error) {
 // The reasoning for this is that we don't fully trust network verifier yet.
 // In the future, we want to automate service logs based on the network verifier output.
 func InvestigateTriggered(r *investigation.Resources) error {
-
 	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
 	if err != nil {
 		logging.Error("Network verifier ran into an error: %s", err.Error())
@@ -43,7 +42,6 @@ func InvestigateTriggered(r *investigation.Resources) error {
 			// We do not return as we want the alert to be escalated either no matter what.
 			logging.Error("could not add failure reason incident notes")
 		}
-
 	}
 
 	switch verifierResult {

--- a/pkg/services/networkverifier/networkverifier.go
+++ b/pkg/services/networkverifier/networkverifier.go
@@ -29,9 +29,7 @@ type egressConfig struct {
 	noTLS        bool
 }
 
-var (
-	awsDefaultTags = map[string]string{"osd-network-verifier": "owned", "red-hat-managed": "true", "Name": "osd-network-verifier"}
-)
+var awsDefaultTags = map[string]string{"osd-network-verifier": "owned", "red-hat-managed": "true", "Name": "osd-network-verifier"}
 
 // VerifierResult type contains the verifier outcomes
 type VerifierResult int
@@ -97,7 +95,7 @@ func Run(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsCl
 
 	awsVerifier, err := awsverifier.NewAwsVerifier(credentials.AccessKeyID, credentials.SecretAccessKey, credentials.SessionToken, cluster.Region().ID(), "", false)
 	if err != nil {
-		return Undefined, "", fmt.Errorf("could not build awsVerifier %v", err)
+		return Undefined, "", fmt.Errorf("could not build awsVerifier %w", err)
 	}
 
 	logging.Infof("Using region: %s", cluster.Region().ID())
@@ -107,7 +105,6 @@ func Run(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsCl
 	verifierFailures, verifierExceptions, verifierErrors := out.Parse()
 
 	if len(verifierExceptions) != 0 || len(verifierErrors) != 0 {
-
 		exceptionsSummary := ""
 		errorsSummary := ""
 

--- a/pkg/services/networkverifier/networkverifier_test.go
+++ b/pkg/services/networkverifier/networkverifier_test.go
@@ -40,7 +40,6 @@ var _ = Describe("RunVerifier", func() {
 		// This test is pretty useless but illustrates what tests for networkverifier should look like
 		When("Getting security group ids", func() {
 			It("Should return the error failed to get SecurityGroupId", func() {
-
 				expectedError := errors.New("failed to get SecurityGroupId: errormessage")
 				// Arrange
 				awsCli.EXPECT().GetSecurityGroupID(gomock.Eq(clusterDeployment.Spec.ClusterMetadata.InfraID)).Return(nil, expectedError)


### PR DESCRIPTION
Ticket: [OSD-16112](https://issues.redhat.com/browse/OSD-16112)

- Adds linters to the golangci-lint config
- Adds an editorconfig to enforce usage of tab over spaces
- Adds a pre-commit hook created by the Makefile

The following lint errors raised by https://github.com/nakabonne/nestif remain up for discussion:
```
cadctl/cmd/investigate/investigate.go:103:2: `if !cloudProviderSupported` has complex nested blocks (complexity: 5) (nestif)
	if !cloudProviderSupported {
	^
pkg/services/chgm/chgm.go:57:2: `if res.UserAuthorized` has complex nested blocks (complexity: 7) (nestif)
	if res.UserAuthorized {
	^
pkg/services/chgm/chgm.go:135:2: `if res.Error != ""` has complex nested blocks (complexity: 5) (nestif)
	if res.Error != "" {
```

We could set the complexity to a value of 10 to prevent complicated code while avoiding the necessity of refactoring the current codebase.