### PR TITLE
fix failing builds by updating e2e tests to use changed ocm.New

### DIFF
--- a/test/e2e/configuration_anomaly_detection_test.go
+++ b/test/e2e/configuration_anomaly_detection_test.go
@@ -52,16 +52,14 @@ var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 		clientID := os.Getenv("CLIENT_ID")
 		clientSecret := os.Getenv("CLIENT_SECRET")
 		clusterID = os.Getenv("OCM_CLUSTER_ID")
-		cadOcmFilePath := os.Getenv("CAD_OCM_FILE_PATH")
 
 		Expect(ocmToken).NotTo(BeEmpty(), "OCM_TOKEN must be set")
 		Expect(clusterID).NotTo(BeEmpty(), "CLUSTER_ID must be set")
-		Expect(cadOcmFilePath).NotTo(BeEmpty(), "CAD_OCM_FILE_PATH must be set")
 
 		ocme2eCli, err = ocme2e.New(ctx, ocmToken, clientID, clientSecret, ocmEnv)
 		Expect(err).ShouldNot(HaveOccurred(), "Unable to setup E2E OCM Client")
 
-		ocmCli, err = ocm.New(cadOcmFilePath)
+		ocmCli, err = ocm.New()
 		Expect(err).ShouldNot(HaveOccurred(), "Unable to setup ocm anomaly detection client")
 
 		k8s, err = openshift.New(ginkgo.GinkgoLogr)


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?
Updates e2e tests to use the updated ocm.New() function which was changed in #492 

### Special notes for your reviewer
No idea if this breaks the e2e tests, I just update this to make the builds pass

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- E2E testing is desired for actioning investigations. See README for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
