### PR TITLE
use dependabot to automatically update osd-network-verifier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'gomod'
+    directory: '/'
+    allow:
+      - dependency-name: "github.com/openshift/osd-network-verifier"
+    schedule:
+      interval: 'daily'

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 *.out
 .docker
 .envrc
+.idea


### PR DESCRIPTION
This would allow a PR to be created automatically in this repo whenever osd-network-verifier has a new version