### PR TITLE
feat(OSD-18650): [stopgap] support alerts from clusters with new backplane flow

### DIFF
--- a/pkg/ocm/mock/ocmmock.go
+++ b/pkg/ocm/mock/ocmmock.go
@@ -36,6 +36,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// AwsClassicJumpRoleCompatible mocks base method.
+func (m *MockClient) AwsClassicJumpRoleCompatible(clusterID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AwsClassicJumpRoleCompatible", clusterID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AwsClassicJumpRoleCompatible indicates an expected call of AwsClassicJumpRoleCompatible.
+func (mr *MockClientMockRecorder) AwsClassicJumpRoleCompatible(clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwsClassicJumpRoleCompatible", reflect.TypeOf((*MockClient)(nil).AwsClassicJumpRoleCompatible), clusterID)
+}
+
 // DeleteLimitedSupportReasons mocks base method.
 func (m *MockClient) DeleteLimitedSupportReasons(ls ocm.LimitedSupportReason, internalClusterID string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -387,7 +387,7 @@ func (c *SdkClient) AddNote(noteContent string) error {
 
 // AddNoteToIncident will add a note to an incident
 func (c *SdkClient) AddNoteToIncident(incidentID string, noteContent string) error {
-	logging.Info("Attaching Note...")
+	logging.Infof("Attaching Note: %s", noteContent)
 	sdkNote := sdk.IncidentNote{
 		Content: noteContent,
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-18650

**What?**
- this adds a check in CAD for clusters using the new flow and escalates them if the clusters aren't in limited support

**Why?**
- new AWS backplane flow will be promoted to production this week or the following, we do not support this flow so we must make sure that we don't accidentally put clusters in limited support due to missing access