### PR TITLE
OSD-29424 - Bugfix to use `pagerdutyTitlePrefix` instead of hardcoded string when updating incident title

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -243,7 +243,7 @@ func updateIncidentTitle(pdClient *pagerduty.SdkClient) error {
 	if strings.Contains(currentTitle, pagerdutyTitlePrefix) {
 		return nil
 	}
-	newTitle := fmt.Sprintf("[CAD Investigated] %s", currentTitle)
+	newTitle := fmt.Sprintf("%s %s", pagerdutyTitlePrefix, currentTitle)
 	err := pdClient.UpdateIncidentTitle(newTitle)
 	if err != nil {
 		return fmt.Errorf("failed to update PagerDuty incident title: %w", err)


### PR DESCRIPTION
Fixes minor bug where the `pagerDutyTitlePrefix` const wasn't being used to prefix the PagerDuty incident title upon investigation completion.