### PR TITLE
OSD-22320: Update SL severities to match OCM guidelines

### DIFF
--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -22,7 +22,7 @@ import (
 )
 
 var chgmSL = ocm.ServiceLog{
-	Severity:     "Error",
+	Severity:     "Critical",
 	Summary:      "Action required: cluster not checking in",
 	ServiceName:  "SREManualAction",
 	Description:  "Your cluster is no longer checking in with Red Hat OpenShift Cluster Manager. Possible causes include stopped instances or a networking misconfiguration. If you have stopped the cluster instances, please start them again - stopping instances is not supported. If you intended to terminate this cluster then please delete the cluster in the Red Hat console",
@@ -30,7 +30,7 @@ var chgmSL = ocm.ServiceLog{
 }
 
 var egressSL = ocm.ServiceLog{
-	Severity:     "Error",
+	Severity:     "Critical",
 	Summary:      "Action required: Network misconfiguration",
 	ServiceName:  "SREManualAction",
 	Description:  "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites. Please revert changes.",

--- a/pkg/investigations/chgm/chgm_test.go
+++ b/pkg/investigations/chgm/chgm_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var chgmSL = &ocm.ServiceLog{
-	Severity:     "Error",
+	Severity:     "Critical",
 	Summary:      "Action required: cluster not checking in",
 	ServiceName:  "SREManualAction",
 	Description:  "Your cluster is no longer checking in with Red Hat OpenShift Cluster Manager. Possible causes include stopped instances or a networking misconfiguration. If you have stopped the cluster instances, please start them again - stopping instances is not supported. If you intended to terminate this cluster then please delete the cluster in the Red Hat console",
@@ -51,8 +51,11 @@ var _ = Describe("chgm", func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 
 		var err error
+
+		region := cmv1.NewCloudRegion().Name("us-east-1")
+
 		// Must explicitly set all node types for GetNodeCount() to work in these tests
-		cluster, err = cmv1.NewCluster().Nodes(cmv1.NewClusterNodes().Compute(0).Master(1).Infra(1)).State(cmv1.ClusterStateReady).Build()
+		cluster, err = cmv1.NewCluster().Nodes(cmv1.NewClusterNodes().Compute(0).Master(1).Infra(1)).State(cmv1.ClusterStateReady).Region(region).Build()
 		Expect(err).ToNot(HaveOccurred())
 		clusterDeployment = &hivev1.ClusterDeployment{
 			Spec: hivev1.ClusterDeploymentSpec{

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -14,7 +14,7 @@ import (
 )
 
 // https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_NoRouteToInternet.json
-var byovpcRoutingSL = &ocm.ServiceLog{Severity: "Error", Summary: "Installation blocked: Missing route to internet", Description: "Your cluster's installation is blocked because of the missing route to internet in the route table(s) associated with the supplied subnet(s) for cluster installation. Please review and validate the routes by following documentation and re-install the cluster: https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc.", InternalOnly: false, ServiceName: "SREManualAction"}
+var byovpcRoutingSL = &ocm.ServiceLog{Severity: "Major", Summary: "Installation blocked: Missing route to internet", Description: "Your cluster's installation is blocked because of the missing route to internet in the route table(s) associated with the supplied subnet(s) for cluster installation. Please review and validate the routes by following documentation and re-install the cluster: https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc.", InternalOnly: false, ServiceName: "SREManualAction"}
 
 // InvestigateTriggered runs the investigation for a triggered CPD pagerduty event
 // Currently what this investigation does is:


### PR DESCRIPTION
**What?**
CAD sends service logs with the "Error" severity, which does not exist. I updated the severities to match the OCM guidelines. 

**Why?**
https://issues.redhat.com/browse/OSD-22320