### PR TITLE
OSD-28775 - Add basic instructions to include test objects for new investigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ To add a new alert investigation:
 
 - run `make bootstrap-investigation` to generate boilerplate code in `pkg/investigations` (This creates the corresponding folder & .go file, and also appends the investigation to the `availableInvestigations` interface in `registry.go`.).
 - investigation.Resources contain initialized clients for the clusters aws environment, ocm and more. See [Integrations](#integrations)
+- Add test objects or scripts used to recreate the alert symptoms to the `pkg/investigations/$INVESTIGATION_NAME/testing/` directory for future use. Be sure to clearly document the testing procedure under the `Testing` section of the investigation-specific README.md file
 
 ### Integrations
 

--- a/hack/bootstrap-investigation.sh
+++ b/hack/bootstrap-investigation.sh
@@ -42,6 +42,7 @@ ls "${INVESTIGATION_DIR}"
 touch "${INVESTIGATION_DIR}/${INVESTIGATION_NAME}.go"
 touch "${INVESTIGATION_DIR}/metadata.yaml"
 touch "${INVESTIGATION_DIR}/README.md"
+mkdir "${INVESTIGATION_DIR}/testing/"
 
 # Create README.md file
 cat <<EOF > "${INVESTIGATION_DIR}/README.md"
@@ -49,7 +50,21 @@ cat <<EOF > "${INVESTIGATION_DIR}/README.md"
 
 ${INVESTIGATION_DESCRIPTION}
 
+## Testing
+
+Refer to the [testing README](./testing/README.md) for instructions on testing this investigation
+
 EOF
+
+# Create testing/README.md file
+cat <<EOF > "${INVESTIGATION_DIR}/testing/README.md"
+# Testing ${INVESTIGATION_NAME} Investigation
+
+TODO:
+- Add a test script or test objects to this `testing/` directory for future maintainers to use
+- Edit this README file and add detailed instructions on how to use the script/objects to recreate the conditions for the investigation. Be sure to include any assumptions or prerequisites about the environment (disable hive syncsetting, etc)
+EOF
+
 
 # Create metadata.yaml file
 cat <<EOF > "${INVESTIGATION_DIR}/metadata.yaml"


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-28775

---

This PR updates the instructions and bootstrapping logic for new investigations to require the test process be preserved for future use.

Specifically, bootstrapping a new investigation will add a `testing/` directory to hold the files and scripts needed to recreate the investigation conditions on a test cluster. Additionally, a placeholder README for the testing procedure is also templated out with the expectation that it will be used to document investigation testing steps for future maintainers.