### PR TITLE
OSD-22496: add scc workaround

### DIFF
--- a/openshift/SRVKP-437-workaround-template.yaml
+++ b/openshift/SRVKP-437-workaround-template.yaml
@@ -1,5 +1,8 @@
 apiVersion: template.openshift.io/v1
 kind: Template
+parameters:
+- name: DEPLOYMENT_NAMESPACE
+  value: configuration-anomaly-detection-production
 metadata:
   name: configuration-anomaly-detection-SRVKP-437-template
 objects:
@@ -25,6 +28,7 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: srvkp-4372
+    namespace: ${DEPLOYMENT_NAMESPACE}
   roleRef:
     kind: ClusterRole
     name: srvkp-4372
@@ -95,5 +99,11 @@ objects:
                 # Current namespace as script can be deployed to different namespaces (prod/stage namespaces differ)
                 namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 
-                echo "Reapplying runtime/default: $seccomp_profile to $scc_name in namespace $namespace"
-                oc patch scc $scc_name -n $namespace --type=json -p '[{"op": "replace", "path": "/seccompProfiles", "value": ["runtime/default"]}]'
+                echo "Checking seccompProfiles to of $scc_name in namespace $namespace"
+                current_seccomp_profiles=$(oc get scc $scc_name -n $namespace -o=jsonpath='{.seccompProfiles}')
+                if [ -z "$current_seccomp_profiles" ]; then
+                  echo "seccompProfiles is empty in SCC $scc_name, applying patch"
+                  oc patch scc $scc_name -n $namespace --type=json -p '[{"op": "add", "path": "/seccompProfiles", "value": ["runtime/default"]}]'
+                else
+                  echo "seccompProfiles is not empty in SCC $scc_name, skipping patch"
+                fi

--- a/openshift/SRVKP-437-workaround-template.yaml
+++ b/openshift/SRVKP-437-workaround-template.yaml
@@ -1,0 +1,101 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: configuration-anomaly-detection-SRVKP-437-template
+objects:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: srvkp-4372
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+    - patch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: srvkp-4372
+  subjects:
+  - kind: ServiceAccount
+    name: srvkp-4372
+    namespace: configuration-anomaly-detection-stage
+  roleRef:
+    kind: ClusterRole
+    name: srvkp-4372
+    apiGroup: rbac.authorization.k8s.io
+- kind: ServiceAccount
+  apiVersion: v1
+  metadata:
+    name: srvkp-4372
+    namespace: configuration-anomaly-detection-stage
+    annotations:
+      kubernetes.io/description: Mitigate https://issues.redhat.com/browse/SRVKP-4372 by manually adding missing permissions to scc
+- apiVersion: batch/v1
+  kind: CronJob
+  metadata:
+    name: srvkp-4372
+  spec:
+    failedJobsHistoryLimit: 2
+    successfulJobsHistoryLimit: 2
+    concurrencyPolicy: Replace
+    schedule: "*/10 * * * *"
+    jobTemplate:
+      spec:
+        ttlSecondsAfterFinished: 3600
+        template:
+          metadata:
+            labels:
+              app: srvkp-4372
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/worker
+                      operator: Exists
+                  weight: 1
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                        - srvkp-4372
+                    topologyKey: kubernetes.io/hostname
+                  weight: 1
+            tolerations:
+              - effect: NoSchedule
+                operator: Exists
+            serviceAccountName: srvkp-4372
+            restartPolicy: Never
+            containers:
+            - name: srvkp-4372
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 100Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              command: ["/bin/sh", "-c"]
+              args:
+              - |
+                scc_name="pipelines-scc"
+
+                # Current namespace as script can be deployed to different namespaces (prod/stage namespaces differ)
+                namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+
+                echo "Reapplying runtime/default: $seccomp_profile to $scc_name in namespace $namespace"
+                oc patch scc $scc_name -n $namespace --type=json -p '[{"op": "replace", "path": "/seccompProfiles", "value": ["runtime/default"]}]'

--- a/openshift/SRVKP-437-workaround-template.yaml
+++ b/openshift/SRVKP-437-workaround-template.yaml
@@ -25,7 +25,6 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: srvkp-4372
-    namespace: configuration-anomaly-detection-stage
   roleRef:
     kind: ClusterRole
     name: srvkp-4372
@@ -34,7 +33,6 @@ objects:
   apiVersion: v1
   metadata:
     name: srvkp-4372
-    namespace: configuration-anomaly-detection-stage
     annotations:
       kubernetes.io/description: Mitigate https://issues.redhat.com/browse/SRVKP-4372 by manually adding missing permissions to scc
 - apiVersion: batch/v1


### PR DESCRIPTION
Adds workaround for pipelines-scc missing the seccompProfile: https://issues.redhat.com/browse/SRVKP-4372 