### PR TITLE
OSD-28525 - Fix typo in clusterrole

### DIFF
--- a/pkg/investigations/machineHealthCheckUnterminatedShortCircuitSRE/metadata.yaml
+++ b/pkg/investigations/machineHealthCheckUnterminatedShortCircuitSRE/metadata.yaml
@@ -8,5 +8,5 @@ rbac:
       apiGroups:
         - "machine.openshift.io"
       resources:
-        - machine
+        - machines
 customerDataAccess: true


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-28525

---

Fixes typo in `MachineHealthCheckUnterminatedShortCircuitSRE`'s clusterrole which prevents the investigation from GET-ing/LIST-ing machine objects.