### PR TITLE
Cleanup k8s

### DIFF
--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -27,6 +27,11 @@ var uwmMisconfiguredSL = ocm.ServiceLog{
 
 func Investigate(r *investigation.Resources) (investigation.InvestigationResult, error) {
 	// Initialize k8s client
+	// This would be better suited to be passend in with the investigation resources
+	// In turn we would need to split out ccam and k8sclient, as those are tied to a cluster
+	// Failing the cleanup call is not critical as there is garbage collection for the RBAC within MCC https://issues.redhat.com/browse/OSD-27692
+	// We can revisit backplane-apis remediation implementation to improve this behavior, by e.g.
+	// patching the existing RBAC etc...
 	result := investigation.InvestigationResult{}
 	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient, r.Name)
 	if err != nil {

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -32,6 +32,14 @@ func New(clusterID string, ocmClient ocm.Client, remediation string) (client.Cli
 	return client.New(cfg, client.Options{Scheme: scheme})
 }
 
+func Cleanup(clusterID string, ocmClient ocm.Client, remediation string) error {
+	backplaneURL := os.Getenv("BACKPLANE_URL")
+	if backplaneURL == "" {
+		return fmt.Errorf("could not create new k8sclient: missing environment variable BACKPLANE_URL")
+	}
+	return bpremediation.DeleteRemediationWithConn(config.BackplaneConfiguration{URL: backplaneURL}, ocmClient.GetConnection(), clusterID, remediation)
+}
+
 // Initialize all apis we need in CAD
 func initScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()

--- a/test/set_stage_env.sh
+++ b/test/set_stage_env.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 export VAULT_ADDR="https://vault.devshift.net"
 export VAULT_TOKEN="$(vault login -method=oidc -token-only)"
@@ -12,5 +12,4 @@ unset VAULT_ADDR VAULT_TOKEN
 export CAD_EXPERIMENTAL_ENABLED=true
 export BACKPLANE_PROXY=http://squid.corp.redhat.com:3128
 
-echo
-
+set +euo pipefail


### PR DESCRIPTION
Add the cleanup call to backplane-api to delete investigation RBAC

After the investigation has ended we need to cleanup the created RBAC.
We will have garbage collection via managed-cluster-config in case this
fails. One can also delete it manually with `ocm backplane remediation delete <clusterid> <investigation>` .