### PR TITLE
feat(OSD-27020): Tekton eventlistener to terminate TLS

### DIFF
--- a/deploy/pipeline-trigger.yaml
+++ b/deploy/pipeline-trigger.yaml
@@ -78,3 +78,14 @@ spec:
                   limits:
                     cpu: 500m
                     memory: 256Mi
+                env:
+                - name: TLS_CERT
+                  valueFrom:
+                    secretKeyRef:
+                      key: tls.crt
+                      name: cad-event-listener-tls-secret
+                - name: TLS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: tls.key
+                      name: cad-event-listener-tls-secret

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -160,7 +160,18 @@ objects:
           template:
             spec:
               containers:
-              - resources:
+              - env:
+                - name: TLS_CERT
+                  valueFrom:
+                    secretKeyRef:
+                      key: tls.crt
+                      name: cad-event-listener-tls-secret
+                - name: TLS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: tls.key
+                      name: cad-event-listener-tls-secret
+                resources:
                   limits:
                     cpu: 500m
                     memory: 256Mi


### PR DESCRIPTION
We need this to move CAD to a private cluster:
- LB service directly pointing at tekton event listener
- event listener is responsible for TLS termination
- added certificate needed by evente listener (ClusterIssuer should already be there)

