### PR TITLE
OSD-27752: Deprecate x-secret-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ Grafana dashboard configmaps are stored in the [Dashboards](./dashboards/) direc
 * `CAD_PD_USERNAME`: refers to the username of CAD on PagerDuty
 * `CAD_SILENT_POLICY`: refers to the silent policy CAD should use if the incident shall be silent
 * `PD_SIGNATURE`: refers to the PagerDuty webhook signature (HMAC+SHA256)
-* `X_SECRET_TOKEN`: refers to our custom Secret Token for authenticating against our pipeline
 * `CAD_PROMETHEUS_PUSHGATEWAY`: refers to the URL cad will push metrics to
 * `BACKPLANE_URL`: refers to the backplane url to use
 * `BACKPLANE_INITIAL_ARN`: refers to the initial ARN used for the isolated backplane jumprole flow

--- a/deploy/pipeline-trigger.yaml
+++ b/deploy/pipeline-trigger.yaml
@@ -40,11 +40,6 @@ metadata:
   name: cad-pipe-listener
 spec:
   interceptors:
-    - ref:
-        name: "cel"
-      params:
-      - name: "filter"
-        value: "header.canonical('X-Secret-Token').compareSecret('X_SECRET_TOKEN', 'cad-pd-token')"
     # Enable after interceptor deployment is tested
     - ref:
         name: "cad-interceptor"

--- a/deploy/task-cad-checks-secrets-pd.yaml
+++ b/deploy/task-cad-checks-secrets-pd.yaml
@@ -10,5 +10,4 @@ stringData:
   CAD_PD_TOKEN: CHANGEME # refers to the generated private access token for token-based authentication
   CAD_PD_USERNAME: CHANGEME # refers to the username in case username/pw credentials should be used
   CAD_SILENT_POLICY: CHANGEME # refers to the silent policy CAD should use if the incident shall be silent
-  X_SECRET_TOKEN: CHANGEME # refers to the PagerDuty webhook signature (HMAC+SHA256)
   PD_SIGNATURE: CHANGEME # refers to our custom Secret Token for authenticating against our pipeline

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -145,12 +145,6 @@ objects:
     bindings:
     - ref: cad-check-trigger
     interceptors:
-    - params:
-      - name: filter
-        value: header.canonical('X-Secret-Token').compareSecret('X_SECRET_TOKEN',
-          'cad-pd-token')
-      ref:
-        name: cel
     - ref:
         kind: NamespacedInterceptor
         name: cad-interceptor
@@ -289,7 +283,6 @@ objects:
     CAD_PD_USERNAME: CHANGEME
     CAD_SILENT_POLICY: CHANGEME
     PD_SIGNATURE: CHANGEME
-    X_SECRET_TOKEN: CHANGEME
   type: Opaque
 - apiVersion: tekton.dev/v1beta1
   kind: Task


### PR DESCRIPTION
This PR aims to deprecate the `x-secret-token`, as CAD now utilizes the `X-PagerDuty-Signature` token in it's place.

Followup to https://github.com/openshift/configuration-anomaly-detection/pull/363