### PR TITLE
fix: logging of unsupported cloud provider

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -281,6 +281,6 @@ func checkCloudProviderSupported(cluster *v1.Cluster, supportedProviders []strin
 		}
 	}
 
-	logging.Infof("Unsupported cloud provider: %s", cloudProvider)
+	logging.Infof("Unsupported cloud provider: %s", cloudProvider.ID())
 	return false, nil
 }


### PR DESCRIPTION
**What?**
Log the string variant of the `cloudProvider` instead of the struct.

**Why?**
```
{"level":"info","timestamp":"2023-08-17T05:45:32Z","msg":"Unsupported cloud provider: &{%!s(uint32=7) gcp /api/clusters_mgmt/v1/cloud_providers/gcp  }"
```