### PR TITLE
Fix bug SREP-652: User's incorrectly reporting as not banned.

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -344,7 +344,12 @@ func GetCreatorFromCluster(ocmConn *sdk.Connection, cluster *cmv1.Cluster) (*amv
 		return nil, fmt.Errorf("expecting status 'Active' found %v", status)
 	}
 
-	creator, ok := subscription.GetCreator()
+	accountResponse, err := ocmConn.AccountsMgmt().V1().Accounts().Account(subscription.Creator().ID()).Get().Send()
+	if err != nil {
+		return nil, err
+	}
+
+	creator, ok := accountResponse.GetBody()
 	if !ok {
 		return nil, errors.New("failed to get creator from subscription")
 	}

--- a/test/generate_incident.sh
+++ b/test/generate_incident.sh
@@ -11,6 +11,7 @@ declare -A alert_mapping=(
     ["MachineHealthCheckUnterminatedShortCircuitSRE"]="MachineHealthCheckUnterminatedShortCircuitSRE CRITICAL (1)"
     ["ApiErrorBudgetBurn"]="api-ErrorBudgetBurn k8sgpt test CRITICAL (1)"
     ["CannotRetrieveUpdatesSRE"]="CannotRetrieveUpdatesSRE"
+    ["UpgradeConfigSyncFailureOver4HrSRE"]="UpgradeConfigSyncFailureOver4HrSRE Critical (1)"
 )
 
 # Function to print help message


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/CB53T9ZHQ/p1748452131912789

The issue in the original code is in the endpoint used to get the creator account information. We originally used the subscription API endpoint, which doesn't return all the information we need to make this change. I have updated the code to take the subscription id we get and hit the api again afterwards, this time using the accounts API endpoint.

I also used this PR to add a line to the generate incident script for the "UpgradeConfigSyncFailureOver4HrSRE Critical (1)" alert which I inadvertently left out of a previous PR.
