### PR TITLE
Simplify the configuration loading

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -19,7 +19,6 @@ package investigate
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -35,12 +34,82 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var debugFlag = false
+var experimentalFlag = false
+var cadOcmClientID string
+var cadOcmClientSecret string
+var cadOcmURL string
+
 // InvestigateCmd represents the entry point for alert investigation
 var InvestigateCmd = &cobra.Command{
 	Use:          "investigate",
 	SilenceUsage: true,
 	Short:        "Filter for and investigate supported alerts",
-	RunE:         run,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		debugFlag, err := cmd.Flags().GetBool("debug")
+		if err != nil {
+			return fmt.Errorf("failed to get debug flag: %w", err)
+		}
+
+		if !debugFlag {
+			// check environment variable
+			debug, exist := os.LookupEnv("CAD_DEBUG")
+			if exist && debug == "true" {
+				debugFlag = true
+			}
+		}
+
+		if debugFlag && !ocm.HasConfigFile() {
+			return fmt.Errorf("debug flag is set, but no OCM config file found. When using debug mode the OCM config file must be set")
+		}
+
+		var exist bool
+		cadOcmURL, err = cmd.Flags().GetString("ocm-url")
+		if err != nil {
+			return fmt.Errorf("failed to get ocm-url flag: %w", err)
+		}
+		if cadOcmURL == "" {
+			cadOcmURL, exist = os.LookupEnv("CAD_OCM_URL")
+			if !exist && !debugFlag {
+				return fmt.Errorf("ocm-url flag or CAD_OCM_URL environment variable must be set")
+			}
+		}
+
+		cadOcmClientID, err = cmd.Flags().GetString("client-id")
+		if err != nil {
+			return fmt.Errorf("failed to get client-id flag: %w", err)
+		}
+		if cadOcmClientID == "" {
+			cadOcmClientID, exist = os.LookupEnv("CAD_OCM_CLIENT_ID")
+			if !exist && !debugFlag {
+				return fmt.Errorf("client-id flag or CAD_OCM_CLIENT_ID environment variable must be set")
+			}
+		}
+		cadOcmClientSecret, err = cmd.Flags().GetString("client-secret")
+		if err != nil {
+			return fmt.Errorf("failed to get client-secret flag: %w", err)
+		}
+		if cadOcmClientSecret == "" {
+			cadOcmClientSecret, exist = os.LookupEnv("CAD_OCM_CLIENT_SECRET")
+			if !exist && !debugFlag {
+				return fmt.Errorf("client-secret flag or CAD_OCM_CLIENT_SECRET environment variable must be set")
+			}
+		}
+
+		experimentalFlag, err = cmd.Flags().GetBool("experimental")
+		if err != nil {
+			return fmt.Errorf("failed to get experimental flag: %w", err)
+		}
+		if !experimentalFlag {
+			experimental, exist := os.LookupEnv("CAD_EXPERIMENTAL_ENABLED")
+			if exist && experimental == "true" {
+				experimentalFlag = true
+			}
+		}
+
+		return nil
+	},
+	RunE: run,
 }
 
 var (
@@ -53,6 +122,11 @@ const pagerdutyTitlePrefix = "[CAD Investigated]"
 func init() {
 	InvestigateCmd.Flags().StringVarP(&payloadPath, "payload-path", "p", payloadPath, "the path to the payload")
 	InvestigateCmd.Flags().StringVarP(&logging.LogLevelString, "log-level", "l", "", "the log level [debug,info,warn,error,fatal], default = info")
+	InvestigateCmd.Flags().BoolP("debug", "d", false, "enable debugging mode, if not present CAD_DEBUG env is checked")
+	InvestigateCmd.Flags().StringP("ocm-url", "u", "", "the OCM URL, when not set the CAD_OCM_URL environment is used.")
+	InvestigateCmd.Flags().StringP("client-id", "i", "", "the OCM client ID, when not set the CAD_OCM_CLIENT_ID environment is used.")
+	InvestigateCmd.Flags().StringP("client-secret", "s", "", "the OCM client secret, when not set the CAD_OCM_CLIENT_SECRET environment is used.")
+	InvestigateCmd.Flags().BoolP("experimental", "e", false, "enable experimental features")
 
 	err := InvestigateCmd.MarkFlagRequired("payload-path")
 	if err != nil {
@@ -87,8 +161,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		}
 	}()
 
-	_, cadExperimentalEnabled := os.LookupEnv("CAD_EXPERIMENTAL_ENABLED")
-	alertInvestigation := investigations.GetInvestigation(pdClient.GetTitle(), cadExperimentalEnabled)
+	alertInvestigation := investigations.GetInvestigation(pdClient.GetTitle(), experimentalFlag)
 
 	// Escalate all unsupported alerts
 	if alertInvestigation == nil {
@@ -109,8 +182,14 @@ func run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ocmClient, err := GetOCMClient()
-	if err != nil {
+	var ocmClient *ocm.SdkClient
+	var ocmErr error
+	if debugFlag {
+		ocmClient, ocmErr = ocm.NewFromConfig()
+	} else {
+		ocmClient, ocmErr = ocm.NewFromClientKeyPair(cadOcmURL, cadOcmClientID, cadOcmClientSecret)
+	}
+	if ocmErr != nil {
 		return fmt.Errorf("could not initialize ocm client: %w", err)
 	}
 
@@ -182,22 +261,6 @@ func handleCADFailure(err error, resources *investigation.Resources, pdClient *p
 	} else {
 		logging.Errorf("Failed to obtain PagerDuty client, unable to escalate CAD failure to PagerDuty notes.")
 	}
-}
-
-// GetOCMClient will retrieve the OcmClient from the 'ocm' package
-func GetOCMClient() (*ocm.SdkClient, error) {
-	cadOcmFilePath := os.Getenv("CAD_OCM_FILE_PATH")
-
-	_, err := os.Stat(cadOcmFilePath)
-	if os.IsNotExist(err) {
-		configDir, err := os.UserConfigDir()
-		if err != nil {
-			return nil, err
-		}
-		cadOcmFilePath = filepath.Join(configDir, "/ocm/ocm.json")
-	}
-
-	return ocm.New(cadOcmFilePath)
 }
 
 // Checks pre-requisites for a cluster investigation:

--- a/cadctl/cmd/root.go
+++ b/cadctl/cmd/root.go
@@ -17,16 +17,21 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	investigate "github.com/openshift/configuration-anomaly-detection/cadctl/cmd/investigate"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
+	ocm "github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 	"github.com/spf13/cobra"
 )
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "cadctl",
-	Short: "A util of configuration-anomaly-detection (CAD) checks",
+	Use:               "cadctl",
+	Short:             "A util of configuration-anomaly-detection (CAD) checks",
+	PersistentPreRunE: loadCommon,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -41,4 +46,44 @@ func Execute() {
 
 func init() {
 	rootCmd.AddCommand(investigate.InvestigateCmd)
+	rootCmd.PersistentFlags().StringP("ocmconfig", "c", "", "Path to the OCM config file to use for CLI requests. When not set the OCM_CONFIG environment variable will be used. If that is not set, the default OCM config locations will be file will be used.")
+}
+
+func loadCommon(cmd *cobra.Command, args []string) error {
+
+	ocmConfigPath, err := cmd.Flags().GetString("ocmconfig")
+	if err != nil {
+		return fmt.Errorf("failed to get ocmconfig flag: %w", err)
+	}
+
+	if ocmConfigPath != "" {
+		if _, err := os.Stat(ocmConfigPath); err != nil {
+			return fmt.Errorf("ocmconfig file not found at %s: %w", ocmConfigPath, err)
+		}
+
+		ocm.SetConfigFile(ocmConfigPath)
+
+		return nil
+	}
+
+	ocmConfigPath, exists := os.LookupEnv("OCM_CONFIG")
+	if exists {
+		if _, err := os.Stat(ocmConfigPath); err != nil {
+			return fmt.Errorf("ocmconfig file not found at %s: %w", ocmConfigPath, err)
+		}
+
+		ocm.SetConfigFile(ocmConfigPath)
+
+		return nil
+	}
+
+	ocmConfigPath, err = ocm.Location()
+	if err != nil {
+		// Location() checks for file existence
+		return fmt.Errorf("failed to get ocmconfig file location: %w", err)
+	}
+
+	ocm.SetConfigFile(ocmConfigPath)
+
+	return nil
 }

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
-	"strconv"
 	"strings"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -57,35 +55,23 @@ type SdkClient struct {
 
 // New will create a new ocm client by using the path to a config file
 // if no path is provided, it will assume it in the default path
-func New(ocmConfigFile string) (*SdkClient, error) {
+func NewFromClientKeyPair(ocmURL string, clientID string, clientSecret string) (*SdkClient, error) {
 	var err error
 	client := SdkClient{}
 
-	// The debug environment variable ensures that we will never use
-	// an ocm config file on a cluster deployment. The debug environment variable
-	// is only for local cadctl development
-	debugMode := os.Getenv("CAD_DEBUG")
-
-	// strconv.ParseBool raises an error when debugMode is empty, thus
-	// we have to set it to false if the value is empty.
-	if debugMode == "" {
-		debugMode = "false"
+	if ocmURL == "" {
+		return nil, fmt.Errorf("Need OCM URL")
 	}
 
-	debugEnabled, err := strconv.ParseBool(debugMode)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse CAD_DEBUG value '%s': %w", debugMode, err)
+	if clientID == "" {
+		return nil, fmt.Errorf("Need OCM Client ID")
 	}
 
-	if debugEnabled {
-		client.conn, err = newConnectionFromFile(ocmConfigFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create connection from ocm.json config file: %w", err)
-		}
-		return &client, nil
+	if clientSecret == "" {
+		return nil, fmt.Errorf("Need OCM Client Secret")
 	}
 
-	client.conn, err = newConnectionFromClientPair()
+	client.conn, err = sdk.NewConnectionBuilder().URL(ocmURL).Client(clientID, clientSecret).Insecure(false).Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connection from client key pair: %w", err)
 	}
@@ -93,15 +79,24 @@ func New(ocmConfigFile string) (*SdkClient, error) {
 	return &client, nil
 }
 
-// newConnectionFromFile loads the configuration file (ocmConfigFile, ~/.ocm.json, /ocm/ocm.json)
-// and creates a connection.
-func newConnectionFromFile(ocmConfigFile string) (*sdk.Connection, error) {
-	if ocmConfigFile != "" {
-		err := os.Setenv("OCM_CONFIG", ocmConfigFile)
-		if err != nil {
-			return nil, err
-		}
+// NewFromConfig creates a new connection from the config file
+// The ocm configuration file stored by the ocm login command
+// is used to create the connection.
+// By the time this is called the ocmConfigFile is already set
+// either from flag, env or default location
+// see the main command.
+// The config file is stored in the default location:
+//   - ocmConfigFile,
+//   - ~/.ocm.json,
+//   - /ocm/ocm.json
+func NewFromConfig() (*SdkClient, error) {
+	if ocmConfigFile == "" {
+		return nil, fmt.Errorf("no config file configured see help")
 	}
+
+	client := SdkClient{}
+	var err error
+
 	// Load the configuration file from std path
 	cfg, err := Load()
 	if err != nil {
@@ -110,19 +105,11 @@ func newConnectionFromFile(ocmConfigFile string) (*sdk.Connection, error) {
 	if cfg == nil || cfg == (&Config{}) {
 		return nil, fmt.Errorf("not logged in")
 	}
-	return cfg.Connection()
-}
-
-// newConnectionFromClientPair creates a new connection via set of client ID, client secret
-// and the target OCM API URL.
-func newConnectionFromClientPair() (*sdk.Connection, error) {
-	ocmClientID, hasOcmClientID := os.LookupEnv("CAD_OCM_CLIENT_ID")
-	ocmClientSecret, hasOcmClientSecret := os.LookupEnv("CAD_OCM_CLIENT_SECRET")
-	ocmURL, hasOcmURL := os.LookupEnv("CAD_OCM_URL")
-	if !hasOcmClientID || !hasOcmClientSecret || !hasOcmURL {
-		return nil, fmt.Errorf("missing environment variables: CAD_OCM_CLIENT_ID CAD_OCM_CLIENT_SECRET CAD_OCM_URL")
+	client.conn, err = cfg.Connection()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection from ocm.json config file: %w", err)
 	}
-	return sdk.NewConnectionBuilder().URL(ocmURL).Client(ocmClientID, ocmClientSecret).Insecure(false).Build()
+	return &client, nil
 }
 
 // GetSupportRoleARN returns the support role ARN that allows the access to the cluster from internal cluster ID

--- a/pkg/ocm/ocm_config.go
+++ b/pkg/ocm/ocm_config.go
@@ -9,6 +9,10 @@ import (
 	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
+// ocmConfigFile is the path refers to existing ocm config file
+// set by the ocm command by calling ocm login
+var ocmConfigFile string
+
 // Config is the type used to store the configuration of the client.
 // There's no way to line-split or predefine tags, so...
 //
@@ -27,6 +31,24 @@ type Config struct {
 	URL          string   `json:"url,omitempty" doc:"URL of the API gateway. The value can be the complete URL or an alias. The valid aliases are 'production', 'staging' and 'integration'."`
 	User         string   `json:"user,omitempty" doc:"User name."`
 	Pager        string   `json:"pager,omitempty" doc:"Pager command, for example 'less'. If empty no pager will be used."`
+}
+
+func SetConfigFile(file string) {
+	ocmConfigFile = file
+}
+
+func HasConfigFile() bool {
+	if ocmConfigFile == "" {
+		return false
+	}
+	_, err := os.Stat(ocmConfigFile)
+	if os.IsNotExist(err) {
+		return false
+	}
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 // Load loads the configuration from the configuration file. If the configuration file doesn't exist
@@ -66,32 +88,39 @@ func Load() (cfg *Config, err error) {
 // Location returns the location of the configuration file. If a configuration file
 // already exists in the HOME directory, it uses that, otherwise it prefers to
 // use the XDG config directory.
-func Location() (path string, err error) {
-	if ocmconfig := os.Getenv("OCM_CONFIG"); ocmconfig != "" {
-		return ocmconfig, nil
-	}
-
+func Location() (string, error) {
 	// Determine home directory to use for the legacy file path
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
 
-	path = filepath.Join(home, ".ocm.json")
-
-	_, err = os.Stat(path)
-	if os.IsNotExist(err) {
-		// Determine standard config directory
-		configDir, err := os.UserConfigDir()
-		if err != nil {
-			return path, err
-		}
-
-		// Use standard config directory
-		path = filepath.Join(configDir, "/ocm/ocm.json")
+	configPath := filepath.Join(home, ".ocm.json")
+	_, err = os.Stat(configPath)
+	if err == nil {
+		// File exists, use it
+		return configPath, nil
 	}
 
-	return path, nil
+	if !os.IsNotExist(err) {
+		return "", fmt.Errorf("can't check if config file '%s' exists: %w", configPath, err)
+	}
+
+	path, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	// Use standard config directory
+	configPath = filepath.Join(path, "/ocm/ocm.json")
+	_, err = os.Stat(configPath)
+	if err == nil {
+		// File exists, use it
+		return configPath, nil
+	}
+
+	// Some weird error occurred
+	return "", err
 }
 
 // Connection creates a connection using this configuration.


### PR DESCRIPTION
The code simplifies the ocm config loading. It also moves the env variables right to the start, 
so it is obvious when they are used.