### PR TITLE
Fix: access to clusterdeployment before defining it

### DIFF
--- a/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
+++ b/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
@@ -20,7 +20,7 @@ type Investigation struct{}
 // Run executes the investigation for the CannotRetrieveUpdatesSRE alert
 func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
-	r, err := rb.WithAwsClient().Build()
+	r, err := rb.WithAwsClient().WithClusterDeployment().Build()
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

We access the clusterdeployment while not querying it through our builder pattern, which causes a seg fault. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x210 pc=0x3bf46b2]

goroutine 1 [running]:
github.com/openshift/configuration-anomaly-detection/pkg/networkverifier.InitializeValidateEgressInput(0xc0004b0c88, 0xa0?, {0x4e951b0, 0xc00038e320})
	github.com/openshift/configuration-anomaly-detection/pkg/networkverifier/networkverifier.go:34 +0x32
github.com/openshift/configuration-anomaly-detection/pkg/networkverifier.Run(0xc0004b0c88, 0x18?, {0x4e951b0, 0xc00038e320})
	github.com/openshift/configuration-anomaly-detection/pkg/networkverifier/networkverifier.go:94 +0x3a
github.com/openshift/configuration-anomaly-detection/pkg/investigations/cannotretrieveupdatessre.(*Investigation).Run(0xc000111958?, {0x4e99700?, 0xc000116a80?})
	github.com/openshift/configuration-anomaly-detection/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go:41 +0x1ba
github.com/openshift/configuration-anomaly-detection/cadctl/cmd/investigate.run(0xc00014a300?, {0x47f6f57?, 0x4?, 0x47f6f5b?})
	github.com/openshift/configuration-anomaly-detection/cadctl/cmd/investigate/investigate.go:137 +0x95b
github.com/spf13/cobra.(*Command).execute(0x6f69860, {0xc00001d180, 0x2, 0x2})
	github.com/spf13/cobra@v1.9.1/command.go:1015 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0x6f695a0)
	github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/openshift/configuration-anomaly-detection/cadctl/cmd.Execute()
	github.com/openshift/configuration-anomaly-detection/cadctl/cmd/root.go:35 +0x1e
main.main()
	github.com/openshift/configuration-anomaly-detection/cadctl/main.go:23 +0xf
```

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
