### PR TITLE
OSD-28525 - make MachineHealthCheckShortCircuitUnterminatedSRE investigation non-experimental

### DIFF
--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre.go
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre.go
@@ -321,7 +321,7 @@ func (i *Investigation) Description() string {
 }
 
 func (i *Investigation) IsExperimental() bool {
-	return true
+	return false
 }
 
 func (i *Investigation) ShouldInvestigateAlert(alert string) bool {


### PR DESCRIPTION
Updates the `MachineHealthCheckShortCircuitUnterminatedSRE` investigation to indicate it's no longer an experimental feature, and should run in prod.