### PR TITLE
Refactor: Extract OCM environment loading to investigate command

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -91,6 +91,22 @@ func run(cmd *cobra.Command, _ []string) error {
 	managedcloud.SetBackplaneProxy(backplaneProxy)
 	managedcloud.SetAWSProxy(awsProxy)
 
+	// Load OCM environment variables
+	ocmClientID := os.Getenv("CAD_OCM_CLIENT_ID")
+	if ocmClientID == "" {
+		return fmt.Errorf("missing required environment variable CAD_OCM_CLIENT_ID")
+	}
+
+	ocmClientSecret := os.Getenv("CAD_OCM_CLIENT_SECRET")
+	if ocmClientSecret == "" {
+		return fmt.Errorf("missing required environment variable CAD_OCM_CLIENT_SECRET")
+	}
+
+	ocmURL := os.Getenv("CAD_OCM_URL")
+	if ocmURL == "" {
+		return fmt.Errorf("missing required environment variable CAD_OCM_URL")
+	}
+
 	payload, err := os.ReadFile(payloadPath)
 	if err != nil {
 		return fmt.Errorf("failed to read webhook payload: %w", err)
@@ -127,7 +143,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ocmClient, err := ocm.New()
+	ocmClient, err := ocm.New(ocmClientID, ocmClientSecret, ocmURL)
 	if err != nil {
 		return fmt.Errorf("could not initialize ocm client: %w", err)
 	}

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -54,13 +53,12 @@ type SdkClient struct {
 	conn *sdk.Connection
 }
 
-// New will create a new ocm client by using the path to a config file
-// if no path is provided, it will assume it in the default path
-func New() (*SdkClient, error) {
+// New will create a new ocm client using the provided credentials
+func New(clientID, clientSecret, url string) (*SdkClient, error) {
 	var err error
 	client := SdkClient{}
 
-	client.conn, err = newConnectionFromClientPair()
+	client.conn, err = newConnectionFromClientPair(clientID, clientSecret, url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connection from client key pair: %w", err)
 	}
@@ -70,14 +68,11 @@ func New() (*SdkClient, error) {
 
 // newConnectionFromClientPair creates a new connection via set of client ID, client secret
 // and the target OCM API URL.
-func newConnectionFromClientPair() (*sdk.Connection, error) {
-	ocmClientID, hasOcmClientID := os.LookupEnv("CAD_OCM_CLIENT_ID")
-	ocmClientSecret, hasOcmClientSecret := os.LookupEnv("CAD_OCM_CLIENT_SECRET")
-	ocmURL, hasOcmURL := os.LookupEnv("CAD_OCM_URL")
-	if !hasOcmClientID || !hasOcmClientSecret || !hasOcmURL {
-		return nil, fmt.Errorf("missing environment variables: CAD_OCM_CLIENT_ID CAD_OCM_CLIENT_SECRET CAD_OCM_URL")
+func newConnectionFromClientPair(clientID, clientSecret, url string) (*sdk.Connection, error) {
+	if clientID == "" || clientSecret == "" || url == "" {
+		return nil, fmt.Errorf("missing required parameters: clientID, clientSecret, or url")
 	}
-	return sdk.NewConnectionBuilder().URL(ocmURL).Client(ocmClientID, ocmClientSecret).Insecure(false).Build()
+	return sdk.NewConnectionBuilder().URL(url).Client(clientID, clientSecret).Insecure(false).Build()
 }
 
 // GetSupportRoleARN returns the support role ARN that allows the access to the cluster from internal cluster ID


### PR DESCRIPTION
### What type of PR is this?

refactor

### What this PR does / Why we need it?

Move OCM environment variable reading from pkg/ocm/ocm.go to investigate.go and refactor ocm.New() to accept credentials as function parameters instead of reading them directly from environment variables. This follows the same pattern established for k8s and managedcloud environment loading and improves testability through dependency injection.

Changes:
- Move CAD_OCM_CLIENT_ID, CAD_OCM_CLIENT_SECRET, CAD_OCM_URL reading to investigate.go
- Modify ocm.New() to accept clientID, clientSecret, url parameters
- Update newConnectionFromClientPair() to use passed parameters
- Remove unused os import from pkg/ocm/ocm.go

🤖 Generated with [Claude Code](https://claude.ai/code)

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
