### PR TITLE
[OSD-18424] Add new check if cluster recently woke up.

### DIFF
--- a/pkg/investigations/chgm/chgm_hibernation_check.go
+++ b/pkg/investigations/chgm/chgm_hibernation_check.go
@@ -1,0 +1,89 @@
+package chgm
+
+import (
+	"sort"
+	"time"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	servicelogsv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+)
+
+const recentWakeupTime = 2 * time.Hour
+
+// 30 Days is always a problem as kubelet certificates will be expired
+const hibernationTooLong = 30 * 24 * time.Hour
+
+const (
+	hibernationStartEvent = "cluster_state_hibernating"
+	hibernationEndEvent   = "cluster_state_ready"
+)
+
+// const hibernationOngoingEvent = "cluster_state_hibernating"
+// const hibernationResumeEvent = "cluster_state_resuming"
+
+type hibernationPeriod struct {
+	HibernationDuration time.Duration
+	DehibernationTime   time.Time
+}
+
+func hibernatedTooLong(hibernations []*hibernationPeriod, now time.Time) bool {
+	if len(hibernations) == 0 {
+		return false
+	}
+	latestHibernation := hibernations[len(hibernations)-1]
+	// The cluster was woken up within the RECENT_WAKEUP_TIME which might
+	// indicate a CSR problem.
+	if now.Sub(latestHibernation.DehibernationTime) >= recentWakeupTime {
+		return false
+	}
+	// Only clusters that have hibernated for a long time are susceptible to
+	// have cert issues.
+	if latestHibernation.HibernationDuration >= hibernationTooLong {
+		return true
+	}
+	return false
+}
+
+func getHibernationStatusForCluster(ocmClient ocm.Client, cluster *v1.Cluster) ([]*hibernationPeriod, error) {
+	filter := "log_type='cluster-state-updates'"
+	clusterStateUpdates, err := ocmClient.GetServiceLog(cluster, filter)
+	if err != nil {
+		return nil, err
+	}
+	return createHibernationTimeLine(clusterStateUpdates.Items().Slice()), nil
+}
+
+func createHibernationTimeLine(clusterStateUpdates []*servicelogsv1.LogEntry) []*hibernationPeriod {
+	var hibernations []*hibernationPeriod
+
+	var hibernationStartTime time.Time
+	var hibernationEndTime time.Time
+	sort.SliceStable(clusterStateUpdates, func(i, j int) bool {
+		return clusterStateUpdates[i].Timestamp().Before(clusterStateUpdates[j].Timestamp())
+	})
+	for _, stateUpdate := range clusterStateUpdates {
+		event := stateUpdate.Summary()
+		date := stateUpdate.Timestamp()
+		if event == hibernationStartEvent {
+			hibernationStartTime = date
+		}
+		if event == hibernationEndEvent {
+			if (hibernationStartTime == time.Time{}) {
+				// Cluster became ready after installation
+				continue
+			}
+			hibernationEndTime = date
+			hibernation := &hibernationPeriod{
+				DehibernationTime:   hibernationEndTime,
+				HibernationDuration: hibernationEndTime.Sub(hibernationStartTime),
+			}
+			hibernations = append(hibernations, hibernation)
+		}
+	}
+	// Would be an ongoing hibernation
+	// if (hibernationStartTime != time.Time{} && hibernationEndTime == time.Time{}) {
+	// 	hibernations = append(hibernations, &HibernationPeriod{})
+	// }
+	return hibernations
+}

--- a/pkg/investigations/chgm/chgm_hibernation_check_test.go
+++ b/pkg/investigations/chgm/chgm_hibernation_check_test.go
@@ -1,0 +1,128 @@
+package chgm
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	servicelogsv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
+)
+
+func TestCreateHibernationTimeLine(t *testing.T) {
+	type args struct {
+		clusterStateUpdates []*servicelogsv1.LogEntry
+	}
+	hibernationStartTime := time.Date(2023, 0o1, 0o1, 0o0, 0o0, 0o0, 0o0, time.Local)
+	hibernationStopTime := time.Date(2023, 0o2, 0o1, 0o0, 0o0, 0o0, 0o0, time.Local)
+	hibernationStart, _ := servicelogsv1.NewLogEntry().Timestamp(hibernationStartTime).Summary(hibernationStartEvent).Build()
+	hibernationEnd, _ := servicelogsv1.NewLogEntry().Timestamp(hibernationStopTime).Summary(hibernationEndEvent).Build()
+	var emptyHibernationSlice []*hibernationPeriod
+	tests := []struct {
+		name string
+		args args
+		want []*hibernationPeriod
+	}{
+		{
+			name: "Hibernation with start and end",
+			args: args{
+				clusterStateUpdates: []*servicelogsv1.LogEntry{
+					hibernationStart,
+					hibernationEnd,
+				},
+			},
+			want: []*hibernationPeriod{
+				{
+					HibernationDuration: hibernationStopTime.Sub(hibernationStartTime),
+					DehibernationTime:   hibernationStopTime,
+				},
+			},
+		},
+		{
+			name: "Hibernation without end is not part of the return",
+			args: args{
+				clusterStateUpdates: []*servicelogsv1.LogEntry{
+					hibernationStart,
+				},
+			},
+			want: emptyHibernationSlice,
+		},
+		{
+			name: "Hibernation without start is not part of the return",
+			args: args{
+				clusterStateUpdates: []*servicelogsv1.LogEntry{
+					hibernationEnd,
+				},
+			},
+			want: emptyHibernationSlice,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := createHibernationTimeLine(tt.args.clusterStateUpdates); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateHibernationTimeLine() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHibernatedTooLong(t *testing.T) {
+	type args struct {
+		hibernations []*hibernationPeriod
+		now          time.Time
+	}
+	hibernationStartTime := time.Date(2023, 0o1, 0o1, 0o0, 0o0, 0o0, 0o0, time.Local)
+	hibernationShortStopTime := time.Date(2023, 0o1, 11, 0o0, 0o0, 0o0, 0o0, time.Local)
+	hibernationLongStopTime := time.Date(2023, 0o2, 11, 0o0, 0o0, 0o0, 0o0, time.Local)
+	shortHibernation := &hibernationPeriod{
+		HibernationDuration: hibernationShortStopTime.Sub(hibernationStartTime),
+		DehibernationTime:   hibernationShortStopTime,
+	}
+	longHibernation := &hibernationPeriod{
+		HibernationDuration: hibernationLongStopTime.Sub(hibernationStartTime),
+		DehibernationTime:   hibernationLongStopTime,
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "Cluster that hibernated for 10 days is ok",
+			args: args{
+				hibernations: []*hibernationPeriod{shortHibernation},
+				now:          hibernationShortStopTime.Add(1 * time.Hour),
+			},
+			want: false,
+		},
+		{
+			name: "Cluster that hibernated for 30+ days is too long",
+			args: args{
+				hibernations: []*hibernationPeriod{longHibernation},
+				now:          hibernationLongStopTime.Add(1 * time.Hour),
+			},
+			want: true,
+		},
+		{
+			name: "Cluster that never hibernated is ok",
+			args: args{},
+			want: false,
+		},
+		{
+			name: "Cluster that woke up for 2+ hours ago ok",
+			args: args{
+				hibernations: []*hibernationPeriod{longHibernation},
+				now:          hibernationLongStopTime.Add(3 * time.Hour),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hibernatedTooLong(tt.args.hibernations, tt.args.now)
+			if got != tt.want {
+				t.Errorf("HibernatedTooLong() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/investigations/chgm/chgm_test.go
+++ b/pkg/investigations/chgm/chgm_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	servicelogsv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	awsmock "github.com/openshift/configuration-anomaly-detection/pkg/aws/mock"
 	investigation "github.com/openshift/configuration-anomaly-detection/pkg/investigations"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/chgm"
@@ -111,6 +112,7 @@ var _ = Describe("chgm", func() {
 				r.PdClient.(*pdmock.MockClient).EXPECT().GetEventType().Return("triggered")
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any())
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 
@@ -137,6 +139,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 				gotErr := chgm.InvestigateTriggered(r)
 				// Assert
 				Expect(gotErr).ToNot(HaveOccurred())
@@ -180,6 +183,7 @@ var _ = Describe("chgm", func() {
 				r.PdClient.(*pdmock.MockClient).EXPECT().GetEventType().Return("triggered")
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				// Act
 				gotErr := chgm.InvestigateTriggered(r)
@@ -200,6 +204,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -217,6 +222,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -238,6 +244,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Any(), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -256,6 +263,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -273,6 +281,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -290,6 +299,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -307,6 +317,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -324,6 +335,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -341,6 +353,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -358,6 +371,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().AddNote(gomock.Any()).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -374,6 +388,7 @@ var _ = Describe("chgm", func() {
 				r.PdClient.(*pdmock.MockClient).EXPECT().GetEventType().Return("triggered")
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -390,6 +405,7 @@ var _ = Describe("chgm", func() {
 				r.PdClient.(*pdmock.MockClient).EXPECT().GetEventType().Return("triggered")
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -406,6 +422,7 @@ var _ = Describe("chgm", func() {
 				r.PdClient.(*pdmock.MockClient).EXPECT().GetEventType().Return("triggered")
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -421,6 +438,7 @@ var _ = Describe("chgm", func() {
 				r.PdClient.(*pdmock.MockClient).EXPECT().GetEventType().Return("triggered")
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -438,6 +456,7 @@ var _ = Describe("chgm", func() {
 				r.PdClient.(*pdmock.MockClient).EXPECT().GetEventType().Return("triggered")
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -455,6 +474,7 @@ var _ = Describe("chgm", func() {
 				r.PdClient.(*pdmock.MockClient).EXPECT().GetEventType().Return("triggered")
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostLimitedSupportReason(gomock.Eq(chgmLimitedSupport), gomock.Eq(cluster.ID())).Return(nil)
 				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := chgm.InvestigateTriggered(r)
 				Expect(gotErr).NotTo(HaveOccurred())

--- a/pkg/ocm/mock/ocmmock.go
+++ b/pkg/ocm/mock/ocmmock.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	v10 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	ocm "github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 )
 
@@ -63,6 +64,21 @@ func (m *MockClient) GetClusterMachinePools(internalClusterID string) ([]*v1.Mac
 func (mr *MockClientMockRecorder) GetClusterMachinePools(internalClusterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMachinePools", reflect.TypeOf((*MockClient)(nil).GetClusterMachinePools), internalClusterID)
+}
+
+// GetServiceLog mocks base method.
+func (m *MockClient) GetServiceLog(cluster *v1.Cluster, filter string) (*v10.ClusterLogsUUIDListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceLog", cluster, filter)
+	ret0, _ := ret[0].(*v10.ClusterLogsUUIDListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetServiceLog indicates an expected call of GetServiceLog.
+func (mr *MockClientMockRecorder) GetServiceLog(cluster, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLog", reflect.TypeOf((*MockClient)(nil).GetServiceLog), cluster, filter)
 }
 
 // GetSupportRoleARN mocks base method.

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -46,6 +46,7 @@ type Client interface {
 	LimitedSupportReasonExists(ls LimitedSupportReason, internalClusterID string) (bool, error)
 	DeleteLimitedSupportReasons(ls LimitedSupportReason, internalClusterID string) (bool, error)
 	GetSupportRoleARN(internalClusterID string) (string, error)
+	GetServiceLog(cluster *v1.Cluster, filter string) (*servicelogsv1.ClusterLogsUUIDListResponse, error)
 	PostServiceLog(cluster *v1.Cluster, sl *ServiceLog) error
 }
 
@@ -222,6 +223,15 @@ func (c *SdkClient) PostLimitedSupportReason(limitedSupportReason LimitedSupport
 	}
 
 	return nil
+}
+
+// GetServiceLog returns all ServiceLogs for a cluster.
+// When supplying a filter it will use the Search call and pass it to this one directly.
+func (c *SdkClient) GetServiceLog(cluster *v1.Cluster, filter string) (*servicelogsv1.ClusterLogsUUIDListResponse, error) {
+	if filter != "" {
+		return c.conn.ServiceLogs().V1().Clusters().Cluster(cluster.ExternalID()).ClusterLogs().List().Search(filter).Send()
+	}
+	return c.conn.ServiceLogs().V1().Clusters().Cluster(cluster.ExternalID()).ClusterLogs().List().Send()
 }
 
 // PostServiceLog allows to send a generic servicelog to a cluster.


### PR DESCRIPTION
When clusters are in hibernation for >= 30 days the internal certificates used by kubelet will have expired and CSRs must be approved by hand to get the cluster into a healthy state again.