### PR TITLE
Fix typo in log output when mapping is found in interceptor

### DIFF
--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -121,7 +121,7 @@ func (pdi *PagerDutyInterceptor) Process(ctx context.Context, r *triggersv1.Inte
 		}
 	}
 
-	pdi.Logger.Infof("Incident %s is not mapped to investigation '%s', returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID(), investigation.Name)
+	pdi.Logger.Infof("Incident %s is mapped to investigation '%s', returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID(), investigation.Name)
 	return &triggersv1.InterceptorResponse{
 		Continue: true,
 	}


### PR DESCRIPTION
Self explanatory - this logger message is for when we find a mapping, but the text says the opposite.