### PR TITLE
Specify service account with quay.io pullsecret

### DIFF
--- a/openshift/gateway-template.yaml
+++ b/openshift/gateway-template.yaml
@@ -8,7 +8,7 @@ parameters:
   value: v0.7.0
 
 - name: REGISTRY_IMG
-  value: quay.io/app-sre/prom-aggregation-gateway
+  value: quay.io/app-sre/aggregation-gateway
 
 - name: MEMORY_REQUEST
   description: Memory request for the API pods.
@@ -68,6 +68,7 @@ objects:
         labels:
           app: aggregation-pushgateway
       spec:
+        serviceAccountName: pushgateway
         containers:
           - name: aggregation-pushgateway
             image: ${REGISTRY_IMG}:${IMAGE_TAG}


### PR DESCRIPTION
The pushgateway image is mirrored in a private repository so we need a pullsecret to be able to pull the image.

This specifies that the deployment uses the serviceaccount 'pushgateway' defined in app-interface.

Also fixes the default parameter for the image path but that has no effect as we overwrite in our saas file currently.