### PR TITLE
fix e2e test blocking build

### DIFF
--- a/test/e2e/configuration_anomaly_detection_test.go
+++ b/test/e2e/configuration_anomaly_detection_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 			ec2Client := ec2.NewFromConfig(awsCfg)
 			ec2Wrapper := NewEC2ClientWrapper(ec2Client)
 
-			awsCli, err := awsinternal.NewClient(awsAccessKey, awsSecretKey, "", region)
+			awsCli, err := awsinternal.NewClient(awsCfg)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create AWS client")
 
 			clusterResource, err := ocme2eCli.ClustersMgmt().V1().Clusters().Cluster(clusterID).Get().Send()


### PR DESCRIPTION
```
# github.com/openshift/configuration-anomaly-detection/test/e2e [github.com/openshift/configuration-anomaly-detection/test/e2e.test]
15:21:47 test/e2e/configuration_anomaly_detection_test.go:93:55: too many arguments in call to awsinternal.NewClient
15:21:47 	have (string, string, string, string)
15:21:47 	want ("github.com/aws/aws-sdk-go-v2/aws".Config)
15:21:53 Error: building at STEP "RUN CGO_ENABLED=0 GOFLAGS="-mod=mod" go test ./test/e2e -v -c --tags=osde2e -o /e2e.test": while running runtime: exit status 1
15:21:53 make: *** [test/e2e/project.mk:31: e2e-image-build-push] Error 1
15:21:53 Build step 'Execute shell' marked build as failure
15:21:53 Finished: FAILURE
```