### PR TITLE
SREP-207: Naming cad-interceptor-service service port so it can be referenced by the ServiceMonitor

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -95,7 +95,8 @@ objects:
       app: configuration-anomaly-detection
   spec:
     ports:
-    - port: 8080
+    - name: web
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:


### PR DESCRIPTION
Unlike what I thought: service monitors cannot handle the numeric value of a port.