### PR TITLE
Refactor: Extract k8s environment loading to investigate command

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/ccam"
 	investigation "github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/precheck"
+	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	ocm "github.com/openshift/configuration-anomaly-detection/pkg/ocm"
@@ -64,6 +65,15 @@ func init() {
 func run(cmd *cobra.Command, _ []string) error {
 	// early init of logger for logs before clusterID is known
 	logging.RawLogger = logging.InitLogger(logLevelFlag, pipelineNameEnv, "")
+
+	// Load k8s environment variables
+	backplaneURL := os.Getenv("BACKPLANE_URL")
+	if backplaneURL == "" {
+		return fmt.Errorf("missing required environment variable BACKPLANE_URL")
+	}
+
+	// Set k8s environment configuration for this session
+	k8sclient.SetBackplaneURL(backplaneURL)
 
 	payload, err := os.ReadFile(payloadPath)
 	if err != nil {

--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/precheck"
 	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/managedcloud"
 	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	ocm "github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
@@ -74,6 +75,21 @@ func run(cmd *cobra.Command, _ []string) error {
 
 	// Set k8s environment configuration for this session
 	k8sclient.SetBackplaneURL(backplaneURL)
+
+	// Load managedcloud environment variables
+	backplaneInitialARN := os.Getenv("BACKPLANE_INITIAL_ARN")
+	if backplaneInitialARN == "" {
+		return fmt.Errorf("missing required environment variable BACKPLANE_INITIAL_ARN")
+	}
+
+	backplaneProxy := os.Getenv("BACKPLANE_PROXY")
+	awsProxy := os.Getenv("AWS_PROXY")
+
+	// Set managedcloud environment configuration for this session
+	managedcloud.SetBackplaneURL(backplaneURL)
+	managedcloud.SetBackplaneInitialARN(backplaneInitialARN)
+	managedcloud.SetBackplaneProxy(backplaneProxy)
+	managedcloud.SetAWSProxy(awsProxy)
 
 	payload, err := os.ReadFile(payloadPath)
 	if err != nil {

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -3,7 +3,6 @@ package k8sclient
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/openshift/backplane-cli/pkg/cli/config"
 	bpremediation "github.com/openshift/backplane-cli/pkg/remediation"
@@ -11,6 +10,14 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var backplaneURL string
+
+// SetBackplaneURL sets the backplane URL to use for k8s client connections
+// FIXME: Replace with proper config mechanism when implemented service
+func SetBackplaneURL(url string) {
+	backplaneURL = url
+}
 
 type Cleaner interface {
 	Clean() error
@@ -74,9 +81,8 @@ func (cleaner remediationCleaner) Clean() error {
 
 // New returns a the k8s rest config for the given cluster scoped to a given remediation's permissions.
 func NewCfg(clusterID string, ocmClient ocm.Client, remediationName string) (cfg *Config, err error) {
-	backplaneURL := os.Getenv("BACKPLANE_URL")
 	if backplaneURL == "" {
-		return nil, fmt.Errorf("could not create new k8sclient: missing environment variable BACKPLANE_URL")
+		return nil, fmt.Errorf("could not create new k8sclient: backplane URL not configured, call SetBackplaneURL first")
 	}
 
 	decoratedCfg, remediationInstanceId, err := bpremediation.CreateRemediationWithConn(
@@ -97,9 +103,8 @@ func NewCfg(clusterID string, ocmClient ocm.Client, remediationName string) (cfg
 
 // Cleanup removes the remediation created for the cluster.
 func deleteRemediation(clusterID string, ocmClient ocm.Client, remediationInstanceId string) error {
-	backplaneURL := os.Getenv("BACKPLANE_URL")
 	if backplaneURL == "" {
-		return fmt.Errorf("could not clean up k8sclient: missing environment variable BACKPLANE_URL")
+		return fmt.Errorf("could not clean up k8sclient: backplane URL not configured, call SetBackplaneURL first")
 	}
 
 	return bpremediation.DeleteRemediationWithConn(


### PR DESCRIPTION
### What type of PR is this?

Refactoring

### What this PR does / Why we need it?

Move BACKPLANE_URL environment variable reading from pkg/k8s/client.go to cadctl/cmd/investigate/investigate.go for better separation of concerns and to avoid repeated environment variable reads.

Changes:
- Add SetBackplaneURL() function to k8s client package
- Load BACKPLANE_URL once in investigate command and pass to k8s client
- Remove direct os.Getenv() calls from k8s client functions
- Update error messages to reflect new configuration approach

This improves code organization by centralizing environment variable loading in the command layer rather than having infrastructure packages read environment variables directly.

🤖 Generated with [Claude Code](https://claude.ai/code)

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
