### PR TITLE
fix: ClusterProvisioningDelay servicelog templating

### DIFF
--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -100,7 +100,7 @@ func (c *Investigation) Run(r *investigation.Resources) (investigation.Investiga
 		logging.Infof("Network verifier reported failure: %s", failureReason)
 		// XXX: metrics.Inc(metrics.ServicelogPrepared, investigationName)
 		result.ServiceLogPrepared = investigation.InvestigationStep{Performed: true, Labels: nil}
-		notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=%s", r.Cluster.ID(), failureReason)
+		notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=\"%s\"", r.Cluster.ID(), failureReason)
 
 		// In the future, we want to send a service log in this case
 		err = r.PdClient.AddNote(notes.String())


### PR DESCRIPTION
The egress urls can contain spaces, thus we need to double quote the URLs string in the template we provide to consumers. 