### PR TITLE
hotfix: metric panic and labels

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -85,7 +85,11 @@ func run(_ *cobra.Command, _ []string) error {
 
 	alertType := isAlertSupported(pdClient.GetTitle())
 	alertTypeString := alertType.String()
-	metrics.Alerts.WithLabelValues(alertTypeString, pdClient.GetEventType()).Inc()
+	metric, err := metrics.Alerts.GetMetricWithLabelValues(alertTypeString, pdClient.GetEventType())
+	if err != nil {
+		logging.Error(err)
+	}
+	metric.Inc()
 
 	// handle unsupported alerts
 	if alertType == investigation.Unsupported {

--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -85,11 +85,7 @@ func run(_ *cobra.Command, _ []string) error {
 
 	alertType := isAlertSupported(pdClient.GetTitle())
 	alertTypeString := alertType.String()
-	metric, err := metrics.Alerts.GetMetricWithLabelValues(alertTypeString, pdClient.GetEventType())
-	if err != nil {
-		logging.Error(err)
-	}
-	metric.Inc()
+	metrics.Inc(metrics.Alerts, alertTypeString, pdClient.GetEventType())
 
 	// handle unsupported alerts
 	if alertType == investigation.Unsupported {

--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -58,7 +58,11 @@ func Evaluate(cluster *v1.Cluster, awsError error, ocmClient ocm.Client, pdClien
 	switch cluster.State() {
 	case v1.ClusterStateReady:
 		// Cluster is in functional sate but we can't jumprole to it: post limited support
-		metrics.LimitedSupportSet.WithLabelValues(alertType, pdClient.GetEventType(), ccamLimitedSupport.Summary).Inc()
+		metric, err := metrics.LimitedSupportSet.GetMetricWithLabelValues(alertType, pdClient.GetEventType(), ccamLimitedSupport.Summary)
+		if err != nil {
+			logging.Error(err)
+		}
+		metric.Inc()
 		err = ocmClient.PostLimitedSupportReason(ccamLimitedSupport, cluster.ID())
 		if err != nil {
 			return fmt.Errorf("could not post limited support reason for %s: %w", cluster.Name(), err)
@@ -99,7 +103,11 @@ func RemoveLimitedSupport(cluster *v1.Cluster, ocmClient ocm.Client, pdClient pa
 		return nil
 	}
 	if removedReason {
-		metrics.LimitedSupportLifted.WithLabelValues(alertType, pdClient.GetEventType(), ccamLimitedSupport.Summary).Inc()
+		metric, err := metrics.LimitedSupportLifted.GetMetricWithLabelValues(alertType, pdClient.GetEventType(), ccamLimitedSupport.Summary)
+		if err != nil {
+			logging.Error(err)
+		}
+		metric.Inc()
 	}
 	return nil
 }

--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -58,11 +58,7 @@ func Evaluate(cluster *v1.Cluster, awsError error, ocmClient ocm.Client, pdClien
 	switch cluster.State() {
 	case v1.ClusterStateReady:
 		// Cluster is in functional sate but we can't jumprole to it: post limited support
-		metric, err := metrics.LimitedSupportSet.GetMetricWithLabelValues(alertType, pdClient.GetEventType(), ccamLimitedSupport.Summary)
-		if err != nil {
-			logging.Error(err)
-		}
-		metric.Inc()
+		metrics.Inc(metrics.LimitedSupportSet, alertType, pdClient.GetEventType(), ccamLimitedSupport.Summary)
 		err = ocmClient.PostLimitedSupportReason(ccamLimitedSupport, cluster.ID())
 		if err != nil {
 			return fmt.Errorf("could not post limited support reason for %s: %w", cluster.Name(), err)
@@ -103,11 +99,7 @@ func RemoveLimitedSupport(cluster *v1.Cluster, ocmClient ocm.Client, pdClient pa
 		return nil
 	}
 	if removedReason {
-		metric, err := metrics.LimitedSupportLifted.GetMetricWithLabelValues(alertType, pdClient.GetEventType(), ccamLimitedSupport.Summary)
-		if err != nil {
-			logging.Error(err)
-		}
-		metric.Inc()
+		metrics.Inc(metrics.LimitedSupportLifted, alertType, pdClient.GetEventType(), ccamLimitedSupport.Summary)
 	}
 	return nil
 }

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -90,11 +90,7 @@ func InvestigateTriggered(r *investigation.Resources) error {
 	// The node shutdown was the customer
 	// Put into limited support, silence and update incident notes
 	return utils.WithRetries(func() error {
-		metric, err := metrics.LimitedSupportSet.GetMetricWithLabelValues(r.AlertType.String(), r.PdClient.GetEventType(), chgmLimitedSupport.Summary)
-		if err != nil {
-			logging.Error(err)
-		}
-		metric.Inc()
+		metrics.Inc(metrics.LimitedSupportSet, r.AlertType.String(), r.PdClient.GetEventType(), chgmLimitedSupport.Summary)
 		return postLimitedSupport(r.Cluster.ID(), res.string(), r.OcmClient, r.PdClient)
 	})
 }
@@ -185,11 +181,7 @@ func InvestigateResolved(r *investigation.Resources) error {
 		return nil
 	}
 	if removedReasons {
-		metric, err := metrics.LimitedSupportLifted.GetMetricWithLabelValues(r.AlertType.String(), r.PdClient.GetEventType(), chgmLimitedSupport.Summary)
-		if err != nil {
-			logging.Error(err)
-		}
-		metric.Inc()
+		metrics.Inc(metrics.LimitedSupportLifted, r.AlertType.String(), r.PdClient.GetEventType(), chgmLimitedSupport.Summary)
 	}
 	return nil
 }

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -90,7 +90,11 @@ func InvestigateTriggered(r *investigation.Resources) error {
 	// The node shutdown was the customer
 	// Put into limited support, silence and update incident notes
 	return utils.WithRetries(func() error {
-		metrics.LimitedSupportSet.WithLabelValues(r.AlertType.String(), r.PdClient.GetEventType(), chgmLimitedSupport.Summary).Inc()
+		metric, err := metrics.LimitedSupportSet.GetMetricWithLabelValues(r.AlertType.String(), r.PdClient.GetEventType(), chgmLimitedSupport.Summary)
+		if err != nil {
+			logging.Error(err)
+		}
+		metric.Inc()
 		return postLimitedSupport(r.Cluster.ID(), res.string(), r.OcmClient, r.PdClient)
 	})
 }
@@ -181,7 +185,11 @@ func InvestigateResolved(r *investigation.Resources) error {
 		return nil
 	}
 	if removedReasons {
-		metrics.LimitedSupportLifted.WithLabelValues(r.AlertType.String(), r.PdClient.GetEventType(), chgmLimitedSupport.Summary).Inc()
+		metric, err := metrics.LimitedSupportLifted.GetMetricWithLabelValues(r.AlertType.String(), r.PdClient.GetEventType(), chgmLimitedSupport.Summary)
+		if err != nil {
+			logging.Error(err)
+		}
+		metric.Inc()
 	}
 	return nil
 }

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -53,11 +53,7 @@ func InvestigateTriggered(r *investigation.Resources) error {
 				logging.Error(err)
 			}
 			if !isValid {
-				metric, err := metrics.ServicelogPrepared.GetMetricWithLabelValues(r.AlertType.String(), r.PdClient.GetEventType())
-				if err != nil {
-					logging.Error(err)
-				}
-				metric.Inc()
+				metrics.Inc(metrics.ServicelogPrepared, r.AlertType.String(), r.PdClient.GetEventType())
 				notesSb.WriteString(fmt.Sprintf("⚠️ subnet %s does not have a default route to 0.0.0.0/0\nRun the following to send the according ServiceLog:\nosdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_NoRouteToInternet.json\n", subnet, r.Cluster.ID()))
 				err = r.PdClient.AddNote(notesSb.String())
 				if err != nil {
@@ -84,11 +80,7 @@ func InvestigateTriggered(r *investigation.Resources) error {
 	switch verifierResult {
 	case networkverifier.Failure:
 		logging.Infof("Network verifier reported failure: %s", failureReason)
-		metric, err := metrics.ServicelogPrepared.GetMetricWithLabelValues(r.AlertType.String(), r.PdClient.GetEventType())
-		if err != nil {
-			logging.Error(err)
-		}
-		metric.Inc()
+		metrics.Inc(metrics.ServicelogPrepared, r.AlertType.String(), r.PdClient.GetEventType())
 		notesSb.WriteString(fmt.Sprintf("⚠️ Network verifier found issues:\n %s \n\n Verify and send service log if necessary: \n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=%s\n", failureReason, r.Cluster.ID(), failureReason))
 
 		// In the future, we want to send a service log in this case

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -28,6 +28,15 @@ func Push() {
 	}
 }
 
+// Inc takes a counterVec and a set of label values and increases by one
+func Inc(counterVec *prometheus.CounterVec, lsv ...string) {
+	metric, err := counterVec.GetMetricWithLabelValues(lsv...)
+	if err != nil {
+		logging.Error(err)
+	}
+	metric.Inc()
+}
+
 const (
 	namespace            = "cad"
 	subsystemInvestigate = "investigate"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -64,5 +64,5 @@ var (
 			Namespace: namespace, Subsystem: subsystemInvestigate,
 			Name: "servicelog_prepared_total",
 			Help: "counts investigations resulting in a prepared servicelog attached to the incident notes",
-		}, []string{alertTypeLabel, eventTypeLabel, lsSummaryLabel})
+		}, []string{alertTypeLabel, eventTypeLabel})
 )


### PR DESCRIPTION
Switch WithLabelValues to GetMetricWithLabelValues to avoid panics

Remove wrongly copy pasted label list on servicelogPerpared metric