### PR TITLE
Update backplane-cli dependency.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.465
 	github.com/openshift/api v0.0.0-20240522145529-93d6bda14341
 	github.com/openshift/aws-account-operator/api v0.0.0-20231122143531-33ce90caf221
-	github.com/openshift/backplane-cli v0.0.0-20250516093910-32e363ce21df
+	github.com/openshift/backplane-cli v0.1.47-0.20250520114816-dcf230e7701b
 	github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f
 	github.com/openshift/osd-network-verifier v1.2.3
 	github.com/openshift/osde2e-common v0.0.0-20250409072139-f917c50a4bd2

--- a/go.sum
+++ b/go.sum
@@ -1436,8 +1436,8 @@ github.com/openshift/aws-account-operator/api v0.0.0-20231122143531-33ce90caf221
 github.com/openshift/aws-account-operator/api v0.0.0-20231122143531-33ce90caf221/go.mod h1:1PdbQqTDrejSl9zsScM1x59f0oHNTsAgoJqTZqTkH/U=
 github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70 h1:rUcdH93mEXHMviKxy1no2vFuQm0TiqA2vuCKnczeQ1k=
 github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
-github.com/openshift/backplane-cli v0.0.0-20250516093910-32e363ce21df h1:AiaYxo0grxE3JTkzwiW+3Qk07s4LChZQbP5liwjW12o=
-github.com/openshift/backplane-cli v0.0.0-20250516093910-32e363ce21df/go.mod h1:DKTrs4gWVq+VMmGGHnxejfTfhz4r4Q4tpXivLBr2JJw=
+github.com/openshift/backplane-cli v0.1.47-0.20250520114816-dcf230e7701b h1:Ozma/KBOl31VWzE+pOxnnGiWPCA1ghovp3cg3zZ/Lu0=
+github.com/openshift/backplane-cli v0.1.47-0.20250520114816-dcf230e7701b/go.mod h1:DKTrs4gWVq+VMmGGHnxejfTfhz4r4Q4tpXivLBr2JJw=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f h1:CedFPNwCSYbjo7rCr9YrJs/0OrBf3m8sLlUZw66VDwY=

--- a/interceptor/go.mod
+++ b/interceptor/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/openshift/api v0.0.0-20240522145529-93d6bda14341 // indirect
 	github.com/openshift/aws-account-operator/api v0.0.0-20231122143531-33ce90caf221 // indirect
 	github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70 // indirect
-	github.com/openshift/backplane-cli v0.0.0-20250516093910-32e363ce21df // indirect
+	github.com/openshift/backplane-cli v0.1.47-0.20250520114816-dcf230e7701b // indirect
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 // indirect
 	github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f // indirect
 	github.com/openshift/osd-network-verifier v1.2.3 // indirect

--- a/interceptor/go.sum
+++ b/interceptor/go.sum
@@ -1476,8 +1476,8 @@ github.com/openshift/aws-account-operator/api v0.0.0-20231122143531-33ce90caf221
 github.com/openshift/aws-account-operator/api v0.0.0-20231122143531-33ce90caf221/go.mod h1:1PdbQqTDrejSl9zsScM1x59f0oHNTsAgoJqTZqTkH/U=
 github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70 h1:rUcdH93mEXHMviKxy1no2vFuQm0TiqA2vuCKnczeQ1k=
 github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
-github.com/openshift/backplane-cli v0.0.0-20250516093910-32e363ce21df h1:AiaYxo0grxE3JTkzwiW+3Qk07s4LChZQbP5liwjW12o=
-github.com/openshift/backplane-cli v0.0.0-20250516093910-32e363ce21df/go.mod h1:DKTrs4gWVq+VMmGGHnxejfTfhz4r4Q4tpXivLBr2JJw=
+github.com/openshift/backplane-cli v0.1.47-0.20250520114816-dcf230e7701b h1:Ozma/KBOl31VWzE+pOxnnGiWPCA1ghovp3cg3zZ/Lu0=
+github.com/openshift/backplane-cli v0.1.47-0.20250520114816-dcf230e7701b/go.mod h1:DKTrs4gWVq+VMmGGHnxejfTfhz4r4Q4tpXivLBr2JJw=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f h1:CedFPNwCSYbjo7rCr9YrJs/0OrBf3m8sLlUZw66VDwY=


### PR DESCRIPTION
This is needed as the previous version filtered the IP Whitelist and blocked CAD.