### PR TITLE
OSD-28224 - cad should always post failures to the incident notes

### DIFF
--- a/hack/bootstrap-investigation.sh
+++ b/hack/bootstrap-investigation.sh
@@ -96,6 +96,7 @@ func (c *Investigation) Run(r *investigation.Resources) (investigation.Investiga
 
 	// Initialize PagerDuty note writer
 	notes := notewriter.New(r.Name, logging.RawLogger)
+	defer func() { r.Notes = notes }()
 
 	// TODO: Implement investigation logic here
 

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -42,6 +42,7 @@ type Investiation struct{}
 func (c *Investiation) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
 	notes := notewriter.New("CHGM", logging.RawLogger)
+	defer func() { r.Notes = notes }()
 
 	// 1. Check if the user stopped instances
 	res, err := investigateStoppedInstances(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -30,6 +30,7 @@ var byovpcRoutingSL = &ocm.ServiceLog{Severity: "Major", Summary: "Installation 
 func (c *Investigation) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
 	notes := notewriter.New("CPD", logging.RawLogger)
+	defer func() { r.Notes = notes }()
 
 	if r.Cluster.Status().State() == "ready" {
 		// We are unsure when this happens, in theory, if the cluster is ready, the alert shouldn't fire or should autoresolve.

--- a/pkg/investigations/investigation/investigation.go
+++ b/pkg/investigations/investigation/investigation.go
@@ -4,6 +4,7 @@ package investigation
 import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -38,5 +39,6 @@ type Resources struct {
 	AwsClient           aws.Client
 	OcmClient           ocm.Client
 	PdClient            pagerduty.Client
+	Notes               *notewriter.NoteWriter
 	AdditionalResources map[string]interface{}
 }


### PR DESCRIPTION
This PR aims to add handling to ensure that investigation failures (and notes collected up until failure) are always posted to PagerDuty, as currently some exceptions/errors result in empty notes.