### PR TITLE
Add metadata file to first investigation using backplane remediations

### DIFF
--- a/pkg/investigations/clustermonitoringerrorbudgetburn/metadata.yaml
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/metadata.yaml
@@ -1,0 +1,12 @@
+name: clustermonitoringerrorbudgetburn
+rbac:
+  roles: []
+  clusterRoleRules:
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "config.openshift.io"
+      resources:
+        - clusteroperators
+customerDataAccess: false


### PR DESCRIPTION
See [SDE-3270](https://issues.redhat.com//browse/SDE-3270) for backplane remediations. 
We use the rbac in the metadata to create rbac on cluster and let cad use the kube-api for its investigation.