### PR TITLE
fix(OSD-24257): put clusters in LS if PD is blocked

### DIFF
--- a/pkg/investigations/chgm/chgm_test.go
+++ b/pkg/investigations/chgm/chgm_test.go
@@ -519,34 +519,5 @@ var _ = Describe("chgm", func() {
 				Expect(gotErr).NotTo(HaveOccurred())
 			})
 		})
-
-		Describe("Blocked Egress Handling", func() {
-			When("An egress is SLA relevant", func() {
-				It("should put the cluster into limited support", func() {
-					// nosnch.in:443 is blocked
-					blockedUrls := "ec2.us-east-1.amazonaws.com:443,nosnch.in:443,events.us-east-1.amazonaws.com:443,elasticloadbalancing.us-east-1.amazonaws.com:443,sts.us-east-1.amazonaws.com:443"
-					egressLS := createEgressLS(blockedUrls)
-
-					// We need to cast it to the mock client, as the investigationResources are unaware the underlying functions are mocks
-					r.OcmClient.(*ocmmock.MockClient).EXPECT().PostLimitedSupportReason(gomock.Eq(egressLS), gomock.Eq(cluster.ID())).Return(nil)
-
-					gotErr := handleBlockedEgress(r.Cluster, r.OcmClient, blockedUrls)
-
-					Expect(gotErr).NotTo(HaveOccurred())
-				})
-			})
-			When("An egress is not SLA relevant", func() {
-				It("should send a service log", func() {
-					blockedUrls := "ec2.us-east-1.amazonaws.com:443,events.us-east-1.amazonaws.com:443,elasticloadbalancing.us-east-1.amazonaws.com:443,sts.us-east-1.amazonaws.com:443"
-					egressSL := createEgressSL(blockedUrls)
-
-					// We need to cast it to the mock client, as the investigationResources are unaware the underlying functions are mocks
-					r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(egressSL)).Return(nil)
-
-					gotErr := handleBlockedEgress(r.Cluster, r.OcmClient, blockedUrls)
-					Expect(gotErr).NotTo(HaveOccurred())
-				})
-			})
-		})
 	})
 })

--- a/pkg/investigations/chgm/util.go
+++ b/pkg/investigations/chgm/util.go
@@ -21,7 +21,7 @@ func createEgressSL(blockedUrls string) *ocm.ServiceLog {
 }
 
 func createEgressLS(blockedUrls string) *ocm.LimitedSupportReason {
-	details := fmt.Sprintf("Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#.", blockedUrls)
+	details := fmt.Sprintf("Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#", blockedUrls)
 
 	egressLS := ocm.LimitedSupportReason{
 		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",

--- a/pkg/investigations/chgm/util_test.go
+++ b/pkg/investigations/chgm/util_test.go
@@ -33,7 +33,7 @@ func TestCreateEgressSL(t *testing.T) {
 // TestCreateEgressLS tests the createEgressLS function
 func TestCreateEgressLS(t *testing.T) {
 	expectedDetails := fmt.Sprintf(
-		"Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#.",
+		"Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#",
 		blockedUrls,
 	)
 


### PR DESCRIPTION
This fixes the previous PR, we now escalate alerts with PD blocked to customers anyway as it is otherwise very confusing: we still need to investigate alerts if only PD is blocked (not DMS). 