### PR TITLE
[OSD-22536] Add new routetables check for public subnets.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/common v0.37.0
 	github.com/spf13/cobra v1.8.0
+	go.uber.org/mock v0.4.0
 	go.uber.org/zap v1.26.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.28.4

--- a/go.sum
+++ b/go.sum
@@ -531,6 +531,7 @@ go.starlark.net v0.0.0-20230525235612-a134d8f9ddca h1:VdD38733bfYv5tUZwEIskMM93V
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=

--- a/pkg/aws/mock/aws.go
+++ b/pkg/aws/mock/aws.go
@@ -112,11 +112,12 @@ func (mr *MockClientMockRecorder) GetSubnetID(infraID interface{}) *gomock.Call 
 }
 
 // IsSubnetPrivate mocks base method.
-func (m *MockClient) IsSubnetPrivate(subnet string) bool {
+func (m *MockClient) IsSubnetPrivate(subnet string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSubnetPrivate", subnet)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // IsSubnetPrivate indicates an expected call of IsSubnetPrivate.

--- a/pkg/networkverifier/networkverifier.go
+++ b/pkg/networkverifier/networkverifier.go
@@ -164,7 +164,11 @@ func getSubnets(infraID string, cluster *v1.Cluster, awsClient aws.Client) ([]st
 	if !cluster.AWS().PrivateLink() && len(cluster.AWS().SubnetIDs()) != 0 {
 		subnets := cluster.AWS().SubnetIDs()
 		for _, subnet := range subnets {
-			if awsClient.IsSubnetPrivate(subnet) {
+			isPrivate, err := awsClient.IsSubnetPrivate(subnet)
+			if err != nil {
+				return []string{}, err
+			}
+			if isPrivate {
 				return []string{subnet}, nil
 			}
 		}


### PR DESCRIPTION
This checks that a subnet does not have a route to `0.0.0.0/0` to an internet gateway. This usually denotes a public subnet.

Currently this keeps the old check for MapPublicIpOnLaunch as well if no IGW route is found.