### PR TITLE
Feat: route CAD_EXPERIMENTAL_ENABLED flag

### DIFF
--- a/deploy/interceptor.yaml
+++ b/deploy/interceptor.yaml
@@ -22,6 +22,9 @@ spec:
         envFrom:
         - secretRef:
             name: cad-pd-token
+        env:
+        - name: CAD_EXPERIMENTAL_ENABLED
+          value: ${CAD_EXPERIMENTAL_ENABLED}
         resources:
           limits:
             cpu: "100m"

--- a/deploy/task-cad-checks.yaml
+++ b/deploy/task-cad-checks.yaml
@@ -30,6 +30,8 @@ spec:
       env:
         - name: CAD_PROMETHEUS_PUSHGATEWAY
           value: aggregation-pushgateway:9091
+        - name: CAD_EXPERIMENTAL_ENABLED
+          value: ${CAD_EXPERIMENTAL_ENABLED}
       # envFrom should pull all the secret information as envvars, so key names should be uppercase
       envFrom:
         - secretRef:

--- a/hack/update-template/main.go
+++ b/hack/update-template/main.go
@@ -31,6 +31,7 @@ var saasTemplateFile = Template{
 		{Name: "IMAGE_TAG", Value: "v0.0.0"},
 		{Name: "REGISTRY_IMG", Value: "quay.io/app-sre/configuration-anomaly-detection"},
 		{Name: "NAMESPACE_NAME", Value: "configuration-anomaly-detection"},
+		{Name: "CAD_EXPERIMENTAL_ENABLED", Value: "FALSE"},
 	},
 }
 

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -9,6 +9,8 @@ parameters:
   value: quay.io/app-sre/configuration-anomaly-detection
 - name: NAMESPACE_NAME
   value: configuration-anomaly-detection
+- name: CAD_EXPERIMENTAL_ENABLED
+  value: "FALSE"
 objects:
 - apiVersion: apps/v1
   kind: Deployment
@@ -30,6 +32,9 @@ objects:
           command:
           - /bin/bash
           - -c
+          env:
+          - name: CAD_EXPERIMENTAL_ENABLED
+            value: ${CAD_EXPERIMENTAL_ENABLED}
           envFrom:
           - secretRef:
               name: cad-pd-token
@@ -312,6 +317,8 @@ objects:
       env:
       - name: CAD_PROMETHEUS_PUSHGATEWAY
         value: aggregation-pushgateway:9091
+      - name: CAD_EXPERIMENTAL_ENABLED
+        value: ${CAD_EXPERIMENTAL_ENABLED}
       envFrom:
       - secretRef:
           name: cad-aws-credentials


### PR DESCRIPTION
This PR routes the CAD_EXPERIMENTAL_ENABLED flag through the deployment to allow enabling and disabling it via the saas file in app-interface.