### PR TITLE
SREP-207: Allowing cad-interceptor-service service to be scrapped by Prometheus

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -91,6 +91,8 @@ objects:
   kind: Service
   metadata:
     name: cad-interceptor-service
+    labels:
+      app: configuration-anomaly-detection
   spec:
     ports:
     - port: 8080


### PR DESCRIPTION
Labelling the service as follows to do so: `app: configuration-anomaly-detection`

Same label is used for the `aggregation-pushgateway` service:
https://github.com/openshift/configuration-anomaly-detection/blob/main/openshift/gateway-template.yaml#L35

The `configuration-anomaly-detection-${env}` servicemonitor in `openshift-customer-monitoring` ns will now be used to configure Prometheus to scrape both services.