### PR TITLE
Set resource limits to all containers

### DIFF
--- a/deploy/pipeline-trigger.yaml
+++ b/deploy/pipeline-trigger.yaml
@@ -61,3 +61,16 @@ metadata:
 spec:
   triggers:
   - triggerRef: cad-pipe-listener
+  resources:
+    kubernetesResource:
+      spec:
+        template:
+          spec:
+            containers:
+              - resources:
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
+                  limits:
+                    cpu: 1
+                    memory: 256Mi

--- a/deploy/pipeline-trigger.yaml
+++ b/deploy/pipeline-trigger.yaml
@@ -72,5 +72,5 @@ spec:
                     cpu: 100m
                     memory: 64Mi
                   limits:
-                    cpu: 1
+                    cpu: 500m
                     memory: 256Mi

--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -41,7 +41,9 @@ spec:
         - secretRef:
             name: cad-backplane-secret
       computeResources:
-        # We need QoS class guaranteed as we do not retry these tasksruns
+        requests:
+          cpu: 10m
+          memory: 64Mi
         limits:
-          cpu: 500m
+          cpu: 100m
           memory: 256Mi

--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -40,3 +40,10 @@ spec:
             name: cad-pd-token
         - secretRef:
             name: cad-backplane-secret
+      computeResources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 1
+          memory: 1Gi

--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -41,9 +41,7 @@ spec:
         - secretRef:
             name: cad-backplane-secret
       computeResources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
+        # We need QoS class guaranteed as we do not retry these tasksruns
         limits:
-          cpu: 1
-          memory: 1Gi
+          cpu: 500m
+          memory: 256Mi

--- a/deploy/tekton-pruner.yaml
+++ b/deploy/tekton-pruner.yaml
@@ -27,7 +27,7 @@ spec:
                   cpu: 100m
                   memory: 64Mi
                 limits:
-                  cpu: 1
+                  cpu: 500m
                   memory: 256Mi
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: FallbackToLogsOnError

--- a/deploy/tekton-pruner.yaml
+++ b/deploy/tekton-pruner.yaml
@@ -22,6 +22,13 @@ spec:
               image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-cli-tkn-rhel8@sha256:e1fa47811f156e48a61741aabe73ef85078960567822a4b23c174c0d9b4d0ee6
               imagePullPolicy: IfNotPresent
               name: tekton-resource-pruner
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+                limits:
+                  cpu: 1
+                  memory: 256Mi
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: FallbackToLogsOnError
           dnsPolicy: ClusterFirst

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -72,7 +72,7 @@ objects:
               containers:
               - resources:
                   limits:
-                    cpu: 1
+                    cpu: 500m
                     memory: 256Mi
                   requests:
                     cpu: 100m
@@ -210,10 +210,7 @@ objects:
       - -c
       computeResources:
         limits:
-          cpu: 1
-          memory: 1Gi
-        requests:
-          cpu: 100m
+          cpu: 500m
           memory: 256Mi
       env:
       - name: CAD_PROMETHEUS_PUSHGATEWAY
@@ -254,7 +251,7 @@ objects:
               name: tekton-resource-pruner
               resources:
                 limits:
-                  cpu: 1
+                  cpu: 500m
                   memory: 256Mi
                 requests:
                   cpu: 100m

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -210,8 +210,11 @@ objects:
       - -c
       computeResources:
         limits:
-          cpu: 500m
+          cpu: 100m
           memory: 256Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi
       env:
       - name: CAD_PROMETHEUS_PUSHGATEWAY
         value: aggregation-pushgateway:9091

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -64,6 +64,19 @@ objects:
       triggers.tekton.dev/old-escape-quotes: "true"
     name: cad-event-listener
   spec:
+    resources:
+      kubernetesResource:
+        spec:
+          template:
+            spec:
+              containers:
+              - resources:
+                  limits:
+                    cpu: 1
+                    memory: 256Mi
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
     triggers:
     - triggerRef: cad-pipe-listener
 - apiVersion: tekton.dev/v1beta1
@@ -195,6 +208,13 @@ objects:
       command:
       - /bin/bash
       - -c
+      computeResources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       env:
       - name: CAD_PROMETHEUS_PUSHGATEWAY
         value: aggregation-pushgateway:9091
@@ -232,6 +252,13 @@ objects:
               image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-cli-tkn-rhel8@sha256:e1fa47811f156e48a61741aabe73ef85078960567822a4b23c174c0d9b4d0ee6
               imagePullPolicy: IfNotPresent
               name: tekton-resource-pruner
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: FallbackToLogsOnError
             dnsPolicy: ClusterFirst


### PR DESCRIPTION
Add resource requests and limits to all containers.
Infered some sensible values from production metrics. 

The TaskRuns only get a limit. This way the resource requests are set to the same value as the limit and we get QoS class Guaranteed. As we do not retry the TaskRuns, we should make them be evicted last. 

Closes: https://issues.redhat.com/browse/OSD-22524