### PR TITLE
Fixing OCM configuration loading using OCM config

### DIFF
--- a/test/e2e/configuration_anomaly_detection_tests.go
+++ b/test/e2e/configuration_anomaly_detection_tests.go
@@ -54,6 +54,8 @@ var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 		Expect(clusterID).NotTo(BeEmpty(), "CLUSTER_ID must be set")
 
 		cfg, err := ocmConfig.Load()
+		connection, err := ocmConnBuilder.NewConnection().Config(cfg).AsAgent("cad-local-e2e-tests").Build()
+
 		if err != nil {
 			// Fall back to environment variables
 			clientID := os.Getenv("OCM_CLIENT_ID")
@@ -64,9 +66,7 @@ var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 			ocme2eCli, err = ocme2e.New(ctx, "", clientID, clientSecret, ocmEnv)
 			Expect(err).ShouldNot(HaveOccurred(), "Unable to setup E2E OCM Client")
 		} else {
-			// Build connection based on local config
-			connection, err := ocmConnBuilder.NewConnection().Config(cfg).AsAgent("cad-local-e2e-tests").Build()
-			Expect(err).ShouldNot(HaveOccurred(), "Unable to build OCM connection")
+
 			ocme2eCli = &ocme2e.Client{Connection: connection}
 		}
 


### PR DESCRIPTION
### What type of PR is this?

Enhancement

### What this PR does / Why we need it?

This PR has been created to fix the OCM configuration for CAD E2E tests to enable the configuration to run in local as well as be able to run in the E2E pipeline

Attached is the successful test case example 
[SREP-1164_tests.txt](https://github.com/user-attachments/files/21853494/SREP-1164_tests.txt)

