### PR TITLE
Remove jq from cads image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -36,6 +36,4 @@ LABEL vendor="RedHat" \
   org.label-schema.vendor="openshift/configuration-anomaly-detection" \
   org.label-schema.version=$VERSION
 
-RUN microdnf install jq
-
 ENTRYPOINT ["/bin/cadctl"]


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / Why we need it?
Removes unnecessary jq dep in cads image. Found this as it failed the image build when using ubi9

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- E2E testing is desired for actioning investigations. See README for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
