### PR TITLE
fix: OSD-17489 empty external cluster id

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -104,7 +104,7 @@ func run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	cloudProviderSupported, err := checkCloudProviderSupported(ocmClient, externalClusterID, []string{"aws"})
+	cloudProviderSupported, err := checkCloudProviderSupported(cluster, []string{"aws"})
 	if err != nil {
 		return err
 	}
@@ -280,14 +280,14 @@ func GetPDClient(webhookPayload []byte) (*pagerduty.SdkClient, error) {
 
 // checkCloudProviderSupported takes a list of supported providers and checks if the
 // cluster to investigate's provider is supported
-func checkCloudProviderSupported(ocmClient *ocm.SdkClient, externalClusterID string, supportedProviders []string) (bool, error) {
-	cloudProvider, err := ocmClient.GetCloudProviderID(externalClusterID)
-	if err != nil {
-		return false, err
+func checkCloudProviderSupported(cluster *v1.Cluster, supportedProviders []string) (bool, error) {
+	cloudProvider, ok := cluster.GetCloudProvider()
+	if !ok {
+		return false, fmt.Errorf("Failed to get clusters cloud provider")
 	}
 
 	for _, provider := range supportedProviders {
-		if cloudProvider == provider {
+		if cloudProvider.ID() == provider {
 			return true, nil
 		}
 	}

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -193,24 +193,6 @@ func (c *SdkClient) getClusterResource(clusterID string, resourceKey string) (st
 	return response.Body().Resources()[resourceKey], nil
 }
 
-// GetCloudProviderID returns the cloud provider name for a given cluster as a string
-func (c *SdkClient) GetCloudProviderID(identifier string) (string, error) {
-	cluster, err := c.GetClusterInfo(identifier)
-	if err != nil {
-		return "", fmt.Errorf("GetClusterInfo failed on: %w", err)
-	}
-
-	cloudProvider, ok := cluster.GetCloudProvider()
-	if !ok {
-		return "", fmt.Errorf("could not get clusters cloudProvider")
-	}
-	cloudProviderID, ok := cloudProvider.GetID()
-	if !ok {
-		return "", fmt.Errorf("could not get cloudProvider id")
-	}
-	return cloudProviderID, nil
-}
-
 // PostLimitedSupportReason allows to post a generic limited support reason to a cluster
 func (c *SdkClient) PostLimitedSupportReason(limitedSupportReason LimitedSupportReason, clusterID string) error {
 	logging.Infof("Sending limited support reason: %s", limitedSupportReason.Summary)


### PR DESCRIPTION
Fixes bug with empty external cluster ids on CPDs.
We do not need to do another call to ocm to get the cloud provider as we already have the full cluster object at that point.
