### PR TITLE
OSD-17456 Add alert handling for hypershift SilenceAlerts

### DIFF
--- a/pkg/investigations/investigation.go
+++ b/pkg/investigations/investigation.go
@@ -71,6 +71,8 @@ const (
 	ClusterHasGoneMissing
 	// ClusterProvisioningDelay represents the alert type ClusterProvisioningDelay
 	ClusterProvisioningDelay
+	// SilenceAlerts represents the alert type SilenceAlerts
+	SilenceAlerts
 )
 
 func (a AlertType) String() (string, error) {
@@ -79,6 +81,8 @@ func (a AlertType) String() (string, error) {
 		return "ClusterHasGoneMissing", nil
 	case ClusterProvisioningDelay:
 		return "ClusterProvisioningDelay", nil
+	case SilenceAlerts:
+		return "SilenceAlerts", nil
 	}
 	return "", fmt.Errorf("missing implementation: .String() needs to be implemented for alert type '%d'", a)
 }

--- a/pkg/investigations/silencealerts/silencealerts.go
+++ b/pkg/investigations/silencealerts/silencealerts.go
@@ -1,0 +1,11 @@
+// Package silencealerts contains functionality to silence alerts based on a cluster id
+package silencealerts
+
+import (
+	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
+)
+
+// ResolveClusterAlerts resolves all alerts for cluster
+func ResolveClusterAlerts(clusterID string, pdClient pagerduty.Client) error {
+	return pdClient.ResolveAlertsForCluster(clusterID)
+}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RawLogger is the raw global logger object used for calls wrapped by the logging package
-var RawLogger = InitLogger("debug", "")
+var RawLogger = InitLogger("info", "")
 
 // InitLogger initializes a cluster-id specific child logger
 func InitLogger(logLevelString string, clusterID string) *zap.SugaredLogger {

--- a/pkg/networkverifier/networkverifier.go
+++ b/pkg/networkverifier/networkverifier.go
@@ -88,7 +88,7 @@ func initializeValidateEgressInput(cluster *v1.Cluster, clusterDeployment *hivev
 }
 
 // Run runs the network verifier tool to check for network misconfigurations
-func Run(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsClient aws.Client) (result VerifierResult, failures string, name error) { // TODO
+func Run(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsClient aws.Client) (result VerifierResult, failures string, name error) {
 	validateEgressInput, err := initializeValidateEgressInput(cluster, clusterDeployment, awsClient)
 	if err != nil {
 		return Undefined, "", fmt.Errorf("failed to initialize validateEgressInput: %w", err)

--- a/pkg/pagerduty/mock/pagerdutymock.go
+++ b/pkg/pagerduty/mock/pagerdutymock.go
@@ -104,6 +104,20 @@ func (mr *MockClientMockRecorder) GetServiceID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceID", reflect.TypeOf((*MockClient)(nil).GetServiceID))
 }
 
+// ResolveAlertsForCluster mocks base method.
+func (m *MockClient) ResolveAlertsForCluster(clusterID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveAlertsForCluster", clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResolveAlertsForCluster indicates an expected call of ResolveAlertsForCluster.
+func (mr *MockClientMockRecorder) ResolveAlertsForCluster(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAlertsForCluster", reflect.TypeOf((*MockClient)(nil).ResolveAlertsForCluster), clusterID)
+}
+
 // SilenceAlertWithNote mocks base method.
 func (m *MockClient) SilenceAlertWithNote(notes string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What?**
Implement [OSD-17456](https://issues.redhat.com//browse/OSD-17456).

CAD can now handle SilenceAlerts (hypershift inhibition alerts). It will resolve all old alerts when a SilenceAlert is triggered.

The next steps would be to add orchestration rules to all hypershift pd services that route only the SilenceAlerts to CAD.

**Why?**

We use alert inhibition as silencing method for hypershift. The issue with this is that inhibiting alerts does not result in active alerts being resolved. This is very frustrating e.g. when starting to work on an alert but the cluster ends up being mid uninstallation.