### PR TITLE
PoC: Investigate ClusterMonitoringErrorBudgetBurn due to a misconfigured UWM configmap

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -26,6 +26,7 @@ import (
 	investigation "github.com/openshift/configuration-anomaly-detection/pkg/investigations"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/ccam"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/chgm"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clustermonitoringerrorbudgetburn"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/cpd"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/managedcloud"
@@ -151,6 +152,9 @@ func getInvestigation(alertTitle string) *investigation.Investigation {
 	logging.Warn("Flag CAD_EXPERIMENTAL_ENABLED is set, experimental CAD investigations are enabled!")
 
 	// Experimental investigations go here
+	if strings.Contains(alertTitle, "ClusterMonitoringErrorBudgetBurnSRE") {
+		return investigation.NewInvestigation(clustermonitoringerrorbudgetburn.Investigate, "ClusterMonitoringErrorBudgetBurnSRE")
+	}
 
 	return nil
 }

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -1,0 +1,79 @@
+// Package clustermonitoringerrorbudgetburn contains remediation for https://issues.redhat.com/browse/OCPBUGS-33863
+package clustermonitoringerrorbudgetburn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	investigation "github.com/openshift/configuration-anomaly-detection/pkg/investigations"
+	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var uwmMisconfiguredSL = ocm.ServiceLog{
+	Severity:     "Major",
+	Summary:      "Action required: review user-workload-monitoring configuration",
+	ServiceName:  "SREManualAction",
+	Description:  "Your cluster's user workload monitoring is misconfigured: please review the user-workload-monitoring-config ConfigMap in the openshift-user-workload-monitoring namespace. For more information, please refer to the product documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/monitoring/configuring-the-monitoring-stack#.",
+	InternalOnly: false,
+}
+
+func Investigate(r *investigation.Resources) error {
+	// Initialize k8s client
+	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient)
+	if err != nil {
+		return fmt.Errorf("unable to initialize k8s cli: %w", err)
+	}
+
+	// Initialize PagerDuty note writer
+	notes := notewriter.New("ClusterMonitoringErrorBudgetBurn", logging.RawLogger)
+
+	// List the monitoring cluster operator
+	coList := &configv1.ClusterOperatorList{}
+	listOptions := &client.ListOptions{FieldSelector: fields.SelectorFromSet(fields.Set{"metadata.name": "monitoring"})}
+	err = k8scli.List(context.TODO(), coList, listOptions)
+	if err != nil {
+		return fmt.Errorf("unable to list monitoring clusteroperator: %w", err)
+	}
+
+	// Make sure our list output only finds a single cluster operator for `metadata.name = monitoring`
+	if len(coList.Items) != 1 {
+		return fmt.Errorf("found %d clusteroperators, expected 1", len(coList.Items))
+	}
+	monitoringCo := coList.Items[0]
+
+	// Check if the UWM configmap is invalid
+	// If it is, send a service log and silence the alert.
+	if isUWMConfigInvalid(&monitoringCo) {
+		notes.AppendAutomation("Customer misconfigured the UWM configmap, sending service log and silencing the alert")
+		err = r.OcmClient.PostServiceLog(r.Cluster.ID(), &uwmMisconfiguredSL)
+		if err != nil {
+			return fmt.Errorf("failed posting servicelog: %w", err)
+		}
+
+		return r.PdClient.SilenceAlertWithNote(notes.String())
+	}
+
+	// The UWM configmap is valid, an SRE will need to manually investigate this alert.
+	// Escalate the alert with our findings.
+	notes.AppendSuccess("Monitoring CO not degraded due to a broken UWM configmap")
+	return r.PdClient.EscalateAlertWithNote(notes.String())
+}
+
+// Check if the `Available` status condition reports a broken UWM config
+func isUWMConfigInvalid(monitoringCo *configv1.ClusterOperator) bool {
+	symptomStatusString := `the User Workload Configuration from "config.yaml" key in the "openshift-user-workload-monitoring/user-workload-monitoring-config" ConfigMap could not be parsed`
+
+	for _, condition := range monitoringCo.Status.Conditions {
+		if condition.Type == "Available" {
+			return strings.Contains(condition.Message, symptomStatusString)
+		}
+	}
+	return false
+}

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn_test.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn_test.go
@@ -1,0 +1,38 @@
+package clustermonitoringerrorbudgetburn
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	statusConditionAvailable                = configv1.ClusterOperatorStatusCondition{Type: "Available", Status: "True"}
+	statusConditionUpgradeable              = configv1.ClusterOperatorStatusCondition{Type: "Upgradeable", Status: "True"}
+	statusConditionUnavailableSymptomsMatch = configv1.ClusterOperatorStatusCondition{Type: "Available", Status: "False", Message: `the User Workload Configuration from "config.yaml" key in the "openshift-user-workload-monitoring/user-workload-monitoring-config" ConfigMap could not be parsed`}
+)
+
+func TestSymptomMatches(t *testing.T) {
+	monitoringCo := configv1.ClusterOperator{
+		ObjectMeta: v1.ObjectMeta{Name: "monitoring"},
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{statusConditionUnavailableSymptomsMatch, statusConditionUpgradeable},
+		},
+	}
+	if !isUWMConfigInvalid(&monitoringCo) {
+		t.Fatal("expected symptoms to match")
+	}
+}
+
+func TestSymptomNoMatch(t *testing.T) {
+	monitoringCo := configv1.ClusterOperator{
+		ObjectMeta: v1.ObjectMeta{Name: "monitoring"},
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{statusConditionAvailable, statusConditionUpgradeable},
+		},
+	}
+	if isUWMConfigInvalid(&monitoringCo) {
+		t.Fatal("expected symptoms to not match")
+	}
+}

--- a/test/generate_incident.sh
+++ b/test/generate_incident.sh
@@ -15,6 +15,7 @@ fi
 declare -A alert_mapping=(
     ["ClusterHasGoneMissing"]="cadtest has gone missing"
     ["ClusterProvisioningDelay"]="ClusterProvisioningDelay -"
+    ["ClusterMonitoringErrorBudgetBurnSRE"]="ClusterMonitoringErrorBudgetBurnSRE Critical (1)"
 )
 
 # Function to print help message


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-23312

This PR showcases how CAD could use kube api with an example implementation of the remediation to https://issues.redhat.com/browse/OCPBUGS-33863. 

The implementation is hidden behind a `CAD_EXPERIMENTAL_ENABLED` flag that we will enable on staging after enabling kube-api access in https://issues.redhat.com/browse/OSD-23311. 


