### PR TITLE
Bump osd-network-verifier to v1.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/aws-account-operator/api v0.0.0-20231122143531-33ce90caf221
 	github.com/openshift/backplane-cli v0.1.39
 	github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f
-	github.com/openshift/osd-network-verifier v1.2.1
+	github.com/openshift/osd-network-verifier v1.2.3
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/common v0.54.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f h1:CedFPNwCSYbjo7rCr9YrJs/0OrBf3m8sLlUZw66VDwY=
 github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f/go.mod h1:RRH8lt09SAiPECNdsbh7Gun0lkcRWi1nYKq6tDp5WxQ=
-github.com/openshift/osd-network-verifier v1.2.1 h1:mrxLHY0wNIULn59opVFKroeBTwVNWc6nUB4dXI4bRfM=
-github.com/openshift/osd-network-verifier v1.2.1/go.mod h1:X3dVNkC91NYTf2kTXUS/PeRTNvfS97WbvIqPIDP083M=
+github.com/openshift/osd-network-verifier v1.2.3 h1:MW+u2LR8M5AWzQ2t/RsS7JWycBAleUgT480AMO4VMu4=
+github.com/openshift/osd-network-verifier v1.2.3/go.mod h1:X3dVNkC91NYTf2kTXUS/PeRTNvfS97WbvIqPIDP083M=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55FuFkxqLw=

--- a/interceptor/go.mod
+++ b/interceptor/go.mod
@@ -5,9 +5,9 @@ go 1.22.7
 toolchain go1.22.12
 
 require (
+	github.com/PagerDuty/go-pagerduty v1.8.0
 	github.com/openshift/configuration-anomaly-detection v0.0.0-00010101000000-000000000000
 	github.com/tektoncd/triggers v0.27.0
-	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.67.3
 	knative.dev/pkg v0.0.0-20240521083825-99e1685a7997
 )
@@ -19,7 +19,6 @@ require (
 	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
-	github.com/PagerDuty/go-pagerduty v1.8.0 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
@@ -123,7 +122,7 @@ require (
 	github.com/openshift/backplane-cli v0.1.39 // indirect
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 // indirect
 	github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f // indirect
-	github.com/openshift/osd-network-verifier v1.2.1 // indirect
+	github.com/openshift/osd-network-verifier v1.2.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
@@ -150,6 +149,7 @@ require (
 	github.com/zalando/go-keyring v0.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect

--- a/interceptor/go.sum
+++ b/interceptor/go.sum
@@ -501,8 +501,8 @@ github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f h1:CedFPNwCSYbjo7rCr9YrJs/0OrBf3m8sLlUZw66VDwY=
 github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f/go.mod h1:RRH8lt09SAiPECNdsbh7Gun0lkcRWi1nYKq6tDp5WxQ=
-github.com/openshift/osd-network-verifier v1.2.1 h1:mrxLHY0wNIULn59opVFKroeBTwVNWc6nUB4dXI4bRfM=
-github.com/openshift/osd-network-verifier v1.2.1/go.mod h1:X3dVNkC91NYTf2kTXUS/PeRTNvfS97WbvIqPIDP083M=
+github.com/openshift/osd-network-verifier v1.2.3 h1:MW+u2LR8M5AWzQ2t/RsS7JWycBAleUgT480AMO4VMu4=
+github.com/openshift/osd-network-verifier v1.2.3/go.mod h1:X3dVNkC91NYTf2kTXUS/PeRTNvfS97WbvIqPIDP083M=
 github.com/openzipkin/zipkin-go v0.4.3 h1:9EGwpqkgnwdEIJ+Od7QVSEIH+ocmm5nPat0G7sjsSdg=
 github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LDHcMZmk3RmK7c=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=


### PR DESCRIPTION
This PR addresses [OSD-29354](https://issues.redhat.com/browse/OSD-29354) by updating CAD's osd-network-verifier dependency from v1.2.1 to v1.2.3 in order to prevent issues with missing/outdated AMIs