### PR TITLE
Replace nil check with len()

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -357,7 +357,7 @@ func (c *SdkClient) GetSecurityGroupID(infraID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to list security group: %w", err)
 	}
-	if out.SecurityGroups == nil {
+	if len(out.SecurityGroups) == 0 {
 		return "", fmt.Errorf("security groups are empty")
 	}
 	if len(*out.SecurityGroups[0].GroupId) == 0 {


### PR DESCRIPTION
As the slice is no longer a pointer, checking len() works in both cases:

- len(nil-slice) == 0
- len(empty-slice) == 0

See: https://go.dev/play/p/ah-hRMCmEWk