### PR TITLE
Fix interceptor e2e env issue & investigation name logging

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -140,7 +140,7 @@ func run(cmd *cobra.Command, _ []string) error {
 
 	investigationResources := &investigation.Resources{Name: alertInvestigation.Name(), Cluster: cluster, ClusterDeployment: clusterDeployment, AwsClient: customerAwsClient, OcmClient: ocmClient, PdClient: pdClient}
 
-	logging.Infof("Starting investigation for %s", alertInvestigation.Name)
+	logging.Infof("Starting investigation for %s", alertInvestigation.Name())
 	result, err := alertInvestigation.Run(investigationResources)
 	updateMetrics(alertInvestigation.Name(), &result)
 	return err

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -110,8 +110,6 @@ func (pdi *PagerDutyInterceptor) executeInterceptor(r *http.Request) ([]byte, er
 
 	var ireq triggersv1.InterceptorRequest
 
-	// logging request
-	logging.Debug("Unwrapped Request header: %v", extractedRequest.Header)
 	logging.Debug("Unwrapped Request body: ", originalReq.Body)
 
 	token, _ := os.LookupEnv("PD_SIGNATURE")
@@ -159,7 +157,7 @@ func (pdi *PagerDutyInterceptor) Process(ctx context.Context, r *triggersv1.Inte
 		}
 	}
 
-	logging.Infof("Incident %s is mapped to investigation '%s', returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID(), investigation.Name)
+	logging.Infof("Incident %s is mapped to investigation '%s', returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID(), investigation.Name())
 	return &triggersv1.InterceptorResponse{
 		Continue: true,
 	}


### PR DESCRIPTION
This PR aims to fix an issue with the interceptor e2e not adding the env signature variable, thus unreadable to the interceptor. It also corrects the investigation's name in logging.