### PR TITLE
Prevent script failure on empty client_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ It will run services on the following local ports:8001 8091 8443 8888
 5. Run `cadctl` with the payload file created by `test/generate_incident.sh` and proxy as well as the backplane URL set to localhost
 
    ```bash
-   BACKPLANE_URL=https://localhost:8443 HTTP_PROXY=http://127.0.0.1:8888 HTTPS_PROXY=http://127.0.0.1:8888 BACKPLANE_PROXY=http://127.0.0.1:8888  ./bin/cadctl investigate --payload-path ./payload --log-level debug"
+   BACKPLANE_URL=https://localhost:8443 HTTP_PROXY=http://127.0.0.1:8888 HTTPS_PROXY=http://127.0.0.1:8888 BACKPLANE_PROXY=http://127.0.0.1:8888  ./bin/cadctl investigate --payload-path ./payload --log-level debug
    ```
 6. Close the local infrastructure when done by sending SIGINT (Ctrl+C) to the launch_local_env.sh
 

--- a/test/launch_local_env.sh
+++ b/test/launch_local_env.sh
@@ -28,7 +28,7 @@ check_presence "haproxy"
 check_presence "proxytunnel"
 
 #loading env vars
-. ${CAD_REPO_PATH}/test/set_stage_env.sh 
+. ${CAD_REPO_PATH}/test/set_stage_env.sh
 
 #checking env vars
 set +u
@@ -38,7 +38,7 @@ if [[ -z "${OCM_BACKPLANE_REPO_PATH}" ]]; then
 fi
 set -u
 
-if ! [ $(cat ${OCM_BACKPLANE_REPO_PATH}/configs/ocm.json | jq -r .client_id) = "ocm-backplane-staging" ]; then
+if ! [ "$(cat ${OCM_BACKPLANE_REPO_PATH}/configs/ocm.json | jq -r .client_id)" = "ocm-backplane-staging" ]; then
     echo "OCM Backplane ocm.json (${OCM_BACKPLANE_REPO_PATH}/configs/ocm.json) isn't the ocm-backplane-staging config."
     echo "Please get the config from a backplane pod on a staging backplanes0* cluster (in /ocm inside the pod)"
     echo "and place it in the configs subdirectory of the backplane-api repo."


### PR DESCRIPTION
In `test/launch_local_env.sh`, the check for the `client_id` could fail with a "unary operator expected" error if the `jq` command produced an empty result. This would happen if the config file path was invalid or the `client_id` key was missing, causing the script to crash abruptly.

By wrapping the command substitution in double quotes, the comparison remains syntactically valid even with an empty string. This allows the script to fail gracefully and display its own helpful error message instead of exiting with a shell error.

Additionally, a stray quotation mark is removed from a command example in the README.
