### PR TITLE
Feat(OSD-27979): remove escalation policy and replace by escalating to the next level

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ Grafana dashboard configmaps are stored in the [Dashboards](./dashboards/) direc
 * `AWS_SECRET_ACCESS_KEY`: refers to the secret access key of the base AWS account used by CAD
 * `CAD_AWS_CSS_JUMPROLE`:  refers to the arn of the RH-SRE-CCS-Access jumprole
 * `CAD_AWS_SUPPORT_JUMPROLE`: refers to the arn of the RH-Technical-Support-Access jumprole
-* `CAD_ESCALATION_POLICY`:  refers to the escalation policy CAD should use to escalate the incident to
 * `CAD_PD_EMAIL`: refers  to the email for a login via mail/pw credentials
 * `CAD_PD_PW`: refers to the password for a login via mail/pw credentials
 * `CAD_PD_TOKEN`: refers to the generated private access token for token-based authentication

--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -75,7 +75,7 @@ func run(_ *cobra.Command, _ []string) error {
 
 	// Escalate all unsupported alerts
 	if alertInvestigation == nil {
-		err = pdClient.EscalateAlert()
+		err = pdClient.EscalateIncident()
 		if err != nil {
 			return fmt.Errorf("could not escalate unsupported alert: %w", err)
 		}
@@ -152,12 +152,12 @@ func GetOCMClient() (*ocm.SdkClient, error) {
 func clusterRequiresInvestigation(cluster *cmv1.Cluster, pdClient *pagerduty.SdkClient, ocmClient *ocm.SdkClient) (bool, error) {
 	if cluster.State() == cmv1.ClusterStateUninstalling {
 		logging.Info("Cluster is uninstalling and requires no investigation. Silencing alert.")
-		return false, pdClient.SilenceAlertWithNote("CAD: Cluster is already uninstalling, silencing alert.")
+		return false, pdClient.SilenceIncidentWithNote("CAD: Cluster is already uninstalling, silencing alert.")
 	}
 
 	if cluster.AWS() == nil {
 		logging.Info("Cloud provider unsupported, forwarding to primary.")
-		return false, pdClient.EscalateAlertWithNote("CAD could not run an automated investigation on this cluster: unsupported cloud provider.")
+		return false, pdClient.EscalateIncidentWithNote("CAD could not run an automated investigation on this cluster: unsupported cloud provider.")
 	}
 
 	isAccessProtected, err := ocmClient.IsAccessProtected(cluster)
@@ -166,7 +166,7 @@ func clusterRequiresInvestigation(cluster *cmv1.Cluster, pdClient *pagerduty.Sdk
 	}
 	if isAccessProtected {
 		logging.Info("Cluster is access protected. Escalating alert.")
-		return false, pdClient.EscalateAlertWithNote("CAD is unable to run against access protected clusters. Please investigate.")
+		return false, pdClient.EscalateIncidentWithNote("CAD is unable to run against access protected clusters. Please investigate.")
 	}
 	return true, nil
 }

--- a/deploy/task-cad-checks-secrets-pd.yaml
+++ b/deploy/task-cad-checks-secrets-pd.yaml
@@ -5,7 +5,6 @@ metadata:
   name: cad-pd-token
 type: Opaque
 stringData:
-  CAD_ESCALATION_POLICY: CHANGEME # refers to the escalation policy CAD should use to escalate the incident to
   CAD_PD_EMAIL: CHANGEME # refers  to the email for a login via mail/pw credentials
   CAD_PD_PW: CHANGEME # refers to the password for a login via mail/pw credentials
   CAD_PD_TOKEN: CHANGEME # refers to the generated private access token for token-based authentication

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -111,7 +111,7 @@ func (pdi *PagerDutyInterceptor) Process(ctx context.Context, r *triggersv1.Inte
 	// and escalate the alert to SRE
 	if investigation == nil {
 		pdi.Logger.Infof("Incident %s is not mapped to an investigation, escalating incident and returning InterceptorResponse `Continue: false`.", pdClient.GetIncidentID())
-		err = pdClient.EscalateAlert()
+		err = pdClient.EscalateIncident()
 		if err != nil {
 			pdi.Logger.Errorf("failed to escalate incident '%s': %w", pdClient.GetIncidentID(), err)
 		}

--- a/interceptor/test/e2e.sh
+++ b/interceptor/test/e2e.sh
@@ -18,7 +18,7 @@ temp_log_file=$(mktemp)
 # Function to send an interceptor request and check the response
 function test_interceptor {
     # Run the interceptor and print logs to temporary log file
-    CAD_PD_TOKEN=$(echo $pd_test_token) CAD_ESCALATION_POLICY=$(echo $pd_test_escalation_policy) CAD_SILENT_POLICY=$(echo $pd_test_silence_policy) ./../bin/interceptor > $temp_log_file  2>&1 &
+    CAD_PD_TOKEN=$(echo $pd_test_token) CAD_SILENT_POLICY=$(echo $pd_test_silence_policy) ./../bin/interceptor > $temp_log_file  2>&1 &
     
     # Store the PID of the interceptor process
     INTERCEPTOR_PID=$!

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -279,7 +279,6 @@ objects:
   metadata:
     name: cad-pd-token
   stringData:
-    CAD_ESCALATION_POLICY: CHANGEME
     CAD_PD_EMAIL: CHANGEME
     CAD_PD_PW: CHANGEME
     CAD_PD_TOKEN: CHANGEME

--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -43,14 +43,14 @@ func Evaluate(cluster *cmv1.Cluster, bpError error, ocmClient ocm.Client, pdClie
 			return fmt.Errorf("could not post limited support reason for %s: %w", cluster.Name(), err)
 		}
 
-		return pdClient.SilenceAlertWithNote(fmt.Sprintf("Added the following Limited Support reason to cluster: %#v. Silencing alert.\n", ccamLimitedSupport))
+		return pdClient.SilenceIncidentWithNote(fmt.Sprintf("Added the following Limited Support reason to cluster: %#v. Silencing alert.\n", ccamLimitedSupport))
 	case cmv1.ClusterStateUninstalling:
 		// A cluster in uninstalling state should not alert primary - we just skip this
-		return pdClient.SilenceAlertWithNote(fmt.Sprintf("Skipped adding limited support reason '%s': cluster is already uninstalling.", ccamLimitedSupport.Summary))
+		return pdClient.SilenceIncidentWithNote(fmt.Sprintf("Skipped adding limited support reason '%s': cluster is already uninstalling.", ccamLimitedSupport.Summary))
 	default:
 		// Anything else is an unknown state to us and/or requires investigation.
 		// E.g. we land here if we run into a CPD alert where credentials were removed (installing state) and don't want to put it in LS yet.
-		return pdClient.EscalateAlertWithNote(fmt.Sprintf("Cluster has invalid cloud credentials (support role/policy is missing) and the cluster is in state '%s'. Please investigate.", cluster.State()))
+		return pdClient.EscalateIncidentWithNote(fmt.Sprintf("Cluster has invalid cloud credentials (support role/policy is missing) and the cluster is in state '%s'. Please investigate.", cluster.State()))
 	}
 }
 

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -46,7 +46,7 @@ func Investigate(r *investigation.Resources) error {
 	// 1. Check if the user stopped instances
 	res, err := investigateStoppedInstances(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 	if err != nil {
-		return r.PdClient.EscalateAlertWithNote(fmt.Sprintf("InvestigateInstances failed: %s\n", err.Error()))
+		return r.PdClient.EscalateIncidentWithNote(fmt.Sprintf("InvestigateInstances failed: %s\n", err.Error()))
 	}
 	logging.Debugf("the investigation returned: [infras running: %d] - [masters running: %d]", res.RunningInstances.Infra, res.RunningInstances.Master)
 
@@ -95,7 +95,7 @@ func Investigate(r *investigation.Resources) error {
 			metrics.Inc(metrics.LimitedSupportSet, investigationName, "EgressBlocked")
 
 			notes.AppendAutomation("Egress `nosnch.in` blocked, sent limited support.")
-			return r.PdClient.SilenceAlertWithNote(notes.String())
+			return r.PdClient.SilenceIncidentWithNote(notes.String())
 		}
 
 		err := r.OcmClient.PostServiceLog(r.Cluster.ID(), createEgressSL(failureReason))
@@ -112,7 +112,7 @@ func Investigate(r *investigation.Resources) error {
 	}
 
 	// Found no issues that CAD can handle by itself - forward notes to SRE.
-	return r.PdClient.EscalateAlertWithNote(notes.String())
+	return r.PdClient.EscalateIncidentWithNote(notes.String())
 }
 
 // investigateHibernation checks if the cluster was recently woken up from
@@ -439,5 +439,5 @@ func postChgmSLAndSilence(clusterID string, ocmCli ocm.Client, pdCli pagerduty.C
 		return fmt.Errorf("failed sending service log: %w", err)
 	}
 
-	return pdCli.SilenceAlertWithNote("Customer stopped instances. Sent SL and silencing alert.")
+	return pdCli.SilenceIncidentWithNote("Customer stopped instances. Sent SL and silencing alert.")
 }

--- a/pkg/investigations/chgm/chgm_test.go
+++ b/pkg/investigations/chgm/chgm_test.go
@@ -105,7 +105,7 @@ var _ = Describe("chgm", func() {
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(&chgmSL)).Return(nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any())
+				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceIncidentWithNote(gomock.Any())
 
 				gotErr := Investigate(r)
 
@@ -124,7 +124,7 @@ var _ = Describe("chgm", func() {
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(&chgmSL)).Return(nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any())
+				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceIncidentWithNote(gomock.Any())
 
 				gotErr := Investigate(r)
 
@@ -134,7 +134,7 @@ var _ = Describe("chgm", func() {
 		When("Triggered errors", func() {
 			It("should update the incident notes and escalate to primary", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().ListNonRunningInstances(gomock.Any()).Return(nil, fakeErr)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 
@@ -149,7 +149,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 				gotErr := Investigate(r)
 				// Assert
@@ -163,7 +163,7 @@ var _ = Describe("chgm", func() {
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return(nil, fakeErr)
 
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).ToNot(HaveOccurred())
@@ -176,7 +176,7 @@ var _ = Describe("chgm", func() {
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetClusterMachinePools(gomock.Any()).Return(machinePools, nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().ListNonRunningInstances(gomock.Eq(infraID)).Return([]ec2v2types.Instance{instance}, nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 
 				// Act
 				gotErr := Investigate(r)
@@ -191,7 +191,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = awsv2.String(`{"eventVersion":"1.08", "userIdentity":{"type":"AssumedRole", "sessionContext":{"sessionIssuer":{"type":"Role", "userName": "654321"}}}}`)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(&chgmSL)).Return(nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceIncidentWithNote(gomock.Any()).Return(nil)
 				// Act
 				gotErr := Investigate(r)
 				// Assert
@@ -209,7 +209,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -226,7 +226,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -244,7 +244,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Any(), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -262,7 +262,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -279,7 +279,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -296,7 +296,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -313,7 +313,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -330,7 +330,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -347,7 +347,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -364,7 +364,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSecurityGroupID(gomock.Eq(infraID)).Return(gomock.Any().String(), nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetAWSCredentials().Return(aws.Credentials{})
 				r.AwsClient.(*awsmock.MockClient).EXPECT().GetSubnetID(gomock.Eq(infraID)).Return([]string{"string1", "string2"}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().GetServiceLog(gomock.Eq(cluster), gomock.Eq("log_type='cluster-state-updates'")).Return(&servicelogsv1.ClusterLogsUUIDListResponse{}, nil)
 
 				gotErr := Investigate(r)
@@ -379,7 +379,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = awsv2.String(`{"eventVersion":"1.08", "userIdentity":{}}`)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(&chgmSL)).Return(nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -393,7 +393,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = awsv2.String(`{"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"REDACTED:OCM","arn":"arn:aws:sts::1234:assumed-role/testuser/OCM","accountId":"1234","accessKeyId":"REDACTED","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"REDACTED","arn":"arn:aws:iam::1234:role/testuser","accountId":"1234","userName":"testuser"},"webIdFederationData":{},"attributes":{"creationDate":"2023-02-21T04:08:01Z","mfaAuthenticated":"false"}}},"eventTime":"2023-02-21T04:10:40Z","eventSource":"ec2v2types.amazonawsv2.com","eventName":"TerminateInstances","awsRegion":"ap-southeast-1","sourceIPAddress":"192.168.0.0","userAgent":"aws-sdk-go-v2/1.17.3 os/linux lang/go/1.19.5 md/GOOS/linux md/GOARCH/amd64 api/ec2/1.25.0","requestParameters":{"instancesSet":{"items":[{"instanceId":"i-00c1f1234567"}]}},"responseElements":{"requestId":"credacted","instancesSet":{"items":[{"instanceId":"i-00c1f1234567","currentState":{"code":32,"name":"shutting-down"},"previousState":{"code":16,"name":"running"}}]}},"requestID":"credacted","eventID":"e55a8a64-9949-47a9-9fff-12345678","readOnly":false,"eventType":"AwsApiCall","managementEvent":true,"recipientAccountId":"1234","eventCategory":"Management","tlsDetails":{"tlsVersion":"TLSv1.2","cipherSuite":"ECDHE-RSA-AES128-GCM-SHA256","clientProvidedHostHeader":"ec2v2types.ap-southeast-1.amazonawsv2.com"}}`)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(&chgmSL)).Return(nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -407,7 +407,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = awsv2.String(`{"eventVersion":"1.08", "userIdentity":{"type":"AssumedRole", "sessionContext":{"sessionIssuer":{"type":"test"}}}}`)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(&chgmSL)).Return(nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -420,7 +420,7 @@ var _ = Describe("chgm", func() {
 				r.AwsClient.(*awsmock.MockClient).EXPECT().ListRunningInstances(gomock.Eq(infraID)).Return([]ec2v2types.Instance{instance}, nil)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(&chgmSL)).Return(nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -435,7 +435,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = awsv2.String(`{"eventVersion":"1.08", "userIdentity":{}}`)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(&chgmSL)).Return(nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -450,7 +450,7 @@ var _ = Describe("chgm", func() {
 				event.CloudTrailEvent = awsv2.String(`{"eventVersion":"1.08", "userIdentity":{"type":"IAMUser"}}`)
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
 				r.OcmClient.(*ocmmock.MockClient).EXPECT().PostServiceLog(gomock.Eq(cluster.ID()), gomock.Eq(&chgmSL)).Return(nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().SilenceIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -465,7 +465,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrailv2types.Resource{ResourceName: awsv2.String("123456")}
 				event.Resources = []cloudtrailv2types.Resource{cloudTrailResource}
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -480,7 +480,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrailv2types.Resource{ResourceName: awsv2.String("123456")}
 				event.Resources = []cloudtrailv2types.Resource{cloudTrailResource}
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -495,7 +495,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrailv2types.Resource{ResourceName: awsv2.String("123456")}
 				event.Resources = []cloudtrailv2types.Resource{cloudTrailResource}
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -510,7 +510,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrailv2types.Resource{ResourceName: awsv2.String("123456")}
 				event.Resources = []cloudtrailv2types.Resource{cloudTrailResource}
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())
@@ -525,7 +525,7 @@ var _ = Describe("chgm", func() {
 				cloudTrailResource := cloudtrailv2types.Resource{ResourceName: awsv2.String("123456")}
 				event.Resources = []cloudtrailv2types.Resource{cloudTrailResource}
 				r.AwsClient.(*awsmock.MockClient).EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return([]cloudtrailv2types.Event{event}, nil)
-				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateAlertWithNote(gomock.Any()).Return(nil)
+				r.PdClient.(*pdmock.MockClient).EXPECT().EscalateIncidentWithNote(gomock.Any()).Return(nil)
 
 				gotErr := Investigate(r)
 				Expect(gotErr).NotTo(HaveOccurred())

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -57,13 +57,13 @@ func Investigate(r *investigation.Resources) error {
 			return fmt.Errorf("failed posting servicelog: %w", err)
 		}
 
-		return r.PdClient.SilenceAlertWithNote(notes.String())
+		return r.PdClient.SilenceIncidentWithNote(notes.String())
 	}
 
 	// The UWM configmap is valid, an SRE will need to manually investigate this alert.
 	// Escalate the alert with our findings.
 	notes.AppendSuccess("Monitoring CO not degraded due to a broken UWM configmap")
-	return r.PdClient.EscalateAlertWithNote(notes.String())
+	return r.PdClient.EscalateIncidentWithNote(notes.String())
 }
 
 // Check if the `Available` status condition reports a broken UWM config

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -35,7 +35,7 @@ func Investigate(r *investigation.Resources) error {
 		// We currently believe this never happens, but want to be made aware if it does.
 		notes.AppendWarning("This cluster is in a ready state, thus provisioning succeeded. Please contact CAD team to investigate if we can just silence this case in the future")
 
-		return r.PdClient.EscalateAlertWithNote(notes.String())
+		return r.PdClient.EscalateIncidentWithNote(notes.String())
 	}
 	notes.AppendSuccess("Cluster installation did not yet finish")
 
@@ -44,14 +44,14 @@ func Investigate(r *investigation.Resources) error {
 		// In case this happens on production, we want to raise this to OCM/CS.
 		notes.AppendWarning("This cluster has an empty ClusterDeployment.Spec.ClusterMetadata, meaning that the provisioning failed before the installation started. This is usually the case when the install configuration is faulty. Please investigate manually.")
 
-		return r.PdClient.EscalateAlertWithNote(notes.String())
+		return r.PdClient.EscalateIncidentWithNote(notes.String())
 	}
 	notes.AppendSuccess("Installation hive job started")
 
 	// Check if DNS is ready, exit out if not
 	if !r.Cluster.Status().DNSReady() {
 		notes.AppendWarning("DNS not ready.\nInvestigate reasons using the dnszones CR in the cluster namespace:\noc get dnszones -n uhc-production-%s -o yaml --as backplane-cluster-admin", r.Cluster.ID())
-		return r.PdClient.EscalateAlertWithNote(notes.String())
+		return r.PdClient.EscalateIncidentWithNote(notes.String())
 	}
 	notes.AppendSuccess("Cluster DNS is ready")
 
@@ -74,7 +74,7 @@ func Investigate(r *investigation.Resources) error {
 					logging.Error(err)
 				}
 
-				return r.PdClient.SilenceAlert()
+				return r.PdClient.SilenceIncident()
 			}
 		}
 	}
@@ -113,7 +113,7 @@ func Investigate(r *investigation.Resources) error {
 
 	// We currently always escalate, in the future, when network verifier is reliable,
 	// we would silence the alert when we had a service log in the case of network verifier detecting failures.
-	return r.PdClient.EscalateAlert()
+	return r.PdClient.EscalateIncident()
 }
 
 func isSubnetRouteValid(awsClient aws.Client, subnetID string) (bool, error) {

--- a/pkg/pagerduty/mock/pagerdutymock.go
+++ b/pkg/pagerduty/mock/pagerdutymock.go
@@ -12,7 +12,6 @@ package pdmock
 import (
 	reflect "reflect"
 
-	pagerduty "github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -54,46 +53,32 @@ func (mr *MockClientMockRecorder) AddNote(notes any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNote", reflect.TypeOf((*MockClient)(nil).AddNote), notes)
 }
 
-// CreateNewAlert mocks base method.
-func (m *MockClient) CreateNewAlert(newAlert pagerduty.NewAlert, serviceID string) error {
+// EscalateIncident mocks base method.
+func (m *MockClient) EscalateIncident() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNewAlert", newAlert, serviceID)
+	ret := m.ctrl.Call(m, "EscalateIncident")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreateNewAlert indicates an expected call of CreateNewAlert.
-func (mr *MockClientMockRecorder) CreateNewAlert(newAlert, serviceID any) *gomock.Call {
+// EscalateIncident indicates an expected call of EscalateIncident.
+func (mr *MockClientMockRecorder) EscalateIncident() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewAlert", reflect.TypeOf((*MockClient)(nil).CreateNewAlert), newAlert, serviceID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EscalateIncident", reflect.TypeOf((*MockClient)(nil).EscalateIncident))
 }
 
-// EscalateAlert mocks base method.
-func (m *MockClient) EscalateAlert() error {
+// EscalateIncidentWithNote mocks base method.
+func (m *MockClient) EscalateIncidentWithNote(notes string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EscalateAlert")
+	ret := m.ctrl.Call(m, "EscalateIncidentWithNote", notes)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// EscalateAlert indicates an expected call of EscalateAlert.
-func (mr *MockClientMockRecorder) EscalateAlert() *gomock.Call {
+// EscalateIncidentWithNote indicates an expected call of EscalateIncidentWithNote.
+func (mr *MockClientMockRecorder) EscalateIncidentWithNote(notes any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EscalateAlert", reflect.TypeOf((*MockClient)(nil).EscalateAlert))
-}
-
-// EscalateAlertWithNote mocks base method.
-func (m *MockClient) EscalateAlertWithNote(notes string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EscalateAlertWithNote", notes)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EscalateAlertWithNote indicates an expected call of EscalateAlertWithNote.
-func (mr *MockClientMockRecorder) EscalateAlertWithNote(notes any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EscalateAlertWithNote", reflect.TypeOf((*MockClient)(nil).EscalateAlertWithNote), notes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EscalateIncidentWithNote", reflect.TypeOf((*MockClient)(nil).EscalateIncidentWithNote), notes)
 }
 
 // GetServiceID mocks base method.
@@ -110,30 +95,30 @@ func (mr *MockClientMockRecorder) GetServiceID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceID", reflect.TypeOf((*MockClient)(nil).GetServiceID))
 }
 
-// SilenceAlert mocks base method.
-func (m *MockClient) SilenceAlert() error {
+// SilenceIncident mocks base method.
+func (m *MockClient) SilenceIncident() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SilenceAlert")
+	ret := m.ctrl.Call(m, "SilenceIncident")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SilenceAlert indicates an expected call of SilenceAlert.
-func (mr *MockClientMockRecorder) SilenceAlert() *gomock.Call {
+// SilenceIncident indicates an expected call of SilenceIncident.
+func (mr *MockClientMockRecorder) SilenceIncident() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SilenceAlert", reflect.TypeOf((*MockClient)(nil).SilenceAlert))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SilenceIncident", reflect.TypeOf((*MockClient)(nil).SilenceIncident))
 }
 
-// SilenceAlertWithNote mocks base method.
-func (m *MockClient) SilenceAlertWithNote(notes string) error {
+// SilenceIncidentWithNote mocks base method.
+func (m *MockClient) SilenceIncidentWithNote(notes string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SilenceAlertWithNote", notes)
+	ret := m.ctrl.Call(m, "SilenceIncidentWithNote", notes)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SilenceAlertWithNote indicates an expected call of SilenceAlertWithNote.
-func (mr *MockClientMockRecorder) SilenceAlertWithNote(notes any) *gomock.Call {
+// SilenceIncidentWithNote indicates an expected call of SilenceIncidentWithNote.
+func (mr *MockClientMockRecorder) SilenceIncidentWithNote(notes any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SilenceAlertWithNote", reflect.TypeOf((*MockClient)(nil).SilenceAlertWithNote), notes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SilenceIncidentWithNote", reflect.TypeOf((*MockClient)(nil).SilenceIncidentWithNote), notes)
 }


### PR DESCRIPTION
Previously, CAD had a separate escalation policy for the prod-deadmanssnitch and app-sre-alertmanager services. To escalate to SRE, it re-assigned to the SRE Platform Oncall escalation policy.

Now CAD is the first level in the SRE Platform Oncall escalation policy, if it re-assigns to that same policy, we introduce a 15 min delay before SRE receive the alert.

Instead of re-assigning to the escalation policy, CAD should use real escalation: escalating to the next level.

Additionally, this PR:
- updates naming of the pagerduty term `alert` to `incident` for consistency with pagerduty
- removes unused functions in `pagerduty.go`

Needed for: https://issues.redhat.com/browse/SDE-4177 
Implements: https://issues.redhat.com/browse/OSD-27979 