### PR TITLE
fix(OSD-24257): put clusters in LS if DMS/PD is blocked

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ run:
   modules-download-mode: readonly
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
-  timeout: 5m
+  timeout: 15m
 
 issues:
   # on default, golangci-lint excludes gosec. Hence, we have to

--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -123,7 +123,7 @@ func run(_ *cobra.Command, _ []string) error {
 		return ccam.Evaluate(cluster, err, ocmClient, pdClient, alertInvestigation.Name)
 	}
 
-	investigationResources := &investigation.Resources{InvestigationName: alertInvestigation.Name, Cluster: cluster, ClusterDeployment: clusterDeployment, AwsClient: customerAwsClient, OcmClient: ocmClient, PdClient: pdClient}
+	investigationResources := &investigation.Resources{Cluster: cluster, ClusterDeployment: clusterDeployment, AwsClient: customerAwsClient, OcmClient: ocmClient, PdClient: pdClient}
 
 	logging.Infof("Starting investigation for %s", alertInvestigation.Name)
 	return alertInvestigation.Run(investigationResources)

--- a/go.mod
+++ b/go.mod
@@ -151,4 +151,5 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/onsi/ginkgo/v2 v2.17.2
 	golang.org/x/sys v0.21.0 // indirect
+	gotest.tools/v3 v3.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -588,6 +588,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.23.3/go.mod h1:w258XdGyvCmnBj/vGzQMj6kzdufJZVUwEM1U2fRJwSQ=

--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 )
 
-var ccamLimitedSupport = ocm.LimitedSupportReason{
+var ccamLimitedSupport = &ocm.LimitedSupportReason{
 	Summary: "Restore missing cloud credentials",
 	Details: "Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install",
 }

--- a/pkg/investigations/chgm/util.go
+++ b/pkg/investigations/chgm/util.go
@@ -1,0 +1,32 @@
+package chgm
+
+import (
+	"fmt"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+)
+
+func createEgressSL(blockedUrls string) *ocm.ServiceLog {
+	description := fmt.Sprintf("Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#.", blockedUrls)
+
+	egressSL := ocm.ServiceLog{
+		Severity:     "Critical",
+		Summary:      "Action required: Network misconfiguration",
+		ServiceName:  "SREManualAction",
+		Description:  description,
+		InternalOnly: false,
+	}
+
+	return &egressSL
+}
+
+func createEgressLS(blockedUrls string) *ocm.LimitedSupportReason {
+	details := fmt.Sprintf("Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#.", blockedUrls)
+
+	egressLS := ocm.LimitedSupportReason{
+		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",
+		Details: details,
+	}
+
+	return &egressLS
+}

--- a/pkg/investigations/chgm/util_test.go
+++ b/pkg/investigations/chgm/util_test.go
@@ -1,0 +1,47 @@
+package chgm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	"gotest.tools/v3/assert"
+)
+
+// Mock data
+var blockedUrls = "example.com, test.com"
+
+// TestCreateEgressSL tests the createEgressSL function
+func TestCreateEgressSL(t *testing.T) {
+	expectedDescription := fmt.Sprintf(
+		"Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#.",
+		blockedUrls,
+	)
+
+	expected := &ocm.ServiceLog{
+		Severity:     "Critical",
+		Summary:      "Action required: Network misconfiguration",
+		ServiceName:  "SREManualAction",
+		Description:  expectedDescription,
+		InternalOnly: false,
+	}
+
+	result := createEgressSL(blockedUrls)
+	assert.Equal(t, *expected, *result)
+}
+
+// TestCreateEgressLS tests the createEgressLS function
+func TestCreateEgressLS(t *testing.T) {
+	expectedDetails := fmt.Sprintf(
+		"Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#.",
+		blockedUrls,
+	)
+
+	expected := &ocm.LimitedSupportReason{
+		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",
+		Details: expectedDetails,
+	}
+
+	result := createEgressLS(blockedUrls)
+	assert.Equal(t, *expected, *result)
+}

--- a/pkg/investigations/investigation.go
+++ b/pkg/investigations/investigation.go
@@ -23,7 +23,6 @@ func NewInvestigation(investigationFn func(resources *Resources) error, name str
 
 // Resources holds all resources/tools required for alert investigations
 type Resources struct {
-	InvestigationName string
 	Cluster           *cmv1.Cluster
 	ClusterDeployment *hivev1.ClusterDeployment
 	AwsClient         aws.Client

--- a/pkg/ocm/mock/ocmmock.go
+++ b/pkg/ocm/mock/ocmmock.go
@@ -127,7 +127,7 @@ func (mr *MockClientMockRecorder) IsAccessProtected(cluster interface{}) *gomock
 }
 
 // PostLimitedSupportReason mocks base method.
-func (m *MockClient) PostLimitedSupportReason(limitedSupportReason ocm.LimitedSupportReason, internalClusterID string) error {
+func (m *MockClient) PostLimitedSupportReason(limitedSupportReason *ocm.LimitedSupportReason, internalClusterID string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostLimitedSupportReason", limitedSupportReason, internalClusterID)
 	ret0, _ := ret[0].(error)

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -40,7 +40,7 @@ type ServiceLog struct {
 // Client is the interface exposing OCM related functions
 type Client interface {
 	GetClusterMachinePools(internalClusterID string) ([]*cmv1.MachinePool, error)
-	PostLimitedSupportReason(limitedSupportReason LimitedSupportReason, internalClusterID string) error
+	PostLimitedSupportReason(limitedSupportReason *LimitedSupportReason, internalClusterID string) error
 	GetSupportRoleARN(internalClusterID string) (string, error)
 	GetServiceLog(cluster *cmv1.Cluster, filter string) (*servicelogsv1.ClusterLogsUUIDListResponse, error)
 	PostServiceLog(clusterID string, sl *ServiceLog) error
@@ -206,7 +206,7 @@ func (c *SdkClient) getClusterResource(internalClusterID string, resourceKey str
 }
 
 // PostLimitedSupportReason allows to post a generic limited support reason to a cluster
-func (c *SdkClient) PostLimitedSupportReason(limitedSupportReason LimitedSupportReason, internalClusterID string) error {
+func (c *SdkClient) PostLimitedSupportReason(limitedSupportReason *LimitedSupportReason, internalClusterID string) error {
 	logging.Infof("Sending limited support reason: %s", limitedSupportReason.Summary)
 
 	ls, err := newLimitedSupportReasonBuilder(limitedSupportReason).Build()
@@ -260,7 +260,7 @@ func (c *SdkClient) PostServiceLog(clusterID string, sl *ServiceLog) error {
 }
 
 // newLimitedSupportReasonBuilder creates a Limited Support reason
-func newLimitedSupportReasonBuilder(ls LimitedSupportReason) *cmv1.LimitedSupportReasonBuilder {
+func newLimitedSupportReasonBuilder(ls *LimitedSupportReason) *cmv1.LimitedSupportReasonBuilder {
 	builder := cmv1.NewLimitedSupportReason()
 	builder.Summary(ls.Summary)
 	builder.Details(ls.Details)


### PR DESCRIPTION
This PR updates CAD's CHGM behavior to put clusters that block PD/DMS into limited support. We need to do this as we can't guarantee SLA in those cases. 