### PR TITLE
Fix: pre-check exits early on unknown access protection

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -122,6 +122,9 @@ func run(cmd *cobra.Command, _ []string) error {
 		logging.Warnf("No cluster found with ID '%s'. Escalating and exiting.", clusterID)
 		return pdClient.EscalateIncidentWithNote("CAD was unable to find the incident cluster in OCM. An alert for a non-existing cluster is unexpected. Please investigate manually.")
 	}
+	if result.StopInvestigations {
+		return nil
+	}
 
 	ccamInvestigation := ccam.Investigation{}
 	result, err = ccamInvestigation.Run(builder)

--- a/pkg/investigations/precheck/precheck.go
+++ b/pkg/investigations/precheck/precheck.go
@@ -35,7 +35,9 @@ func (c *ClusterStatePrecheck) Run(rb investigation.ResourceBuilder) (investigat
 
 	isAccessProtected, err := ocmClient.IsAccessProtected(cluster)
 	if err != nil {
-		logging.Warnf("failed to get access protection status for cluster. %w. Continuing...")
+		logging.Warnf("failed to get access protection status for cluster: %v. Escalating for manual handling.", err)
+		result.StopInvestigations = true
+		return result, pdClient.EscalateIncidentWithNote("CAD could not determine access protection status for this cluster, as CAD is unable to run against access protected clusters, please investigate manually.")
 	}
 	if isAccessProtected {
 		logging.Info("Cluster is access protected. Escalating alert.")


### PR DESCRIPTION
### What type of PR is this?

This PR fixes two things:
- we now exit early and gracefully if access protection is unknown. This prevents errors later in the logic with little context.
- we exit gracefully again if prechecks determine a cluster doesn't need to be investigated. 
### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
