### PR TITLE
dashboard: remove id to fix deployment

### DIFF
--- a/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
+++ b/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
@@ -34,7 +34,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 622044,
+      "id": null,
       "links": [],
       "liveNow": false,
       "panels": [


### PR DESCRIPTION
The dashboard does not get deployed. I think we need to remove the id for grafana to load it properly.