### PR TITLE
Osd_30030 E2E Test cases ClusterMonitoringErrorBudgetBurnSRE

### DIFF
--- a/test/e2e/configuration_anomaly_detection_test.go
+++ b/test/e2e/configuration_anomaly_detection_test.go
@@ -407,9 +407,6 @@ var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 			err = k8s.Get(ctx, configMapName, namespace, originalCM)
 			Expect(err).ToNot(HaveOccurred(), "Failed to fetch original ConfigMap")
 
-			// Create a deep copy so we can restore it later
-			// backupCM := originalCM.DeepCopy()
-
 			// STEP 3: Inject invalid YAML into the ConfigMap to simulate misconfiguration
 			fmt.Println("Step 3: Injecting invalid config to simulate misconfiguration")
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -4,12 +4,16 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	servicelogsv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 	ocme2e "github.com/openshift/osde2e-common/pkg/clients/ocm"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func GetLimitedSupportReasons(ocme2eCli *ocme2e.Client, clusterID string) (*cmv1.LimitedSupportReasonsListResponse, error) {
@@ -28,4 +32,25 @@ func GetServiceLogs(ocmCli ocm.Client, cluster *cmv1.Cluster) (*servicelogsv1.Cl
 		return nil, fmt.Errorf("Failed to get service log: %w", err)
 	}
 	return clusterLogsUUIDListResponse, nil
+}
+
+// FetchConfigMap fetches the ConfigMap from Kubernetes.
+func FetchConfigMap(kubeClient kubernetes.Interface, namespace, configMapName string, ctx context.Context) (*corev1.ConfigMap, error) {
+	return kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, configMapName, metav1.GetOptions{})
+}
+
+// UpdateConfigMap applies the provided data to the ConfigMap.
+func UpdateConfigMap(kubeClient kubernetes.Interface, namespace, configMapName string, updatedData map[string]string, ctx context.Context) error {
+	cm, err := FetchConfigMap(kubeClient, namespace, configMapName, ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch ConfigMap %s/%s: %w", namespace, configMapName, err)
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	for k, v := range updatedData {
+		cm.Data[k] = v
+	}
+	_, err = kubeClient.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	return err
 }


### PR DESCRIPTION

E2E Test: ClusterMonitoringErrorBudgetBurn Alert Trigger and Recovery (OSD-30030)

Description:
This PR adds an E2E test for the ClusterMonitoringErrorBudgetBurn alert, targeting AWS CCS clusters.

The test misconfigures the user-workload-monitoring-config ConfigMap in the openshift-user-workload-monitoring namespace to simulate excessive monitoring error budget burn. It then checks if a service log is created and finally deletes the ConfigMap to clean up the test state.

Steps:
Fetch initial cluster info and current service logs.

Backup the original ConfigMap.

Inject malformed YAML to trigger the alert.

Wait for CAD/system reaction.

Validate that a new service log is generated.

Delete the ConfigMap as a recovery step.

Acceptance:
Alert is triggered (ClusterMonitoringErrorBudgetBurnSRE).

Service log is sent to the customer.

Cluster state is restored by deleting the ConfigMap.