### PR TITLE
Maint: makefile better split into categories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,27 +5,28 @@ GOLANGCI_LINT_VERSION=v1.58.1
 PRE_COMMIT_HOOK = .git/hooks/pre-commit
 PRE_COMMIT_SCRIPT = hack/pre-commit.sh
 
-help:
-	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-30s\033[0m %s\n", $$1, $$2}'
+.DEFAULT_GOAL := all
 
-.DEFAULT_GOAL := cadctl
+help:  # Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-50s\033[0m %s\n", $$1, $$2 } /^\$$\([0-9A-Za-z_-]+\):.*?##/ { gsub("_","-", $$1); printf "  \033[36m%-50s\033[0m %s\n", tolower(substr($$1, 3, length($$1)-7)), $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Global:
+.PHONY: all 
+all: interceptor cadctl template-updater generate-template-file  ## Generate, build, lint, test all subprojects
+
+.PHONY: build 
+build: build-interceptor build-cadctl build-template-updater ## Build all subprojects in this repository 
+
+.PHONY: lint
+lint: getlint lint-cadctl lint-interceptor lint-template-updater ## Lint all subprojects
+
+##@ cadctl:
 .PHONY: cadctl 
-cadctl: build-cadctl test-cadctl lint-cadctl generate-template-file ## Run all jobs for cadctl (build, test, lint, generation)
+cadctl: generate-cadctl build-cadctl test-cadctl lint-cadctl generate-template-file ## Run all targets for cadctl (generate, build, test, lint, generation)
 
-.PHONY: interceptor 
-interceptor: build-interceptor test-interceptor lint-interceptor  ## Run all jobs for interceptor (build, test, lint)
-
-# build uses the following Go flags:
-# -s -w for stripping the binary (making it smaller)
-# -mod=readonly and -trimpath are for generating reproducible/verifiable binaries. See also: https://reproducible-builds.org/
-PHONY: build	
-build: build-interceptor build-cadctl build-template-updater  ## Build all binaries in this repository 
-
-.PHONY: build-interceptor
-build-interceptor: ## Build the interceptor binary
-	@echo
-	@echo "Building interceptor..."
-	cd interceptor && go build -ldflags="-s -w" -mod=readonly -trimpath -o ../bin/interceptor .
+.PHONY: generate-cadctl 
+generate-cadctl: ## Generate mocks for cadctl
+	go generate -mod=readonly ./...
 
 .PHONY: build-cadctl
 build-cadctl: ## Build the cadctl binary
@@ -33,41 +34,35 @@ build-cadctl: ## Build the cadctl binary
 	@echo "Building cadctl..."
 	cd cadctl && go build -ldflags="-s -w" -mod=readonly -trimpath -o ../bin/cadctl .
 
-.PHONY: build-template-updater
-build-template-updater: ## Build the interceptor binary
-	@echo
-	@echo "Building template-updater..."
-	cd hack/update-template && go build -ldflags="-s -w" -mod=readonly -trimpath -o ../../bin/template-updater .
-
-
-.PHONY: lint 
-lint: getlint lint-cadctl lint-interceptor lint-template-updater ## Lint all subprojects
-
-.PHONY: lint-cadctl
+.PHONY: lint-cadctl 
 lint-cadctl: ## Lint cadctl subproject
 	@echo
 	@echo "Linting cadctl..."
 	cd cadctl && GOLANGCI_LINT_CACHE=$$(mktemp -d) $(GOPATH)/bin/golangci-lint run -c ../.golangci.yml
 
-.PHONY: lint-interceptor
+.PHONY: test-cadctl
+test-cadctl:  ## Run automated tests for cadctl
+	@echo
+	@echo "Running unit tests for cadctl..."
+	go test $(TESTOPTS) -race -mod=readonly ./cadctl/... ./pkg/...
+
+##@ Interceptor:
+.PHONY: interceptor
+interceptor: build-interceptor test-interceptor lint-interceptor ## Run all targets for interceptor (build, test, lint)
+
+.PHONY: build-interceptor 
+build-interceptor: ## Build the interceptor binary
+	@echo
+	@echo "Building interceptor..."
+	cd interceptor && go build -ldflags="-s -w" -mod=readonly -trimpath -o ../bin/interceptor .
+
+.PHONY: lint-interceptor 
 lint-interceptor: ## Lint interceptor subproject
 	@echo
 	@echo "Linting interceptor..."
 	cd interceptor && GOLANGCI_LINT_CACHE=$$(mktemp -d) $(GOPATH)/bin/golangci-lint run -c ../.golangci.yml
 
-.PHONY: lint-template-updater
-lint-template-updater: ## Lint template-updater subproject
-	@echo
-	@echo "Linting template-updater..."
-	cd hack/update-template && GOLANGCI_LINT_CACHE=$$(mktemp -d) $(GOPATH)/bin/golangci-lint run -c ../../.golangci.yml
-
-.PHONY: test-cadctl
-test-cadctl: ## Run automated tests for cadctl
-	@echo
-	@echo "Running unit tests for cadctl..."
-	go test $(TESTOPTS) -race -mod=readonly ./cadctl/... ./pkg/...
-
-.PHONY: test-interceptor
+.PHONY: test-interceptor 
 test-interceptor: build-interceptor ## Run automated tests for interceptor
 	@echo
 	@echo "Running unit tests for interceptor..."
@@ -76,22 +71,39 @@ test-interceptor: build-interceptor ## Run automated tests for interceptor
 	@echo "Running e2e tests for interceptor..."
 	cd interceptor && ./test/e2e.sh
 
-.PHONY: generate-template-file
-generate-template-file: build-template-updater ## Generate deploy template file
+##@ Template-updater:
+.PHONY: template-updater
+template-updater: build-template-updater lint-template-updater ## Run all targets for template-updater
+
+.PHONY: build-template-updater
+build-template-updater: ## Build the template-updater binary
 	@echo
-	@echo "Generating template file..."
-	cp ./bin/template-updater ./hack/update-template/ && cd ./hack/update-template/ && ./template-updater
+	@echo "Building template-updater..."
+	cd hack/update-template && go build -ldflags="-s -w" -mod=readonly -trimpath -o ../../bin/template-updater .
 
-.PHONY: boilerplate-update
-boilerplate-update: ## Update boilerplate version
-	@boilerplate/update
+.PHONY: lint-template-updater
+lint-template-updater: ## Lint template-updater subproject
+	@echo
+	@echo "Linting template-updater..."
+	cd hack/update-template && GOLANGCI_LINT_CACHE=$$(mktemp -d) $(GOPATH)/bin/golangci-lint run -c ../../.golangci.yml
 
-.PHONY: pre-commit
+##@ Utility:
+.PHONY: pre-commit 
 pre-commit: ## Run pre-commit hook
 	@echo
 	@echo "Running pre-commit hook..."
 	@cp $(PRE_COMMIT_SCRIPT) $(PRE_COMMIT_HOOK)
 	@chmod +x $(PRE_COMMIT_HOOK)
+
+.PHONY: boilerplate-update 
+boilerplate-update: ## Update boilerplate version
+	@boilerplate/update
+
+.PHONY: generate-template-file
+generate-template-file: build-template-updater ## Generate deploy template file
+	@echo
+	@echo "Generating template file..."
+	cp ./bin/template-updater ./hack/update-template/ && cd ./hack/update-template/ && ./template-updater
 
 # Installed using instructions from: https://golangci-lint.run/usage/install/#linux-and-windows
 getlint:
@@ -105,8 +117,8 @@ coverage:
 
 .PHONY: validate
 validate: generate-template-file isclean
-	
-### Build jobs
+
+# Build targets
 cadctl/cadctl: cadctl/**/*.go pkg/**/*.go go.mod go.sum
 	GOBIN=$(PWD)/cadctl go install -ldflags="-s -w" -mod=readonly -trimpath $(PWD)/cadctl
 


### PR DESCRIPTION
```
make help

Usage:
  make <target>

Global:
  all                                                 Generate, build, lint, test all subprojects
  build                                               Build all subprojects in this repository 
  lint                                                Lint all subprojects

cadctl:
  cadctl                                              Run all targets for cadctl (generate, build, test, lint, generation)
  generate-cadctl                                     Generate mocks for cadctl
  build-cadctl                                        Build the cadctl binary
  lint-cadctl                                         Lint cadctl subproject
  test-cadctl                                         Run automated tests for cadctl

Interceptor:
  interceptor                                         Run all targets for interceptor (build, test, lint)
  build-interceptor                                   Build the interceptor binary
  lint-interceptor                                    Lint interceptor subproject
  test-interceptor                                    Run automated tests for interceptor

Template-updater:
  template-updater                                    Run all targets for template-updater
  build-template-updater                              Build the template-updater binary
  lint-template-updater                               Lint template-updater subproject

Utility:
  pre-commit                                          Run pre-commit hook
  boilerplate-update                                  Update boilerplate version
  generate-template-file                              Generate deploy template file

```

Previously, the categories were not split and I had accidentally removed the make generate during my refactor 