### PR TITLE
fix(OSD-25690): pipeline failure for removed GetRole permission on installer

### DIFF
--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -74,6 +74,10 @@ var userCausedErrors = []string{
 	// This error is the response from backplane calls when:
 	// trust policy of ManagedOpenShift-Support-Role is changed
 	".*could not assume support role in customer's account: AccessDenied:.*",
+
+	// Customer removed the `GetRole` permission from the Installer role.
+	// Failed to get role: User: arn:aws:sts::<id>:assumed-role/ManagedOpenShift-Installer-Role/OCM is not authorized to perform: iam:GetRole on resource: role ManagedOpenShift-Support-Role because no identity-based policy allows the iam:GetRole action
+	".*is not authorized to perform: iam:GetRole on resource: role.*",
 }
 
 func customerRemovedPermissions(backplaneError string) bool {

--- a/pkg/investigations/ccam/ccam_test.go
+++ b/pkg/investigations/ccam/ccam_test.go
@@ -40,6 +40,11 @@ func TestCustomerRemovedPermissions(t *testing.T) {
 			expectedMatch: true,
 		},
 		{
+			name:          "Matching error 5",
+			errorMessage:  "unable to query aws credentials from backplane: failed to determine if cluster is using isolated backlpane access: failed to get sts support jump role ARN for cluster <cluster_id>: failed to get STS Support Jump Role for cluster <cluster_id>, status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is '<op_id>': Failed to get role: User: arn:aws:sts::<cluster_aws_account_id>:assumed-role/ManagedOpenShift-Installer-Role/OCM is not authorized to perform: iam:GetRole on resource: role ManagedOpenShift-Support-Role because no identity-based policy allows the iam:GetRole action",
+			expectedMatch: true,
+		},
+		{
 			name:          "Non-matching error",
 			errorMessage:  "Some timeout error",
 			expectedMatch: false,


### PR DESCRIPTION
**What?**

Handles the scenario where customers remove the `GetRole` permission of the installer role, which OCM requires to get the support role. With this PR, CAD will handle this scenario the same way as the other cases where customers broke permissions needed to access the cloud environment. 

**Why?**

This is a customer caused error that CAD can handle as "customer broke permissions" scenario route a notification to the customer.