### PR TITLE
Maint: handle degraded api when creating k8sclient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common v0.63.0
 	github.com/spf13/cobra v1.8.1
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.4.0
 	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -122,6 +123,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -36,6 +36,10 @@ func (c *Investigation) Run(r *investigation.Resources) (result investigation.In
 	// patching the existing RBAC etc...
 	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient, r.Name)
 	if err != nil {
+		if errors.Is(k8sclient.ErrAPIServerUnavailable, err) {
+			return result, r.PdClient.EscalateIncidentWithNote("CAD was unable to  cluster's kube-api. Please investigate manually.")
+		}
+
 		return result, fmt.Errorf("unable to initialize k8s cli: %w", err)
 	}
 	defer func() {

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -37,7 +37,7 @@ func (c *Investigation) Run(r *investigation.Resources) (result investigation.In
 	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient, r.Name)
 	if err != nil {
 		if errors.Is(k8sclient.ErrAPIServerUnavailable, err) {
-			return result, r.PdClient.EscalateIncidentWithNote("CAD was unable to  cluster's kube-api. Please investigate manually.")
+			return result, r.PdClient.EscalateIncidentWithNote("CAD was unable to access cluster's kube-api. Please investigate manually.")
 		}
 
 		return result, fmt.Errorf("unable to initialize k8s cli: %w", err)

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -36,7 +36,7 @@ func (c *Investigation) Run(r *investigation.Resources) (result investigation.In
 	// patching the existing RBAC etc...
 	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient, r.Name)
 	if err != nil {
-		if errors.Is(k8sclient.ErrAPIServerUnavailable, err) {
+		if errors.Is(err, k8sclient.ErrAPIServerUnavailable) {
 			return result, r.PdClient.EscalateIncidentWithNote("CAD was unable to access cluster's kube-api. Please investigate manually.")
 		}
 

--- a/pkg/investigations/insightsoperatordown/insightsoperatordown.go
+++ b/pkg/investigations/insightsoperatordown/insightsoperatordown.go
@@ -39,7 +39,7 @@ func (c *Investigation) Run(r *investigation.Resources) (investigation.Investiga
 	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient, r.Name)
 	if err != nil {
 		if errors.Is(k8sclient.ErrAPIServerUnavailable, err) {
-			return result, r.PdClient.EscalateIncidentWithNote("CAD was unable to  cluster's kube-api. Please investigate manually.")
+			return result, r.PdClient.EscalateIncidentWithNote("CAD was unable to access cluster's kube-api. Please investigate manually.")
 		}
 
 		return result, fmt.Errorf("unable to initialize k8s cli: %w", err)

--- a/pkg/investigations/insightsoperatordown/insightsoperatordown.go
+++ b/pkg/investigations/insightsoperatordown/insightsoperatordown.go
@@ -38,6 +38,10 @@ func (c *Investigation) Run(r *investigation.Resources) (investigation.Investiga
 	// We continue with the next step OCPBUG22226 even if the user is banned.
 	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient, r.Name)
 	if err != nil {
+		if errors.Is(k8sclient.ErrAPIServerUnavailable, err) {
+			return result, r.PdClient.EscalateIncidentWithNote("CAD was unable to  cluster's kube-api. Please investigate manually.")
+		}
+
 		return result, fmt.Errorf("unable to initialize k8s cli: %w", err)
 	}
 	defer func() {

--- a/pkg/investigations/insightsoperatordown/insightsoperatordown.go
+++ b/pkg/investigations/insightsoperatordown/insightsoperatordown.go
@@ -38,7 +38,7 @@ func (c *Investigation) Run(r *investigation.Resources) (investigation.Investiga
 	// We continue with the next step OCPBUG22226 even if the user is banned.
 	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient, r.Name)
 	if err != nil {
-		if errors.Is(k8sclient.ErrAPIServerUnavailable, err) {
+		if errors.Is(err, k8sclient.ErrAPIServerUnavailable) {
 			return result, r.PdClient.EscalateIncidentWithNote("CAD was unable to access cluster's kube-api. Please investigate manually.")
 		}
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -4,23 +4,29 @@ import (
 	"fmt"
 	"os"
 
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/backplane-cli/pkg/cli/config"
 	bpremediation "github.com/openshift/backplane-cli/pkg/remediation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// New returns a Kubernetes client for the given cluster scoped to a given remediation's permissions.
 func New(clusterID string, ocmClient ocm.Client, remediation string) (client.Client, error) {
 	backplaneURL := os.Getenv("BACKPLANE_URL")
 	if backplaneURL == "" {
 		return nil, fmt.Errorf("could not create new k8sclient: missing environment variable BACKPLANE_URL")
 	}
 
-	cfg, err := bpremediation.CreateRemediationWithConn(config.BackplaneConfiguration{URL: backplaneURL}, ocmClient.GetConnection(), clusterID, remediation)
+	cfg, err := bpremediation.CreateRemediationWithConn(
+		config.BackplaneConfiguration{URL: backplaneURL},
+		ocmClient.GetConnection(),
+		clusterID,
+		remediation,
+	)
 	if err != nil {
+		if isAPIServerUnavailable(err) {
+			return nil, fmt.Errorf("%w: %v", ErrAPIServerUnavailable, err)
+		}
 		return nil, err
 	}
 
@@ -32,26 +38,17 @@ func New(clusterID string, ocmClient ocm.Client, remediation string) (client.Cli
 	return client.New(cfg, client.Options{Scheme: scheme})
 }
 
+// Cleanup removes the remediation created for the cluster.
 func Cleanup(clusterID string, ocmClient ocm.Client, remediation string) error {
 	backplaneURL := os.Getenv("BACKPLANE_URL")
 	if backplaneURL == "" {
-		return fmt.Errorf("could not create new k8sclient: missing environment variable BACKPLANE_URL")
-	}
-	return bpremediation.DeleteRemediationWithConn(config.BackplaneConfiguration{URL: backplaneURL}, ocmClient.GetConnection(), clusterID, remediation)
-}
-
-// Initialize all apis we need in CAD
-func initScheme() (*runtime.Scheme, error) {
-	scheme := runtime.NewScheme()
-
-	// Add corev1 to scheme for core k8s
-	if err := corev1.AddToScheme(scheme); err != nil {
-		return nil, fmt.Errorf("unable to add corev1 scheme: %w", err)
+		return fmt.Errorf("could not clean up k8sclient: missing environment variable BACKPLANE_URL")
 	}
 
-	// Add config.openshift.io/v1 to scheme for clusteroperator
-	if err := configv1.Install(scheme); err != nil {
-		return nil, fmt.Errorf("unable to add openshift/api/config scheme: %w", err)
-	}
-	return scheme, nil
+	return bpremediation.DeleteRemediationWithConn(
+		config.BackplaneConfiguration{URL: backplaneURL},
+		ocmClient.GetConnection(),
+		clusterID,
+		remediation,
+	)
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -25,7 +25,7 @@ func New(clusterID string, ocmClient ocm.Client, remediation string) (client.Cli
 	)
 	if err != nil {
 		if isAPIServerUnavailable(err) {
-			return nil, fmt.Errorf("%w: %v", ErrAPIServerUnavailable, err)
+			return nil, fmt.Errorf("%w: %w", ErrAPIServerUnavailable, err)
 		}
 		return nil, err
 	}

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -10,8 +10,5 @@ var ErrAPIServerUnavailable = errors.New("kubernetes API server unavailable")
 // isAPIServerUnavailable detects common symptoms of an unreachable API server.
 func isAPIServerUnavailable(err error) bool {
 	errStr := err.Error()
-	return strings.Contains(errStr, "TLS handshake timeout") ||
-		strings.Contains(errStr, "connection refused") ||
-		strings.Contains(errStr, "i/o timeout") ||
-		strings.Contains(errStr, "dial tcp")
+	return strings.Contains(errStr, "The cluster could be down or under heavy load")
 }

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -1,0 +1,17 @@
+package k8sclient
+
+import (
+	"errors"
+	"strings"
+)
+
+var ErrAPIServerUnavailable = errors.New("kubernetes API server unavailable")
+
+// isAPIServerUnavailable detects common symptoms of an unreachable API server.
+func isAPIServerUnavailable(err error) bool {
+	errStr := err.Error()
+	return strings.Contains(errStr, "TLS handshake timeout") ||
+		strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "i/o timeout") ||
+		strings.Contains(errStr, "dial tcp")
+}

--- a/pkg/k8s/errors_test.go
+++ b/pkg/k8s/errors_test.go
@@ -1,0 +1,27 @@
+package k8sclient
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAPIServerUnavailable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"TLS timeout", errors.New("TLS handshake timeout"), true},
+		{"Connection refused", errors.New("connection refused"), true},
+		{"Dial tcp", errors.New("dial tcp 1.2.3.4:443"), true},
+		{"Other error", errors.New("some random error"), false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, isAPIServerUnavailable(c.err))
+		})
+	}
+}

--- a/pkg/k8s/scheme.go
+++ b/pkg/k8s/scheme.go
@@ -1,0 +1,24 @@
+package k8sclient
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// initScheme initializes the runtime scheme with required APIs.
+func initScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("unable to add corev1 scheme: %w", err)
+	}
+
+	if err := configv1.Install(scheme); err != nil {
+		return nil, fmt.Errorf("unable to add config.openshift.io/v1 scheme: %w", err)
+	}
+
+	return scheme, nil
+}


### PR DESCRIPTION
This PR adds handling for degraded api errors we can receive when calling backplane to create our kubeconfig/permission mappings. I also split up the k8sclient package for separation of concerns. 