### PR TITLE
Update security group and subnet tag filters for 4.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Example usage:`./test/generate_incident.sh ClusterHasGoneMissing 2b94brrrrrrrrrr
   ```
 3) Run `cadctl` using the payload file
   ```bash
-  ./cadctl/cadctl investigate --payload-path payload
+  ./bin/cadctl investigate --payload-path payload
   ```
 
 ## Documentation


### PR DESCRIPTION
The tag format has slightly changed in 4.16 causing a failure to find the security group and subnet to populate the network verifier.

"As of 4.16, some downstream component is causing the subnet tag kubernetes.io/cluster/<infra_id> to show as "shared" instead of "owned" now, even for fresh installs in clean AWS accounts. As far as the network verifier is concerned, we probably don't actually care about the value of this tag, just that it exists.
Also in 4.16, security group have changed the name tag format from  `<infra_id>-master-sg` to `<infra_id>-controlplane`. 
We need to check for both now."

Fixes https://issues.redhat.com/browse/OSD-24458 
Tested in stage against 4.15 and 4.16 cluster.

Note to the reviewer: There is a similar PR for osdctl here https://github.com/openshift/osdctl/pull/596 

Before, for some reason we had used the worker sg for the network verifier. I changed this to master which should be more applicable for our purposes and brings it in line with what osdctl is doing.