### PR TITLE
Fix invalid tekton step definition

### DIFF
--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -40,7 +40,7 @@ spec:
             name: cad-pd-token
         - secretRef:
             name: cad-backplane-secret
-      computeResources:
+      resources:
         requests:
           cpu: 10m
           memory: 64Mi

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -208,13 +208,6 @@ objects:
       command:
       - /bin/bash
       - -c
-      computeResources:
-        limits:
-          cpu: 100m
-          memory: 256Mi
-        requests:
-          cpu: 10m
-          memory: 64Mi
       env:
       - name: CAD_PROMETHEUS_PUSHGATEWAY
         value: aggregation-pushgateway:9091
@@ -229,6 +222,13 @@ objects:
           name: cad-backplane-secret
       image: ${REGISTRY_IMG}:${IMAGE_TAG}
       name: check-infrastructure
+      resources:
+        limits:
+          cpu: 100m
+          memory: 256Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi
 - apiVersion: batch/v1
   kind: CronJob
   metadata:


### PR DESCRIPTION
We use tekton v1beta1 and the field is 'resources' instead of 'computeResources'
https://tekton.dev/docs/pipelines/tasks/#defining-steps