### PR TITLE
OSD-28525 - Add MachineHealthCheckUnterminatedShortCircuitSRE investigation `metadata.yaml`

### DIFF
--- a/pkg/investigations/machineHealthCheckUnterminatedShortCircuitSRE/metadata.yaml
+++ b/pkg/investigations/machineHealthCheckUnterminatedShortCircuitSRE/metadata.yaml
@@ -1,0 +1,12 @@
+name: MachineHealthCheckUnterminatedShortCircuitSRE
+rbac:
+  roles: []
+  clusterRoleRules:
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "machine.openshift.io"
+      resources:
+        - machine
+customerDataAccess: true


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-28525

---

Adds the `metadata.yaml` remediation file to a new investigation directory. This is done prior to the actual implementation of the investigation logic, so that it can be used by the backplane-api during development.