### PR TITLE
dashboard: fix title and uid

### DIFF
--- a/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
+++ b/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
@@ -502,8 +502,8 @@ data:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "Configuration-Anomaly-Detection-SLOsv2",
-      "uid": "2k6bSMj7t",
+      "title": "Configuration-Anomaly-Detection-SLOs",
+      "uid": "2k6bSMj7k",
       "version": 11,
       "weekStart": ""
     }


### PR DESCRIPTION
Fix wrong title and uid from grafana playground.
Sorry for the noise.