### PR TITLE
Make dependabot work with multinode repo due to interceptor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: 'gomod'
-    directory: '/'
+    directories:
+      - '/'
+      - 'interceptor/'
     allow:
       - dependency-type: all
-      - dependency-name: "github.com/openshift/osd-network-verifier"
     schedule:
       interval: 'daily'
   - package-ecosystem: "docker"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   - package-ecosystem: 'gomod'
     directory: '/'
     allow:
+      - dependency-type: all
       - dependency-name: "github.com/openshift/osd-network-verifier"
     schedule:
       interval: 'daily'


### PR DESCRIPTION
Our sub module interceptor requires to be updated ( might just be go mod tidy? ) when the outer mod receives updates.
See https://github.com/dependabot/dependabot-core/issues/6678