### PR TITLE
Fix: Exit early if user is banned in insightsoperatordown investigation

### DIFF
--- a/pkg/investigations/insightsoperatordown/insightsoperatordown.go
+++ b/pkg/investigations/insightsoperatordown/insightsoperatordown.go
@@ -35,6 +35,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	if user.Banned() {
 		notes.AppendWarning("User is banned: %s\nBan description: %s\nPlease open a proactive case, so that MCS can resolve the ban or organize a ownership transfer.", user.BanCode(), user.BanDescription())
+		return result, r.PdClient.EscalateIncidentWithNote(notes.String())
 	} else {
 		notes.AppendSuccess("User is not banned.")
 	}


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Insightsoperatordown investigation provides differing steps for SRE:
```
🤖 Automated insightsoperatordown pre-investigation 🤖
===========================
⚠️ User is banned: pending
Ban description: pending
Please open a proactive case, so that MCS can resolve the ban or organize a ownership transfer.
⚠️ Found symptom of OCPBUGS-22226. Try deleting the insights operator pod to remediate.
$ oc -n openshift-insights delete pods -l app=insights-operator --wait=false
```

When a user is banned, the status on the insights CO still contains "Failed to pull SCA certs"
```
 message: 'Failed to pull SCA certs from https://api.openshift.com/api/accounts_mgmt/v1/certificates:
      OCM API https://api.openshift.com/api/accounts_mgmt/v1/certificates returned
      HTTP 403: {"code":"ACCT-MGMT-22","href":"/api/accounts_mgmt/v1/errors/22","id":"22","kind":"Error","operation_id":"2x","reason":"Account
      x is banned. Reason: "}'

```

We can just exit early if we know the user is banned. 

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
