### PR TITLE
Experimental POC: add k8sgpt permissions

### DIFF
--- a/pkg/investigations/aitest/README.md
+++ b/pkg/investigations/aitest/README.md
@@ -1,0 +1,8 @@
+# aitest Investigation
+
+Test investigation to run k8sgpt
+
+## Testing
+
+Refer to the [testing README](./testing/README.md) for instructions on testing this investigation
+

--- a/pkg/investigations/aitest/metadata.yaml
+++ b/pkg/investigations/aitest/metadata.yaml
@@ -5,5 +5,4 @@ rbac:
     - verbs: ["get", "watch", "list"]
       apiGroups: ["*"]
       resources: ["*"]
-customerDataAccess: false
-
+customerDataAccess: true

--- a/pkg/investigations/aitest/metadata.yaml
+++ b/pkg/investigations/aitest/metadata.yaml
@@ -1,0 +1,9 @@
+name: aitest
+rbac:
+  roles: []
+  clusterRoleRules:
+    - verbs: ["get", "watch", "list"]
+      apiGroups: ["*"]
+      resources: ["*"]
+customerDataAccess: false
+

--- a/pkg/investigations/aitest/testing/README.md
+++ b/pkg/investigations/aitest/testing/README.md
@@ -1,0 +1,5 @@
+# Testing aitest Investigation
+
+TODO:
+- Add a test script or test objects to this  directory for future maintainers to use
+- Edit this README file and add detailed instructions on how to use the script/objects to recreate the conditions for the investigation. Be sure to include any assumptions or prerequisites about the environment (disable hive syncsetting, etc)


### PR DESCRIPTION
This PR adds full read permissions for a new investigation that will stay experimental for now and doesn't map to a real alert. 