### PR TITLE
fix: check if alert is supported before decoding cluster_id

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -73,14 +73,6 @@ func run(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not initialize pagerduty client: %w", err)
 	}
 
-	// clusterID can end up being either be the internal or external ID.
-	// We don't really care, as we only use this to initialize the cluster object,
-	// which will contain both IDs.
-	clusterID, err := pdClient.RetrieveClusterID()
-	if err != nil {
-		return err
-	}
-
 	logging.Infof("Incident link: %s", pdClient.GetIncidentRef())
 
 	alertType := isAlertSupported(pdClient.GetTitle())
@@ -94,6 +86,14 @@ func run(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("Could not escalate unsupported alert: %w", err)
 		}
 		return nil
+	}
+
+	// clusterID can end up being either be the internal or external ID.
+	// We don't really care, as we only use this to initialize the cluster object,
+	// which will contain both IDs.
+	clusterID, err := pdClient.RetrieveClusterID()
+	if err != nil {
+		return err
 	}
 
 	ocmClient, err := GetOCMClient()


### PR DESCRIPTION
**What?**
- Moves logic to decode `cluster_id` after checking if the alert is supported by CAD. 

**Why?**
Some unsupported alerts don't contain the `cluster_id`, e.g. the AVO alerts on the `app-sre-alertmanager` service. This causes CAD pipelines to exit ungracefully. 
Therefore, we need to move the logic to decode the cluster_id after the check if an alert is supported.