### PR TITLE
[OSD-23696-Add-CAD-liveness-probe] Add liveness probe for interceptor

### DIFF
--- a/deploy/interceptor.yaml
+++ b/deploy/interceptor.yaml
@@ -29,6 +29,15 @@ spec:
           requests:
             cpu: "10m"
             memory: "100Mi"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /ready
@@ -48,7 +57,7 @@ spec:
           runAsUser: 65532
           seccompProfile:
             type: RuntimeDefault
-      restartPolicy: Always 
+      restartPolicy: Always
       serviceAccountName: pipeline
       terminationGracePeriodSeconds: 30
 ---

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -34,6 +34,15 @@ objects:
           - secretRef:
               name: cad-pd-token
           image: ${REGISTRY_IMG}:${IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
           name: cad-interceptor
           ports:
           - containerPort: 8080


### PR DESCRIPTION
Adds liveness probe to CAD interceptor, so SRE can know when the interceptor service for CAD is down. This [PR](https://github.com/openshift/managed-cluster-config/pull/2252) will alert SRE when two or more CAD interceptor pods are crashloopoing.

https://issues.redhat.com/browse/OSD-23696
