### PR TITLE
Revert "Add loadbalancer service to the pipeline trigger"

### DIFF
--- a/deploy/pipeline-trigger.yaml
+++ b/deploy/pipeline-trigger.yaml
@@ -62,14 +62,11 @@ metadata:
   name: cad-event-listener
   annotations:
     triggers.tekton.dev/old-escape-quotes: "true"
-    service.beta.kubernetes.io/load-balancer-source-ranges: 44.242.69.192/32,52.89.71.166/32,54.213.187.133/32,35.86.21.47/32,52.88.94.18/32,44.238.89.29/32,54.241.68.46/32,54.176.72.216/32,54.177.81.67/32,13.56.49.27/32,34.210.57.30/32,34.210.242.134/32,52.34.208.156/32,18.192.91.93/32,18.158.120.237/32,18.194.177.30/32,18.158.199.216/32,3.126.25.87/32,18.197.187.16/32,54.76.3.62/32,54.170.2.90/32,52.213.188.110/32,54.195.179.238/32,34.250.91.200/32,54.76.225.71/32
-    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
 spec:
   triggers:
   - triggerRef: cad-pipe-listener
   resources:
     kubernetesResource:
-      serviceType: LoadBalancer
       spec:
         template:
           spec:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -151,14 +151,11 @@ objects:
   kind: EventListener
   metadata:
     annotations:
-      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-      service.beta.kubernetes.io/load-balancer-source-ranges: 44.242.69.192/32,52.89.71.166/32,54.213.187.133/32,35.86.21.47/32,52.88.94.18/32,44.238.89.29/32,54.241.68.46/32,54.176.72.216/32,54.177.81.67/32,13.56.49.27/32,34.210.57.30/32,34.210.242.134/32,52.34.208.156/32,18.192.91.93/32,18.158.120.237/32,18.194.177.30/32,18.158.199.216/32,3.126.25.87/32,18.197.187.16/32,54.76.3.62/32,54.170.2.90/32,52.213.188.110/32,54.195.179.238/32,34.250.91.200/32,54.76.225.71/32
       triggers.tekton.dev/old-escape-quotes: "true"
     name: cad-event-listener
   spec:
     resources:
       kubernetesResource:
-        serviceType: LoadBalancer
         spec:
           template:
             spec:


### PR DESCRIPTION
This reverts commit ed6f585f882ceb9539e96b5734f3d1cd63dd9f18.

The load balancer is created in app-interface separately from tekton. The reasoning for this:
- lack of tekton documentation on the topic
- we risk having the loadbalancer deleted by app-interface due to the annotation inheritance done by tekton, this is not an issue for most resources but for load balancers we map DNS entries to, it's a big deal
- we'll keep the deployment details apart from the code repo (although we have not done this in the past..)