### PR TITLE
[SREP-703] Add a limitrange to CAD.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -416,3 +416,22 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: cad-tekton-pruner
+- apiVersion: v1
+  kind: LimitRange
+  metadata:
+    name: cad-limitrange
+  spec:
+    limits:
+    - default:  # The default limits
+        cpu: 500m
+        memory: 256Mi
+      defaultRequest:  # The default requests
+        cpu: 100m
+        memory: 128Mi
+      max:  # The maximum limits
+        cpu: 1
+        memory: 1Gi
+      min:  # The minimum requests
+        cpu: 1m
+        memory: 32Mi
+      type: Container


### PR DESCRIPTION
This is required, because Tekton does not set resourcerequests and limits for the init-containers which will trigger deployment-validation alerts.

Instead it will use the limitRange for init-containers: see https://github.com/tektoncd/pipeline/blob/main/docs/compute-resources.md#limitrange-support

### What type of PR is this?

Feature

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
