### PR TITLE
Add seccompProfile RuntimeDefault to tekton pruner job

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -360,6 +360,8 @@ objects:
                 runAsGroup: 65534
                 runAsNonRoot: true
                 runAsUser: 65534
+                seccompProfile:
+                  type: RuntimeDefault
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: FallbackToLogsOnError
             dnsPolicy: ClusterFirst


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-67

Follow up to https://github.com/openshift/configuration-anomaly-detection/pull/440 as user and group was not enough :D 

`Warning  FailedCreate  56s (x42 over 36m)  job-controller  Error creating: pods "tekton-resource-pruner-29117400-" is forbidden: unable to validate against any security context constraint`