### PR TITLE
SREP-207: The interceptor is now producing metrics which can will be used to alert is something is wrong

### DIFF
--- a/interceptor/go.mod
+++ b/interceptor/go.mod
@@ -7,9 +7,11 @@ toolchain go1.23.9
 require (
 	github.com/PagerDuty/go-pagerduty v1.8.0
 	github.com/openshift/configuration-anomaly-detection v0.0.0-00010101000000-000000000000
+	github.com/prometheus/client_golang v1.22.0
 	github.com/tektoncd/triggers v0.27.0
 	google.golang.org/grpc v1.70.0
 	knative.dev/pkg v0.0.0-20241026180704-25f6002b00f3
+	sigs.k8s.io/controller-runtime v0.19.3
 )
 
 require (
@@ -226,7 +228,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
@@ -306,7 +307,6 @@ require (
 	k8s.io/kubectl v0.32.2 // indirect
 	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979 // indirect
 	oras.land/oras-go v1.2.5 // indirect
-	sigs.k8s.io/controller-runtime v0.19.3 // indirect
 	sigs.k8s.io/gateway-api v1.2.1 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/kustomize/api v0.18.0 // indirect

--- a/interceptor/pkg/interceptor/metrics.go
+++ b/interceptor/pkg/interceptor/metrics.go
@@ -1,0 +1,59 @@
+package interceptor
+
+import (
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	requestsCountMetricName = "cad_interceptor_requests_total"
+	requestsCountMetricHelp = "Number of times CAD interceptor has been called (through a PagerDuty webhook, normally)"
+
+	errorsCountMetricName = "cad_interceptor_errors_total"
+	errorsCountMetricHelp = "Number of times CAD interceptor has been failed to process a request"
+)
+
+var (
+	requestsCountMetricDesc = prometheus.NewDesc(
+		requestsCountMetricName,
+		requestsCountMetricHelp,
+		nil, nil)
+
+	errorsCountMetricDesc = prometheus.NewDesc(
+		errorsCountMetricName,
+		errorsCountMetricHelp,
+		[]string{"error_code", "reason"}, nil)
+)
+
+type interceptorMetricsCollector struct {
+	stats *InterceptorStats
+}
+
+func CreateAndRegisterMetricsCollector(stats *InterceptorStats) {
+	metrics.Registry.MustRegister(&interceptorMetricsCollector{stats})
+}
+
+func (c *interceptorMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func (c *interceptorMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(
+		requestsCountMetricDesc,
+		prometheus.CounterValue,
+		float64(c.stats.RequestsCount),
+	)
+
+	for codeWithReason, errorsCount := range c.stats.CodeWithReasonToErrorsCount {
+		ch <- prometheus.MustNewConstMetric(
+			errorsCountMetricDesc,
+			prometheus.CounterValue,
+			float64(errorsCount),
+			strconv.Itoa(codeWithReason.ErrorCode),
+			codeWithReason.Reason,
+		)
+	}
+}

--- a/interceptor/test/e2e.sh
+++ b/interceptor/test/e2e.sh
@@ -20,7 +20,8 @@ function test_interceptor {
 
     local incident_id=$1
     local expected_response=$2
-    local override_signature=$3
+    local expected_metrics=$3
+    local override_signature=$4
 
     # Run the interceptor and print logs to temporary log file
     export PD_SIGNATURE="test"
@@ -52,13 +53,10 @@ function test_interceptor {
         -d "$WRAPPED_PAYLOAD" \
         http://localhost:8080) || CURL_EXITCODE=$?
 
-    # Check if the curl output matches the expected response
-    if [[ "$CURL_OUTPUT" == "$expected_response" ]] && [[ "$CURL_EXITCODE" == "0" ]]; then
-        echo -e "${GREEN}Test passed for incident ID $incident_id: Response is as expected.${NC}"
+    local return_code=0
 
-        # Shut down the interceptor
-        kill $INTERCEPTOR_PID
-    else
+    # Check if the curl output differs from the expected response
+    if [[ "$CURL_OUTPUT" != "$expected_response" ]] || [[ "$CURL_EXITCODE" != "0" ]]; then
         echo -e "${RED}Test failed for incident ID $incident_id: Unexpected response.${NC}"
         echo -e "${RED}Expected: $expected_response${NC}"
         echo -e "${RED}Got: $CURL_OUTPUT${NC}"
@@ -66,12 +64,29 @@ function test_interceptor {
         echo -e ""
         echo -e "Interceptor logs"
         cat $temp_log_file
+        return_code=1
+    else
+        curl_metrics_exitcode=0
+        curl_metrics_output=$(curl -s http://localhost:8080/metrics | grep '^cad_interceptor_') || curl_metrics_exitcode=$?
 
-        # Shut down the interceptor
-        kill $INTERCEPTOR_PID
-
-        return 1
+        if [[ "$curl_metrics_output" != "$expected_metrics" ]] || [[ "$curl_metrics_exitcode" != "0" ]]; then
+            echo -e "${RED}Test failed for incident ID $incident_id: Unexpected metrics.${NC}"
+            echo -e "${RED}Expected: $expected_metrics${NC}"
+            echo -e "${RED}Got: $curl_metrics_output${NC}"
+            echo -e "${RED}Exit code: $curl_metrics_exitcode${NC}"
+            echo -e ""
+            echo -e "Interceptor logs"
+            cat $temp_log_file
+            return_code=1
+        else
+            echo -e "${GREEN}Test passed for incident ID $incident_id: Response and metrics are as expected.${NC}"
+        fi
     fi
+
+    # Shut down the interceptor
+    kill $INTERCEPTOR_PID
+
+    return $return_code
 }
 
 # Expected outputs
@@ -83,13 +98,13 @@ EXPECTED_RESPONSE_SIGNATURE_ERROR='failed to verify signature: invalid webhook s
 echo "========= TESTS ============="
 # Test for a pre-existing alert we handle (ClusterProvisioningDelay)
 echo "Test 1: alert with existing handling returns a 'continue: true' response"
-test_interceptor "Q12WO44XJLR3H3" "$EXPECTED_RESPONSE_CONTINUE"
+test_interceptor "Q12WO44XJLR3H3" "$EXPECTED_RESPONSE_CONTINUE" "cad_interceptor_requests_total 1"
 
 # Test for an alert we don't handle (alert called unhandled)
 echo "Test 2: unhandled alerts returns a 'continue: false' response"
-test_interceptor "Q3722KGCG12ZWD" "$EXPECTED_RESPONSE_STOP"
+test_interceptor "Q3722KGCG12ZWD" "$EXPECTED_RESPONSE_STOP" "cad_interceptor_requests_total 1"
 
 # Test for an alert with invalid signature
 echo "Test 3: expected failure due to invalid signature"
 PD_SIGNATURE="invalid-signature"
-test_interceptor "Q12WO44XJLR3H3" "$EXPECTED_RESPONSE_SIGNATURE_ERROR" "invalid-signature"
+test_interceptor "Q12WO44XJLR3H3" "$EXPECTED_RESPONSE_SIGNATURE_ERROR" 'cad_interceptor_errors_total{error_code="400",reason="failed to verify signature"} 1'$'\n''cad_interceptor_requests_total 1' "invalid-signature"


### PR DESCRIPTION
Added the following metrics to the interceptor process:

- `cad_interceptor_requests_total` no labels
- `cad_interceptor_errors_total` with `error_code` and `reason` labels.

Cardinality should be quite low.
Tell me if we also need to track the time it takes to process the requests. I personally don't think this is needed, or at least not yet.