### PR TITLE
Group golang dependencies in daily dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
       - dependency-type: all
     schedule:
       interval: "daily"
+    groups:
+      golang-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Configure dependabot to group all golang dependency updates into a single daily PR
- Reduces individual dependency PRs that trigger E2E tests on each main branch merge
- Maintains daily update schedule while consolidating changes

## Test plan
- [ ] Verify dependabot configuration is valid
- [ ] Confirm that future golang dependency updates are grouped into single PRs
- [ ] Monitor that E2E test runs are reduced on main branch

🤖 Generated with [Claude Code](https://claude.ai/code)