### PR TITLE
Fix obtaining of "experimental enabled" env variable

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -87,7 +88,8 @@ func run(cmd *cobra.Command, _ []string) error {
 		}
 	}()
 
-	_, cadExperimentalEnabled := os.LookupEnv("CAD_EXPERIMENTAL_ENABLED")
+	experimentalEnabledVar := os.Getenv("CAD_EXPERIMENTAL_ENABLED")
+	cadExperimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
 	alertInvestigation := investigations.GetInvestigation(pdClient.GetTitle(), cadExperimentalEnabled)
 
 	// Escalate all unsupported alerts

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/PagerDuty/go-pagerduty/webhookv3"
@@ -141,7 +142,9 @@ func (pdi *PagerDutyInterceptor) Process(ctx context.Context, r *triggersv1.Inte
 		return interceptors.Failf(codes.InvalidArgument, "could not initialize pagerduty client: %v", err)
 	}
 
-	_, cadExperimentalEnabled := os.LookupEnv("CAD_EXPERIMENTAL_ENABLED")
+	experimentalEnabledVar := os.Getenv("CAD_EXPERIMENTAL_ENABLED")
+	cadExperimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
+
 	investigation := investigations.GetInvestigation(pdClient.GetTitle(), cadExperimentalEnabled)
 	// If the alert is not in the whitelist, return `Continue: false` as interceptor response
 	// and escalate the alert to SRE


### PR DESCRIPTION
This minor PR fixes the non-functioning experimental enabled flag. For context see https://redhat-internal.slack.com/archives/C04PN0YCWGL/p1747756748758649?thread_ts=1747754723.175979&cid=C04PN0YCWGL