### PR TITLE
Align network misconfig LS message

### DIFF
--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -82,7 +82,12 @@ func Investigate(r *investigation.Resources) error {
 		logging.Infof("Network verifier reported failure: %s", failureReason)
 
 		if strings.Contains(failureReason, "nosnch.in") {
-			err := r.OcmClient.PostLimitedSupportReason(createEgressLS(), r.Cluster.ID())
+			egressLS := ocm.LimitedSupportReason{
+				Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",
+				Details: "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#",
+			}
+
+			err := r.OcmClient.PostLimitedSupportReason(&egressLS, r.Cluster.ID())
 			if err != nil {
 				return err
 			}

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -32,6 +32,11 @@ var (
 		Description:  "Your cluster is no longer checking in with Red Hat OpenShift Cluster Manager. Possible causes include stopped instances or a networking misconfiguration. If you have stopped the cluster instances, please start them again - stopping instances is not supported. If you intended to terminate this cluster then please delete the cluster in the Red Hat console",
 		InternalOnly: false,
 	}
+
+	egressLS = ocm.LimitedSupportReason{
+		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",
+		Details: "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#",
+	}
 )
 
 // Investigate runs the investigation for a triggered chgm pagerduty event
@@ -82,11 +87,6 @@ func Investigate(r *investigation.Resources) error {
 		logging.Infof("Network verifier reported failure: %s", failureReason)
 
 		if strings.Contains(failureReason, "nosnch.in") {
-			egressLS := ocm.LimitedSupportReason{
-				Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",
-				Details: "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#",
-			}
-
 			err := r.OcmClient.PostLimitedSupportReason(&egressLS, r.Cluster.ID())
 			if err != nil {
 				return err

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -82,7 +82,7 @@ func Investigate(r *investigation.Resources) error {
 		logging.Infof("Network verifier reported failure: %s", failureReason)
 
 		if strings.Contains(failureReason, "nosnch.in") {
-			err := r.OcmClient.PostLimitedSupportReason(createEgressLS(failureReason), r.Cluster.ID())
+			err := r.OcmClient.PostLimitedSupportReason(createEgressLS(), r.Cluster.ID())
 			if err != nil {
 				return err
 			}

--- a/pkg/investigations/chgm/util.go
+++ b/pkg/investigations/chgm/util.go
@@ -20,8 +20,8 @@ func createEgressSL(blockedUrls string) *ocm.ServiceLog {
 	return &egressSL
 }
 
-func createEgressLS(blockedUrls string) *ocm.LimitedSupportReason {
-	details := fmt.Sprintf("Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#", blockedUrls)
+func createEgressLS() *ocm.LimitedSupportReason {
+	details := "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#"
 
 	egressLS := ocm.LimitedSupportReason{
 		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",

--- a/pkg/investigations/chgm/util.go
+++ b/pkg/investigations/chgm/util.go
@@ -19,14 +19,3 @@ func createEgressSL(blockedUrls string) *ocm.ServiceLog {
 
 	return &egressSL
 }
-
-func createEgressLS() *ocm.LimitedSupportReason {
-	details := "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#"
-
-	egressLS := ocm.LimitedSupportReason{
-		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",
-		Details: details,
-	}
-
-	return &egressLS
-}

--- a/pkg/investigations/chgm/util_test.go
+++ b/pkg/investigations/chgm/util_test.go
@@ -32,16 +32,13 @@ func TestCreateEgressSL(t *testing.T) {
 
 // TestCreateEgressLS tests the createEgressLS function
 func TestCreateEgressLS(t *testing.T) {
-	expectedDetails := fmt.Sprintf(
-		"Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: %s. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#",
-		blockedUrls,
-	)
+	expectedDetails := "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#"
 
 	expected := &ocm.LimitedSupportReason{
 		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",
 		Details: expectedDetails,
 	}
 
-	result := createEgressLS(blockedUrls)
+	result := createEgressLS()
 	assert.Equal(t, *expected, *result)
 }

--- a/pkg/investigations/chgm/util_test.go
+++ b/pkg/investigations/chgm/util_test.go
@@ -29,16 +29,3 @@ func TestCreateEgressSL(t *testing.T) {
 	result := createEgressSL(blockedUrls)
 	assert.Equal(t, *expected, *result)
 }
-
-// TestCreateEgressLS tests the createEgressLS function
-func TestCreateEgressLS(t *testing.T) {
-	expectedDetails := "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#"
-
-	expected := &ocm.LimitedSupportReason{
-		Summary: "Cluster is in Limited Support due to unsupported cloud provider configuration",
-		Details: expectedDetails,
-	}
-
-	result := createEgressLS()
-	assert.Equal(t, *expected, *result)
-}


### PR DESCRIPTION
Solves failing to post LS on network misconfigs https://issues.redhat.com/browse/OSD-27300

The limitedsupport message defined here https://github.com/openshift/managed-notifications/blob/master/osd/limited_support/egressFailureLimitedSupport.json
does no longer include the blocked URLs, so we remove it here as well.  
Since networkverifier >= 1.0 the errors include parenthesis which break the current behavior ( as LS api does not allow for them, see https://issues.redhat.com/browse/OCM-13249 )