### PR TITLE
WIP: Add special handling for critical customer

### DIFF
--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -38,9 +38,9 @@ func Evaluate(cluster *cmv1.Cluster, bpError error, ocmClient ocm.Client, pdClie
 	case cmv1.ClusterStateReady:
 		// Cluster is in functional sate but we can't jumprole to it: post limited support
 		metrics.Inc(metrics.LimitedSupportSet, alertType, ccamLimitedSupport.Summary)
-		err := ocmClient.PostLimitedSupportReason(ccamLimitedSupport, cluster.ID())
+		err := ocmClient.PostLimitedSupportReason(ccamLimitedSupport, cluster)
 		if err != nil {
-			return fmt.Errorf("could not post limited support reason for %s: %w", cluster.Name(), err)
+			return pdClient.EscalateAlertWithNote(fmt.Sprintf("could not post limited support reason for %s: %v", cluster.Name(), err))
 		}
 
 		return pdClient.SilenceAlertWithNote(fmt.Sprintf("Added the following Limited Support reason to cluster: %#v. Silencing alert.\n", ccamLimitedSupport))

--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -40,7 +40,7 @@ func Evaluate(cluster *cmv1.Cluster, bpError error, ocmClient ocm.Client, pdClie
 		metrics.Inc(metrics.LimitedSupportSet, alertType, ccamLimitedSupport.Summary)
 		err := ocmClient.PostLimitedSupportReason(ccamLimitedSupport, cluster)
 		if err != nil {
-			return pdClient.EscalateAlertWithNote(fmt.Sprintf("could not post limited support reason for %s: %v", cluster.Name(), err))
+			return pdClient.EscalateAlertWithNote(fmt.Sprintf("could not post limited support reason for %s: %s", cluster.Name(), err.Error()))
 		}
 
 		return pdClient.SilenceAlertWithNote(fmt.Sprintf("Added the following Limited Support reason to cluster: %#v. Silencing alert.\n", ccamLimitedSupport))

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -85,7 +85,7 @@ func Investigate(r *investigation.Resources) error {
 			err := r.OcmClient.PostLimitedSupportReason(createEgressLS(failureReason), r.Cluster)
 			if err != nil {
 				notes.AppendWarning("NetworkVerifier found unreachable targets, deadmanssnitch is blocked! \nUnreachable: \n%s", failureReason)
-				notes.AppendWarning("Failed to post limited support: %v", err)
+				notes.AppendWarning("Failed to post limited support: %s", err.Error())
 				return r.PdClient.EscalateAlertWithNote(notes.String())
 			}
 

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -82,9 +82,11 @@ func Investigate(r *investigation.Resources) error {
 		logging.Infof("Network verifier reported failure: %s", failureReason)
 
 		if strings.Contains(failureReason, "nosnch.in") {
-			err := r.OcmClient.PostLimitedSupportReason(createEgressLS(failureReason), r.Cluster.ID())
+			err := r.OcmClient.PostLimitedSupportReason(createEgressLS(failureReason), r.Cluster)
 			if err != nil {
-				return err
+				notes.AppendWarning("NetworkVerifier found unreachable targets, deadmanssnitch is blocked! \nUnreachable: \n%s", failureReason)
+				notes.AppendWarning("Failed to post limited support: %v", err)
+				return r.PdClient.EscalateAlertWithNote(notes.String())
 			}
 
 			metrics.Inc(metrics.LimitedSupportSet, investigationName, "EgressBlocked")

--- a/pkg/ocm/mock/ocmmock.go
+++ b/pkg/ocm/mock/ocmmock.go
@@ -127,17 +127,17 @@ func (mr *MockClientMockRecorder) IsAccessProtected(cluster interface{}) *gomock
 }
 
 // PostLimitedSupportReason mocks base method.
-func (m *MockClient) PostLimitedSupportReason(limitedSupportReason *ocm.LimitedSupportReason, internalClusterID string) error {
+func (m *MockClient) PostLimitedSupportReason(limitedSupportReason *ocm.LimitedSupportReason, cluster *v1.Cluster) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostLimitedSupportReason", limitedSupportReason, internalClusterID)
+	ret := m.ctrl.Call(m, "PostLimitedSupportReason", limitedSupportReason, cluster)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PostLimitedSupportReason indicates an expected call of PostLimitedSupportReason.
-func (mr *MockClientMockRecorder) PostLimitedSupportReason(limitedSupportReason, internalClusterID interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) PostLimitedSupportReason(limitedSupportReason, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostLimitedSupportReason", reflect.TypeOf((*MockClient)(nil).PostLimitedSupportReason), limitedSupportReason, internalClusterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostLimitedSupportReason", reflect.TypeOf((*MockClient)(nil).PostLimitedSupportReason), limitedSupportReason, cluster)
 }
 
 // PostServiceLog mocks base method.


### PR DESCRIPTION
We do no longer post LimitedSupport if the target cluster is from a organization with the managed_critical_customer capability. Instead we redirect SRE to take additional steps for those clusters.

See https://issues.redhat.com/browse/OSD-24126 