### PR TITLE
OSD-28525 - Additional permission for CAD to retrieve machinehealthchecks on-cluster

### DIFF
--- a/pkg/investigations/machineHealthCheckUnterminatedShortCircuitSRE/metadata.yaml
+++ b/pkg/investigations/machineHealthCheckUnterminatedShortCircuitSRE/metadata.yaml
@@ -10,6 +10,7 @@ rbac:
             - "machine.openshift.io"
           resources:
             - "machines"
+            - "machinehealthchecks"
   clusterRoleRules:
     - verbs:
         - "get"


### PR DESCRIPTION
Adds an additional object to the `machinehealthcheckUnterminatedShortCircuit` investigation's `openshift-machine-api` role, so that the investigation can retrieve the machinehealthcheck object it's investigating