### PR TITLE
Fix: ignore non-existant clusters

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -116,8 +116,13 @@ func run(cmd *cobra.Command, _ []string) error {
 
 	cluster, err := ocmClient.GetClusterInfo(clusterID)
 	if err != nil {
+		if strings.Contains(err.Error(), "no cluster found") {
+			logging.Warnf("No cluster found with ID '%s'. Exiting.", clusterID)
+			return pdClient.EscalateIncidentWithNote("CAD was unable to find the incident cluster in OCM. An alert for a non-existing cluster is unexpected. Please investigate manually.")
+		}
 		return fmt.Errorf("could not retrieve cluster info for %s: %w", clusterID, err)
 	}
+
 	// From this point on, we normalize to internal ID, as this ID always exists.
 	// For installing clusters, externalID can be empty.
 	internalClusterID := cluster.ID()


### PR DESCRIPTION
This PR gets rid of all the non-0 exiting pipelines for clusters that don't exist (e.g. integration cluster ids in staging). This is mostly to suppress failed pipeline noise, should not happen on production.