### PR TITLE
Fix security group fetching for AWSv2 SDK

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -449,7 +449,7 @@ func (c *SdkClient) GetSecurityGroupID(infraID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to list security group: %w", err)
 	}
-	if out.SecurityGroups == nil {
+	if out.SecurityGroups == nil || len(out.SecurityGroups) == 0 {
 		return "", fmt.Errorf("security groups are empty")
 	}
 	if len(*out.SecurityGroups[0].GroupId) == 0 {


### PR DESCRIPTION
AWSv2 SDK does not use pointers for the slice anymore.