### PR TITLE
OSD-29424 - Update PD incident title after investigation

### DIFF
--- a/pkg/pagerduty/mock/pagerdutymock.go
+++ b/pkg/pagerduty/mock/pagerdutymock.go
@@ -122,3 +122,17 @@ func (mr *MockClientMockRecorder) SilenceIncidentWithNote(notes any) *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SilenceIncidentWithNote", reflect.TypeOf((*MockClient)(nil).SilenceIncidentWithNote), notes)
 }
+
+// UpdateIncidentTitle mocks base method.
+func (m *MockClient) UpdateIncidentTitle(title string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateIncidentTitle", title)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateIncidentTitle indicates an expected call of UpdateIncidentTitle.
+func (mr *MockClientMockRecorder) UpdateIncidentTitle(title any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIncidentTitle", reflect.TypeOf((*MockClient)(nil).UpdateIncidentTitle), title)
+}

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -51,6 +51,7 @@ type Client interface {
 	GetServiceID() string
 	EscalateIncidentWithNote(notes string) error
 	EscalateIncident() error
+	UpdateIncidentTitle(title string) error
 }
 
 // SdkClient will hold all the required fields for any SdkClient Operation
@@ -228,22 +229,22 @@ func (c *SdkClient) SetIncidentData(incidentData *IncidentData) {
 	c.incidentData = incidentData
 }
 
-// GetServiceID returns the event type of the webhook
+// GetServiceID returns the ID of the pagerduty service containing the client's incident
 func (c *SdkClient) GetServiceID() string {
 	return c.incidentData.ServiceID
 }
 
-// GetServiceName returns the event type of the webhook
+// GetServiceName returns the pagerduty service containing the client's incident
 func (c *SdkClient) GetServiceName() string {
 	return c.incidentData.ServiceSummary
 }
 
-// GetTitle returns the event type of the webhook
+// GetTitle returns the title of the client's incident
 func (c *SdkClient) GetTitle() string {
 	return c.incidentData.IncidentTitle
 }
 
-// GetIncidentID returns the event type of the webhook
+// GetIncidentID returns the ID of the client's incident
 func (c *SdkClient) GetIncidentID() string {
 	return c.incidentData.IncidentID
 }
@@ -538,6 +539,21 @@ func (c *SdkClient) EscalateIncident() error {
 			return nil
 		}
 		return fmt.Errorf("could not escalate the incident: %w", err)
+	}
+	return nil
+}
+
+func (c *SdkClient) UpdateIncidentTitle(title string) error {
+	o := []sdk.ManageIncidentsOptions{
+		{
+			ID:    c.GetIncidentID(),
+			Title: title,
+		},
+	}
+
+	err := c.updateIncident(o)
+	if err != nil {
+		return fmt.Errorf("failed to update incident: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-29424

---

These changes update the PagerDuty incident title after an investigation completes to more visibly indicate when CAD has run. The goal is to reduce the potential for duplicated work as a result of on-call not seeing the investigation notes CAD attaches to the incident.

The title is only updated once: subsequent CAD runs will not re-attach the `[CAD Investigated]` prefix to the incident, in order to keep titles useful across multiple investigation attempts