### PR TITLE
Add remaining checks from 'osdctl cluster cpd' to cpd investigation

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -49,6 +49,8 @@ type Client interface {
 	GetSubnetID(infraID string) ([]string, error)
 	IsSubnetPrivate(subnet string) bool
 	AssumeRole(roleARN, region string) (*SdkClient, error)
+	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
+	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
 }
 
 // SdkClient is a representation of the AWS Client
@@ -491,4 +493,14 @@ func (c *SdkClient) IsSubnetPrivate(subnet string) bool {
 	out, _ := c.Ec2Client.DescribeSubnets(in)
 
 	return !*out.Subnets[0].MapPublicIpOnLaunch
+}
+
+// DescribeRouteTables returns DescribeRouteTablesOutput
+func (c *SdkClient) DescribeRouteTables(input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
+	return c.Ec2Client.DescribeRouteTables(input)
+}
+
+// DescribeSubnets return DescribeSubnetsOutput
+func (c *SdkClient) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	return c.Ec2Client.DescribeSubnets(input)
 }

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -49,8 +49,7 @@ type Client interface {
 	GetSubnetID(infraID string) ([]string, error)
 	IsSubnetPrivate(subnet string) bool
 	AssumeRole(roleARN, region string) (*SdkClient, error)
-	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
-	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+	GetRouteTableForSubnet(subnetID string) (*ec2.RouteTable, error)
 }
 
 // SdkClient is a representation of the AWS Client
@@ -495,12 +494,94 @@ func (c *SdkClient) IsSubnetPrivate(subnet string) bool {
 	return !*out.Subnets[0].MapPublicIpOnLaunch
 }
 
-// DescribeRouteTables returns DescribeRouteTablesOutput
-func (c *SdkClient) DescribeRouteTables(input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
-	return c.Ec2Client.DescribeRouteTables(input)
+// GetRouteTableForSubnet returns the subnets routeTable
+func (c *SdkClient) GetRouteTableForSubnet(subnetID string) (*ec2.RouteTable, error) {
+	out, err := c.Ec2Client.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("association.subnet-id"),
+				Values: []*string{aws.String(subnetID)},
+			},
+		},
+	})
+
+	if err != nil {
+		return &ec2.RouteTable{}, fmt.Errorf("failed to describe route tables associated to subnet %s: %w", subnetID, err)
+	}
+
+	var routeTable string
+
+	// If there are no associated RouteTables, then the subnet uses the default RoutTable for the VPC
+	if len(out.RouteTables) == 0 {
+		vpcID, err := c.findVpcIDForSubnet(subnetID)
+		if err != nil {
+			return &ec2.RouteTable{}, err
+		}
+
+		// Set the route table to the default for the VPC
+		routeTable, err = c.findDefaultRouteTableForVPC(vpcID)
+		if err != nil {
+			return &ec2.RouteTable{}, err
+		}
+	} else {
+		// Set the route table to the one associated with the subnet
+		routeTable = *out.RouteTables[0].RouteTableId
+	}
+
+	return c.getRouteTable(routeTable)
 }
 
-// DescribeSubnets return DescribeSubnetsOutput
-func (c *SdkClient) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
-	return c.Ec2Client.DescribeSubnets(input)
+// findVpcIDForSubnet returns the VPC ID for the subnet
+func (c *SdkClient) findVpcIDForSubnet(subnetID string) (string, error) {
+	describeSubnetOutput, err := c.Ec2Client.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		SubnetIds: []*string{&subnetID},
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(describeSubnetOutput.Subnets) == 0 {
+		return "", fmt.Errorf("no subnets returned for subnet id %v", subnetID)
+	}
+
+	return *describeSubnetOutput.Subnets[0].VpcId, nil
+}
+
+// findDefaultRouteTableForVPC returns the AWS Route Table ID of the VPC's default Route Table
+func (c *SdkClient) findDefaultRouteTableForVPC(vpcID string) (string, error) {
+	describeRouteTablesOutput, err := c.Ec2Client.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{aws.String(vpcID)},
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to describe route tables associated with vpc %s: %w", vpcID, err)
+	}
+
+	for _, rt := range describeRouteTablesOutput.RouteTables {
+		for _, assoc := range rt.Associations {
+			if *assoc.Main {
+				return *rt.RouteTableId, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no default route table found for vpc: %s", vpcID)
+}
+
+// GetRouteTable takes a routeTable ID and returns a RouteTablesOutput
+func (c *SdkClient) getRouteTable(routeTableID string) (*ec2.RouteTable, error) {
+	describeRouteTablesOutput, err := c.Ec2Client.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		RouteTableIds: []*string{aws.String(routeTableID)},
+	})
+	if err != nil {
+		return &ec2.RouteTable{}, err
+	}
+
+	if len(describeRouteTablesOutput.RouteTables) == 0 {
+		return &ec2.RouteTable{}, fmt.Errorf("no route tables found for route table id %v", routeTableID)
+	}
+	return describeRouteTablesOutput.RouteTables[0], nil
 }

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -504,7 +504,6 @@ func (c *SdkClient) GetRouteTableForSubnet(subnetID string) (*ec2.RouteTable, er
 			},
 		},
 	})
-
 	if err != nil {
 		return &ec2.RouteTable{}, fmt.Errorf("failed to describe route tables associated to subnet %s: %w", subnetID, err)
 	}

--- a/pkg/aws/mock/aws.go
+++ b/pkg/aws/mock/aws.go
@@ -52,6 +52,36 @@ func (mr *MockClientMockRecorder) AssumeRole(roleARN, region interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRole", reflect.TypeOf((*MockClient)(nil).AssumeRole), roleARN, region)
 }
 
+// DescribeRouteTables mocks base method.
+func (m *MockClient) DescribeRouteTables(arg0 *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeRouteTables", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeRouteTablesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeRouteTables indicates an expected call of DescribeRouteTables.
+func (mr *MockClientMockRecorder) DescribeRouteTables(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTables", reflect.TypeOf((*MockClient)(nil).DescribeRouteTables), arg0)
+}
+
+// DescribeSubnets mocks base method.
+func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSubnets", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeSubnetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSubnets indicates an expected call of DescribeSubnets.
+func (mr *MockClientMockRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockClient)(nil).DescribeSubnets), arg0)
+}
+
 // GetAWSCredentials mocks base method.
 func (m *MockClient) GetAWSCredentials() credentials.Value {
 	m.ctrl.T.Helper()

--- a/pkg/aws/mock/aws.go
+++ b/pkg/aws/mock/aws.go
@@ -52,36 +52,6 @@ func (mr *MockClientMockRecorder) AssumeRole(roleARN, region interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRole", reflect.TypeOf((*MockClient)(nil).AssumeRole), roleARN, region)
 }
 
-// DescribeRouteTables mocks base method.
-func (m *MockClient) DescribeRouteTables(arg0 *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeRouteTables", arg0)
-	ret0, _ := ret[0].(*ec2.DescribeRouteTablesOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribeRouteTables indicates an expected call of DescribeRouteTables.
-func (mr *MockClientMockRecorder) DescribeRouteTables(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTables", reflect.TypeOf((*MockClient)(nil).DescribeRouteTables), arg0)
-}
-
-// DescribeSubnets mocks base method.
-func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeSubnets", arg0)
-	ret0, _ := ret[0].(*ec2.DescribeSubnetsOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribeSubnets indicates an expected call of DescribeSubnets.
-func (mr *MockClientMockRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockClient)(nil).DescribeSubnets), arg0)
-}
-
 // GetAWSCredentials mocks base method.
 func (m *MockClient) GetAWSCredentials() credentials.Value {
 	m.ctrl.T.Helper()
@@ -94,6 +64,21 @@ func (m *MockClient) GetAWSCredentials() credentials.Value {
 func (mr *MockClientMockRecorder) GetAWSCredentials() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAWSCredentials", reflect.TypeOf((*MockClient)(nil).GetAWSCredentials))
+}
+
+// GetRouteTableForSubnet mocks base method.
+func (m *MockClient) GetRouteTableForSubnet(subnetID string) (*ec2.RouteTable, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRouteTableForSubnet", subnetID)
+	ret0, _ := ret[0].(*ec2.RouteTable)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRouteTableForSubnet indicates an expected call of GetRouteTableForSubnet.
+func (mr *MockClientMockRecorder) GetRouteTableForSubnet(subnetID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouteTableForSubnet", reflect.TypeOf((*MockClient)(nil).GetRouteTableForSubnet), subnetID)
 }
 
 // GetSecurityGroupID mocks base method.

--- a/pkg/services/cpd/cpd.go
+++ b/pkg/services/cpd/cpd.go
@@ -6,10 +6,15 @@ import (
 	"fmt"
 	"regexp"
 
+	awsSdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/services/networkverifier"
 )
+
+const unknownProvisionCode = "OCM3999"
 
 // GetCPDAlertInternalID gets the internal ID from a CPD pagerduty alert's title
 // We need this function as CPD's alert formatting is an edge case to our other alerts.
@@ -29,11 +34,48 @@ func GetCPDAlertInternalID(alertTitle string) (string, error) {
 
 // InvestigateTriggered runs the investigation for a triggered CPD pagerduty event
 // Currently what this investigation does is:
+// - check cluster state
+// - check DNS
+// - check OcmErrorCode
+// - check subnet routes
 // - run network verifier and add the output as pagerduty note
 // - always escalate the alert to primary
 // The reasoning for this is that we don't fully trust network verifier yet.
 // In the future, we want to automate service logs based on the network verifier output.
 func InvestigateTriggered(r *investigation.Resources) error {
+	if r.Cluster.Status().State() == "ready" {
+		logging.Infof("This cluster is in a ready state and already provisioned")
+		err := r.PdClient.AddNote("This cluster is in a ready state and already provisioned")
+		if err != nil {
+			logging.Error("could not add clusters ready state to incident notes")
+		}
+	}
+
+	// Check if DNS is ready, exit out if not
+	if !r.Cluster.Status().DNSReady() {
+		note := fmt.Sprintf("DNS not ready. Investigate reasons using the dnszones CR in the cluster namespace:\noc get dnszones -n uhc-production-%s -o yaml --as backplane-cluster-admin\n", r.Cluster.ID())
+		logging.Info(note)
+		return r.PdClient.EscalateAlertWithNote(note)
+	}
+
+	// Check if the OCM Error code is a known error
+	if len(r.Cluster.Status().ProvisionErrorCode()) > 0 && r.Cluster.Status().ProvisionErrorCode() != unknownProvisionCode {
+		return r.PdClient.EscalateAlertWithNote(fmt.Sprintf("Error code '%s' is known, customer already received Service Log\n", r.Cluster.Status().ProvisionErrorCode()))
+	}
+
+	if r.Cluster.AWS().SubnetIDs() != nil && len(r.Cluster.AWS().SubnetIDs()) > 0 {
+		logging.Info("Checking BYOVPC to ensure subnets have valid routing")
+		for _, subnet := range r.Cluster.AWS().SubnetIDs() {
+			isValid, err := isSubnetRouteValid(r.AwsClient, subnet)
+			if err != nil {
+				logging.Error(err)
+			}
+			if !isValid {
+				return r.PdClient.EscalateAlertWithNote(fmt.Sprintf("subnet %s does not have a default route to 0.0.0.0/0\n Run the following to send a SerivceLog:\n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_NoRouteToInternet.json", subnet, r.Cluster.ID()))
+			}
+		}
+	}
+
 	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
 	if err != nil {
 		logging.Error("Network verifier ran into an error: %s", err.Error())
@@ -46,7 +88,7 @@ func InvestigateTriggered(r *investigation.Resources) error {
 
 	switch verifierResult {
 	case networkverifier.Failure:
-		logging.Info("Network verifier reported failure: %s", failureReason)
+		logging.Infof("Network verifier reported failure: %s", failureReason)
 		// In the future, we want to send a service log in this case
 		err = r.PdClient.AddNote(fmt.Sprintf("Network verifier found issues:\n %s \n\n Verify and send service log if necessary: \n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=%s", failureReason, r.Cluster.ID(), failureReason))
 		if err != nil {
@@ -63,4 +105,94 @@ func InvestigateTriggered(r *investigation.Resources) error {
 	// We currently always escalate, in the future, when network verifier is reliable,
 	// we would silence the alert when we had a service log in the case of network verifier detecting failures.
 	return r.PdClient.EscalateAlert()
+}
+
+func isSubnetRouteValid(awsClient aws.Client, subnetID string) (bool, error) {
+	var routeTable string
+
+	// Try and find a Route Table associated with the given subnet
+	describeRouteTablesOutput, err := awsClient.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   awsSdk.String("association.subnet-id"),
+				Values: []*string{awsSdk.String(subnetID)},
+			},
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to describe route tables associated to subnet %s: %w", subnetID, err)
+	}
+
+	// If there are no associated RouteTables, then the subnet uses the default RoutTable for the VPC
+	if len(describeRouteTablesOutput.RouteTables) == 0 {
+		// Get the VPC ID for the subnet
+		describeSubnetOutput, err := awsClient.DescribeSubnets(&ec2.DescribeSubnetsInput{
+			SubnetIds: []*string{&subnetID},
+		})
+		if err != nil {
+			return false, err
+		}
+		if len(describeSubnetOutput.Subnets) == 0 {
+			return false, fmt.Errorf("no subnets returned for subnet id %v", subnetID)
+		}
+
+		vpcID := *describeSubnetOutput.Subnets[0].VpcId
+
+		// Set the route table to the default for the VPC
+		routeTable, err = findDefaultRouteTableForVPC(awsClient, vpcID)
+		if err != nil {
+			return false, err
+		}
+	} else {
+		// Set the route table to the one associated with the subnet
+		routeTable = *describeRouteTablesOutput.RouteTables[0].RouteTableId
+	}
+
+	// Check that the RouteTable for the subnet has a default route to 0.0.0.0/0
+	describeRouteTablesOutput, err = awsClient.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		RouteTableIds: []*string{awsSdk.String(routeTable)},
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if len(describeRouteTablesOutput.RouteTables) == 0 {
+		// Shouldn't happen
+		return false, fmt.Errorf("no route tables found for route table id %v", routeTable)
+	}
+
+	for _, route := range describeRouteTablesOutput.RouteTables[0].Routes {
+		// Some routes don't use CIDR blocks as targets, so this needs to be checked
+		if route.DestinationCidrBlock != nil && *route.DestinationCidrBlock == "0.0.0.0/0" {
+			return true, nil
+		}
+	}
+
+	// We haven't found a default route to the internet, so this subnet has an invalid route table
+	return false, nil
+}
+
+// findDefaultRouteTableForVPC returns the AWS Route Table ID of the VPC's default Route Table
+func findDefaultRouteTableForVPC(awsClient aws.Client, vpcID string) (string, error) {
+	describeRouteTablesOutput, err := awsClient.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   awsSdk.String("vpc-id"),
+				Values: []*string{awsSdk.String(vpcID)},
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to describe route tables associated with vpc %s: %w", vpcID, err)
+	}
+
+	for _, rt := range describeRouteTablesOutput.RouteTables {
+		for _, assoc := range rt.Associations {
+			if *assoc.Main {
+				return *rt.RouteTableId, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no default route table found for vpc: %s", vpcID)
 }


### PR DESCRIPTION
This adds the rest of the checks that are run with 'osdctl cluster cpd' command to the cpd investigation for https://issues.redhat.com/browse/OSD-13697

Why: this will allow us to remove the highlighting for the cpd command in CPDS sop and eventually we should be able to deprecate it completely.

osdctl implementation https://github.com/openshift/osdctl/blob/master/cmd/cluster/cpd.go#L69 

I did not change the escalation behavior, so everything should still get escalated but with some more specific information.
Tested manually.
Please keep it a draft for now. I am still testing the BYOVPC subnet validation.