### PR TITLE
OSD-28525 - Update permissions for MachineHealthCheckUnterminatedShortCircuitSRE investigation

### DIFF
--- a/pkg/investigations/machineHealthCheckUnterminatedShortCircuitSRE/metadata.yaml
+++ b/pkg/investigations/machineHealthCheckUnterminatedShortCircuitSRE/metadata.yaml
@@ -1,12 +1,21 @@
 name: MachineHealthCheckUnterminatedShortCircuitSRE
 rbac:
-  roles: []
+  roles:
+    - namespace: "openshift-machine-api"
+      rules:
+        - verbs:
+            - "get"
+            - "list"
+          apiGroups:
+            - "machine.openshift.io"
+          resources:
+            - "machines"
   clusterRoleRules:
     - verbs:
         - "get"
         - "list"
       apiGroups:
-        - "machine.openshift.io"
+        - ""
       resources:
-        - machines
+        - "nodes"
 customerDataAccess: true


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-28525

---

Rescopes the existing permissions for the `MachineHealthCheckUnterminatedShortCircuitSRE` investigation remediation serviceaccount - specifically makes `machine.machine.openshift.io` permissions namespace-scoped instead of cluster-scoped.

Adds additional cluster-scoped permission to GET nodes