### PR TITLE
OSD-28972: Updated github actions workflow to support dependabot PRs

### DIFF
--- a/.github/workflows/auto-tidy-interceptor.yml
+++ b/.github/workflows/auto-tidy-interceptor.yml
@@ -1,37 +1,51 @@
 name: Auto tidy interceptor after cadctl changes
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
     paths:
       - 'go.mod'
       - 'go.sum'
       - '**/*.go'
       - '!interceptor/**'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   tidy:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout the repository
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-            go-version: 'stable'
+          go-version: stable
 
       - name: Run go mod tidy in interceptor
         working-directory: interceptor
+        run: go mod tidy
+
+      - name: Check for changes when run go mod tidy in interceptor
+        id: diffcheck
         run: |
-          go mod tidy
-          git diff
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add go.mod go.sum
-            git commit -m "On PR: tidy interceptor go.mod after cadctl go.mod update"
-            git push
+          if [[ -n "$(git status --porcelain interceptor/go.mod interceptor/go.sum)" ]]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Commit and push if there are changes
+        if: steps.diffcheck.outputs.changes == 'true'
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: "On PR: tidy interceptor go.mod after cadctl go.mod update"
+          add: "interceptor/go.mod interceptor/go.sum"


### PR DESCRIPTION
Implemented a github action to fix the [OSD-28972](https://issues.redhat.com//browse/OSD-28972).
This will automatically detect if there is any change in go.mod from root/cadctl and auto tidy the interceptor go.mod and updates the PR