### PR TITLE
fix(OSD-19596): skip aws access compatibility check for non-sts clusters

### DIFF
--- a/pkg/ocm/mock/ocmmock.go
+++ b/pkg/ocm/mock/ocmmock.go
@@ -37,18 +37,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AwsClassicJumpRoleCompatible mocks base method.
-func (m *MockClient) AwsClassicJumpRoleCompatible(clusterID string) (bool, error) {
+func (m *MockClient) AwsClassicJumpRoleCompatible(cluster *v1.Cluster) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AwsClassicJumpRoleCompatible", clusterID)
+	ret := m.ctrl.Call(m, "AwsClassicJumpRoleCompatible", cluster)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AwsClassicJumpRoleCompatible indicates an expected call of AwsClassicJumpRoleCompatible.
-func (mr *MockClientMockRecorder) AwsClassicJumpRoleCompatible(clusterID interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) AwsClassicJumpRoleCompatible(cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwsClassicJumpRoleCompatible", reflect.TypeOf((*MockClient)(nil).AwsClassicJumpRoleCompatible), clusterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwsClassicJumpRoleCompatible", reflect.TypeOf((*MockClient)(nil).AwsClassicJumpRoleCompatible), cluster)
 }
 
 // DeleteLimitedSupportReasons mocks base method.


### PR DESCRIPTION
**What?**
- Skip the CAD aws access compatibility check for non sts clusters (this was causing pipeline failures, as non-sts clusters have no sts support role).
- Reorders the logic if an investigation should be started on a cluster. The previous logic was getting too complicated with the additional STS logic, so I split it up which causes code duplication but is easier to read.

**Why?**

```
could not query sts support role from ocm: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is '123456': Retrieving SRE support role arn is only available for AWS STS clusters only
```