### PR TITLE
OSD-28725 - Rename investigation structures to standard name 'Investigation'

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -122,7 +122,7 @@ func run(_ *cobra.Command, _ []string) error {
 	customerAwsClient, err := managedcloud.CreateCustomerAWSClient(cluster, ocmClient)
 	if err != nil {
 		ccamResources := &investigation.Resources{Name: "ccam", Cluster: cluster, ClusterDeployment: clusterDeployment, AwsClient: customerAwsClient, OcmClient: ocmClient, PdClient: pdClient, AdditionalResources: map[string]interface{}{"error": err}}
-		inv := ccam.CCAM{}
+		inv := ccam.Investigation{}
 		result, err := inv.Run(ccamResources)
 		updateMetrics(alertInvestigation.Name(), &result)
 		return err

--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 )
 
-type CCAM struct{}
+type Investigation struct{}
 
 var ccamLimitedSupport = &ocm.LimitedSupportReason{
 	Summary: "Restore missing cloud credentials",
@@ -21,14 +21,14 @@ var ccamLimitedSupport = &ocm.LimitedSupportReason{
 
 // Evaluate estimates if the awsError is a cluster credentials are missing error. If it determines that it is,
 // the cluster is placed into limited support (if the cluster state allows it), otherwise an error is returned.
-func (c *CCAM) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
+func (c *Investigation) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
 	cluster := r.Cluster
 	ocmClient := r.OcmClient
 	pdClient := r.PdClient
 	bpError, ok := r.AdditionalResources["error"].(error)
 	if !ok {
-		return result, fmt.Errorf("Missing required CCAM field 'error'")
+		return result, fmt.Errorf("Missing required Investigation field 'error'")
 	}
 	logging.Info("Investigating possible missing cloud credentials...")
 
@@ -64,19 +64,19 @@ func (c *CCAM) Run(r *investigation.Resources) (investigation.InvestigationResul
 	}
 }
 
-func (c *CCAM) Name() string {
+func (c *Investigation) Name() string {
 	return "Cluster Credentials Are Missing (CCAM)"
 }
 
-func (c *CCAM) Description() string {
+func (c *Investigation) Description() string {
 	return "Detects missing cluster credentials"
 }
 
-func (c *CCAM) ShouldInvestigateAlert(alert string) bool {
+func (c *Investigation) ShouldInvestigateAlert(alert string) bool {
 	return false
 }
 
-func (c *CCAM) IsExperimental() bool {
+func (c *Investigation) IsExperimental() bool {
 	return false
 }
 

--- a/pkg/investigations/ccam/ccam_test.go
+++ b/pkg/investigations/ccam/ccam_test.go
@@ -20,7 +20,7 @@ func TestEvaluateRandomError(t *testing.T) {
 		},
 	}
 
-	inv := CCAM{}
+	inv := Investigation{}
 
 	_, err := inv.Run(&input)
 	if err.Error() != timeoutError.Error() {

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -36,10 +36,10 @@ var (
 	}
 )
 
-type CHGM struct{}
+type Investiation struct{}
 
 // Run runs the investigation for a triggered chgm pagerduty event
-func (c *CHGM) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
+func (c *Investiation) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
 	notes := notewriter.New("CHGM", logging.RawLogger)
 
@@ -118,19 +118,19 @@ func (c *CHGM) Run(r *investigation.Resources) (investigation.InvestigationResul
 	return result, r.PdClient.EscalateIncidentWithNote(notes.String())
 }
 
-func (c *CHGM) Name() string {
+func (c *Investiation) Name() string {
 	return "Cluster Has Gone Missing (CHGM)"
 }
 
-func (c *CHGM) Description() string {
+func (c *Investiation) Description() string {
 	return "Detects reason for clusters that have gone missing"
 }
 
-func (c *CHGM) ShouldInvestigateAlert(alert string) bool {
+func (c *Investiation) ShouldInvestigateAlert(alert string) bool {
 	return strings.Contains(alert, "has gone missing")
 }
 
-func (c *CHGM) IsExperimental() bool {
+func (c *Investiation) IsExperimental() bool {
 	return false
 }
 

--- a/pkg/investigations/chgm/chgm_test.go
+++ b/pkg/investigations/chgm/chgm_test.go
@@ -92,7 +92,7 @@ var _ = Describe("chgm", func() {
 		mockCtrl.Finish()
 	})
 
-	inv := CHGM{}
+	inv := Investiation{}
 
 	Describe("Triggered", func() {
 		When("Triggered finds instances stopped by the customer", func() {

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -25,9 +25,9 @@ var uwmMisconfiguredSL = ocm.ServiceLog{
 	InternalOnly: false,
 }
 
-type CMEBB struct{}
+type Investigation struct{}
 
-func (c *CMEBB) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
+func (c *Investigation) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
 	// Initialize k8s client
 	// This would be better suited to be passend in with the investigation resources
 	// In turn we would need to split out ccam and k8sclient, as those are tied to a cluster
@@ -84,19 +84,19 @@ func (c *CMEBB) Run(r *investigation.Resources) (investigation.InvestigationResu
 	return result, r.PdClient.EscalateIncidentWithNote(notes.String())
 }
 
-func (c *CMEBB) Name() string {
+func (c *Investigation) Name() string {
 	return "clustermonitoringerrorbudgetburn"
 }
 
-func (c *CMEBB) Description() string {
+func (c *Investigation) Description() string {
 	return "Investigate the cluster monitoring error budget burn alert"
 }
 
-func (c *CMEBB) ShouldInvestigateAlert(alert string) bool {
+func (c *Investigation) ShouldInvestigateAlert(alert string) bool {
 	return strings.Contains(alert, "ClusterMonitoringErrorBudgetBurnSRE")
 }
 
-func (c *CMEBB) IsExperimental() bool {
+func (c *Investigation) IsExperimental() bool {
 	return true
 }
 

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 )
 
-type CPD struct{}
+type Investigation struct{}
 
 // https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_NoRouteToInternet.json
 var byovpcRoutingSL = &ocm.ServiceLog{Severity: "Major", Summary: "Installation blocked: Missing route to internet", Description: "Your cluster's installation is blocked because of the missing route to internet in the route table(s) associated with the supplied subnet(s) for cluster installation. Please review and validate the routes by following documentation and re-install the cluster: https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc.", InternalOnly: false, ServiceName: "SREManualAction"}
@@ -27,7 +27,7 @@ var byovpcRoutingSL = &ocm.ServiceLog{Severity: "Major", Summary: "Installation 
 // - always escalate the alert to primary
 // The reasoning for this is that we don't fully trust network verifier yet.
 // In the future, we want to automate service logs based on the network verifier output.
-func (c *CPD) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
+func (c *Investigation) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
 	notes := notewriter.New("CPD", logging.RawLogger)
 
@@ -119,19 +119,19 @@ func (c *CPD) Run(r *investigation.Resources) (investigation.InvestigationResult
 	return result, r.PdClient.EscalateIncident()
 }
 
-func (c *CPD) Name() string {
+func (c *Investigation) Name() string {
 	return "ClusterProvisioningDelay"
 }
 
-func (c *CPD) Description() string {
+func (c *Investigation) Description() string {
 	return "Investigates the ClusterProvisioningDelay alert"
 }
 
-func (c *CPD) ShouldInvestigateAlert(alert string) bool {
+func (c *Investigation) ShouldInvestigateAlert(alert string) bool {
 	return strings.Contains(alert, "ClusterProvisioningDelay -")
 }
 
-func (c *CPD) IsExperimental() bool {
+func (c *Investigation) IsExperimental() bool {
 	return false
 }
 

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -10,10 +10,10 @@ import (
 
 // availableInvestigations holds all Investigation implementations.
 var availableInvestigations = []investigation.Investigation{
-	&ccam.CCAM{},
-	&chgm.CHGM{},
-	&clustermonitoringerrorbudgetburn.CMEBB{},
-	&cpd.CPD{},
+	&ccam.Investigation{},
+	&chgm.Investiation{},
+	&clustermonitoringerrorbudgetburn.Investigation{},
+	&cpd.Investigation{},
 }
 
 // GetInvestigation returns the first Investigation that applies to the given alert title.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-28725

---

This PR just updates the name of each investigation package's primary struct to a standard name, `Investigation`.

The goal is to create a consistent package standard, and to make object initialization more idiomatic. ie -

```
&clustermonitoringerrorbudgetburn.CMEBB{}
```
becomes
```
&clustermonitoringerrorbudgetburn.Investigation{}
```