### PR TITLE
Add base image to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       - dependency-name: "github.com/openshift/osd-network-verifier"
     schedule:
       interval: 'daily'
+  - package-ecosystem: "docker"
+    directory: "/"
+    ignore:
+      # Only update runners base image not builder
+      - dependency-name: "registry.ci.openshift.org/openshift/release"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Recude toil and time to update the base image

I excluded the builder image due to the golang version being pinned.