### PR TITLE
Fix security context for tekton resource pruner

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -357,9 +357,9 @@ objects:
                   cpu: 100m
                   memory: 64Mi
               securityContext:
-                runAsGroup: 1000
+                runAsGroup: 65534
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 65534
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: FallbackToLogsOnError
             dnsPolicy: ClusterFirst


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-67
Switch to runAsUser & runAsGroup 65534

`Warning  FailedCreate  56s (x42 over 36m)  job-controller  Error creating: pods "tekton-resource-pruner-29117400-" is forbidden: unable to validate against any security context constraint`
