### PR TITLE
Add hotfix for network verifier LS

### DIFF
--- a/pkg/investigations/chgm/util.go
+++ b/pkg/investigations/chgm/util.go
@@ -23,8 +23,8 @@ func createEgressSL(blockedUrls string) *ocm.ServiceLog {
 
 func createEgressLS(blockedUrls string) *ocm.LimitedSupportReason {
 	details := fmt.Sprintf("Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#", blockedUrls)
-	details = strings.ReplaceAll(details, "(", "'")
-	details = strings.ReplaceAll(details, ")", "'")
+	details = strings.ReplaceAll(details, "(", "")
+	details = strings.ReplaceAll(details, ")", "")
 	egressLS := ocm.LimitedSupportReason{
 		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",
 		Details: details,

--- a/pkg/investigations/chgm/util_test.go
+++ b/pkg/investigations/chgm/util_test.go
@@ -29,7 +29,7 @@ func TestCreateEgressSL(t *testing.T) {
 
 // TestCreateEgressLS tests the createEgressLS function
 func TestCreateEgressLS(t *testing.T) {
-	expectedDetails := "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: example.com 'timeout', test.com 'timeout'. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#"
+	expectedDetails := "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: example.com timeout, test.com timeout. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#"
 
 	expected := &ocm.LimitedSupportReason{
 		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-27300

we need to remove the paranthesis to be able to send of the limited support on network failures