### PR TITLE
Add template for pushgateway deployment

### DIFF
--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -27,6 +27,9 @@ spec:
           EOF
           # run the cadctl command
           PIPELINE_NAME=$(params.pipeline-name) cadctl investigate --payload-path $file
+      env:
+        - name: CAD_PROMETHEUS_GATEWAY
+          value: aggregation-pushgateway:9091
       # envFrom should pull all the secret information as envvars, so key names should be uppercase
       envFrom:
         - secretRef:

--- a/openshift/gateway-template.yaml
+++ b/openshift/gateway-template.yaml
@@ -8,10 +8,7 @@ parameters:
   value: v0.7.0
 
 - name: REGISTRY_IMG
-  value: zapier/prom-aggregation-gateway
-
-- name: IMAGE_REPOSITORY
-  value: ghcr.io
+  value: quay.io/app-sre/prom-aggregation-gateway
 
 - name: MEMORY_REQUEST
   description: Memory request for the API pods.
@@ -73,7 +70,7 @@ objects:
       spec:
         containers:
           - name: aggregation-pushgateway
-            image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
+            image: ${REGISTRY_IMG}:${IMAGE_TAG}
             securityContext: 
               allowPrivilegeEscalation: false
               runAsNonRoot: true
@@ -85,7 +82,6 @@ objects:
             env:
               - name: PAG_APILISTEN
                 value: :9091
-                # Do we need 9092 for the health checks?
               - name: PAG_LIFECYCLELISTEN
                 value: :9092
             resources:

--- a/openshift/gateway-template.yaml
+++ b/openshift/gateway-template.yaml
@@ -1,0 +1,118 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: configuration-anomaly-detection-gateway-template
+parameters:
+
+- name: IMAGE_TAG
+  value: v0.7.0
+
+- name: REGISTRY_IMG
+  value: zapier/prom-aggregation-gateway
+
+- name: IMAGE_REPOSITORY
+  value: ghcr.io
+
+- name: MEMORY_REQUEST
+  description: Memory request for the API pods.
+  value: "512Mi"
+
+- name: MEMORY_LIMIT
+  description: Memory limit for the API pods.
+  value: "1Gi"
+
+- name: CPU_REQUEST
+  description: CPU request for the API pods.
+  value: "200m"
+
+- name: CPU_LIMIT
+  description: CPU limit for the API pods.
+  value: "1"
+
+objects:
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: aggregation-pushgateway
+    labels:
+      app: aggregation-pushgateway
+      port: metrics
+    annotations:
+      description: Exposes and load balances the aggregation-pushgateway pods
+  spec:
+    selector:
+      app: aggregation-pushgateway
+    ports:
+    - name: metrics
+      port: 9091
+      targetPort: 9091
+      protocol: TCP
+- kind: Deployment
+  apiVersion: apps/v1
+  metadata:
+    name: aggregation-pushgateway
+    labels:
+      app: aggregation-pushgateway
+  spec:
+    selector:
+      matchLabels:
+        app: aggregation-pushgateway
+    replicas: 1
+    strategy:
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
+    template:
+      metadata:
+        labels:
+          app: aggregation-pushgateway
+      spec:
+        containers:
+          - name: aggregation-pushgateway
+            image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
+            securityContext: 
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: PAG_APILISTEN
+                value: :9091
+                # Do we need 9092 for the health checks?
+              - name: PAG_LIFECYCLELISTEN
+                value: :9092
+            resources:
+              requests:
+                cpu: ${CPU_REQUEST}
+                memory: ${MEMORY_REQUEST}
+              limits:
+                cpu: ${CPU_LIMIT}
+                memory: ${MEMORY_LIMIT}
+            ports:
+            - name: metrics
+              protocol: TCP
+              containerPort: 9091
+            - name: lifecycle
+              protocol: TCP
+              containerPort: 9092
+            livenessProbe:
+              httpGet:
+                path: /healthy
+                port: 9092
+                scheme: HTTP
+              initialDelaySeconds: 15
+              periodSeconds: 5
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 9092
+                scheme: HTTP
+              initialDelaySeconds: 20
+              periodSeconds: 10

--- a/openshift/gateway-template.yaml
+++ b/openshift/gateway-template.yaml
@@ -54,7 +54,7 @@ objects:
     selector:
       matchLabels:
         app: aggregation-pushgateway
-    replicas: 1
+    replicas: 2
     strategy:
     rollingParams:
       intervalSeconds: 1

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -187,6 +187,9 @@ objects:
       command:
       - /bin/bash
       - -c
+      env:
+      - name: CAD_PROMETHEUS_GATEWAY
+        value: aggregation-pushgateway:9091
       envFrom:
       - secretRef:
           name: cad-aws-credentials


### PR DESCRIPTION
This adds a new template for deploying an aggregation pushgateway
It will allow for the metrics to get pushed to this gateway and subsequently scraped by app-sre's prometheus.

The template should get added to our cad-saas file in app interface and use the mirrored aggregation-pushgateway image on quay. ( See corresponding app-interface change )