### PR TITLE
Fix dependabot for gomod updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "interceptor/"
+    allow:
+      - dependency-type: all
+    schedule:
+      interval: "daily"
   - package-ecosystem: "docker"
     directory: "/build"
     labels:


### PR DESCRIPTION
We had some issues with our multi go mod setup for the interceptor, but this configuration might work.

We had tried to fix it with commit https://github.com/openshift/configuration-anomaly-detection/commit/68f13da267a8cf1c4e7032b1727d801878818162 
But either by mistake or some unknown reason we removed it here https://github.com/openshift/configuration-anomaly-detection/pull/353