### PR TITLE
OSD-29402: Increase the default network-verifier timeout from 2s to 5s

### DIFF
--- a/pkg/networkverifier/networkverifier.go
+++ b/pkg/networkverifier/networkverifier.go
@@ -76,8 +76,8 @@ func InitializeValidateEgressInput(cluster *v1.Cluster, clusterDeployment *hivev
 	}
 
 	return &verifier.ValidateEgressInput{
-		Timeout:      2 * time.Second,
-		Ctx:          context.TODO(),
+		Timeout:      5 * time.Second,
+		Ctx:          context.Background(),
 		SubnetID:     subnet,
 		InstanceType: "t3.micro",
 		Proxy:        proxy,


### PR DESCRIPTION
We tend to see a lot of clusters that have CAD run against them hit timeouts with egress.

After reviewing, I noticed we had set the timeout to 2 seconds which felt pretty tight.

I have updated that value to be 5 seconds, which lines up with what OCM uses to perform pre-cluster creation network verification. I think unifying on a default (in osd-network-verifier next) will ensure we are consistent about this across tools and services.