### PR TITLE
fix regression in CPD investigation - clusterdeployment missing

### DIFF
--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -29,7 +29,7 @@ var byovpcRoutingSL = &ocm.ServiceLog{Severity: "Major", Summary: "Installation 
 // In the future, we want to automate service logs based on the network verifier output.
 func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
-	r, err := rb.Build()
+	r, err := rb.WithClusterDeployment().Build()
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
### What type of PR is this?

Fix regression in cpd builder

The introduction of the request builder pattern in the cluster-permission-denied investigation caused a regression.

This change introduces the call to `WithClusterDeployment()` when building the request, ensuring the investigation runs correctly.

This has caused segfaults in staging.