### PR TITLE
Fix(OSD-23693): wrong string to determine installer assumerole failure

### DIFF
--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -60,7 +60,7 @@ const accessDeniedErrorSupportRole string = "could not assume support role in cu
 
 // - installer role is deleted (it falls back to old flow, which results in access denied)
 // - installer and support role are deleted
-const accessDeniedErrorInstallerRole string = "could not assume support role in customer's account: AccessDenied:"
+const accessDeniedErrorInstallerRole string = "RH-Managed-OpenShift-Installer/OCM is not authorized to perform: sts:AssumeRole on resource:"
 
 func customerRemovedPermissions(backplaneError string) bool {
 	return strings.Contains(backplaneError, accessDeniedErrorSupportRole) || strings.Contains(backplaneError, accessDeniedErrorInstallerRole)


### PR DESCRIPTION
Fixes a copy paste error in https://github.com/openshift/configuration-anomaly-detection/pull/285:

I had copy pasted and forgot to update the string.
This is now tested on a cluster where the pipeline fails, so it will work. 