### PR TITLE
Use master instead of worker security group

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -442,7 +442,7 @@ func (c *SdkClient) GetSecurityGroupID(infraID string) (string, error) {
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag:Name"),
-				Values: []*string{aws.String(fmt.Sprintf("%s-worker-sg", infraID))},
+				Values: []*string{aws.String(fmt.Sprintf("%s-master-sg", infraID))},
 			},
 		},
 	}
@@ -454,7 +454,7 @@ func (c *SdkClient) GetSecurityGroupID(infraID string) (string, error) {
 		return "", fmt.Errorf("security groups are empty")
 	}
 	if len(*out.SecurityGroups[0].GroupId) == 0 {
-		return "", fmt.Errorf("failed to list security group %s-worker-sg", infraID)
+		return "", fmt.Errorf("failed to list security group %s-master-sg", infraID)
 	}
 	return *out.SecurityGroups[0].GroupId, nil
 }


### PR DESCRIPTION
When running the network verifer on cpds, 'osdctl cluster cpd' uses the master security group instead of the worker security group we use in CAD. 


I am in favor of a deeper investigation into how we startup and configure the verifier, but we can use this as a hotfix to reduce some toil for primary.

https://issues.redhat.com/browse/OSD-17515 