### PR TITLE
Fix remediation name for CannotRetrieveUpdatesSRE to match directory

### DIFF
--- a/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
+++ b/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
@@ -15,18 +15,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	alertname       = "CannotRetrieveUpdatesSRE"
-	remediationName = "CannotRetrieveUpdatesSRE"
-)
-
 type Investigation struct{}
 
 // Run executes the investigation for the CannotRetrieveUpdatesSRE alert
 func (c *Investigation) Run(r *investigation.Resources) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
 	notes := notewriter.New("CannotRetrieveUpdatesSRE", logging.RawLogger)
-	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient, remediationName)
+	k8scli, err := k8sclient.New(r.Cluster.ID(), r.OcmClient, r.Name)
 	if err != nil {
 		return result, fmt.Errorf("unable to initialize k8s cli: %w", err)
 	}
@@ -101,15 +96,15 @@ func checkCondition(condition configv1.ClusterOperatorStatusCondition) (string, 
 }
 
 func (i *Investigation) Name() string {
-	return alertname
+	return "cannotretrieveupdatessre"
 }
 
 func (i *Investigation) Description() string {
-	return fmt.Sprintf("Investigates '%s' alerts by running network verifier and checking ClusterVersion", alertname)
+	return fmt.Sprintf("Investigates '%s' alerts by running network verifier and checking ClusterVersion", i.Name())
 }
 
 func (i *Investigation) ShouldInvestigateAlert(alert string) bool {
-	return strings.Contains(alert, alertname)
+	return strings.Contains(alert, "CannotRetrieveUpdatesSRE")
 }
 
 func (i *Investigation) IsExperimental() bool {


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / Why we need it?
Fix the remediation name for CannotRetrieveUpdatesSRE to match the directory.
This is due to a backplane limitation. 
To find the metadata.yaml, backplane-api needs the remediation to have the same name as the directory it lives in.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- E2E testing is desired for actioning investigations. See README for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
