### PR TITLE
Fix missing parameters for 'osdctl servicelic post' commands

### DIFF
--- a/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
+++ b/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
@@ -45,7 +45,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		switch verifierResult {
 		case networkverifier.Failure:
 			result.ServiceLogPrepared = investigation.InvestigationStep{Performed: true, Labels: nil}
-			notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=%s", r.Cluster.ID(), failureReason)
+			notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post --cluster-id %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=%s", r.Cluster.ID(), failureReason)
 		case networkverifier.Success:
 			notes.AppendSuccess("Network verifier passed")
 		}

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -104,7 +104,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		logging.Infof("Network verifier reported failure: %s", failureReason)
 		// XXX: metrics.Inc(metrics.ServicelogPrepared, investigationName)
 		result.ServiceLogPrepared = investigation.InvestigationStep{Performed: true, Labels: nil}
-		notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=\"%s\"", r.Cluster.ID(), failureReason)
+		notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post --cluster-id %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=\"%s\"", r.Cluster.ID(), failureReason)
 
 		// In the future, we want to send a service log in this case
 		err = r.PdClient.AddNote(notes.String())

--- a/pkg/investigations/insightsoperatordown/insightsoperatordown.go
+++ b/pkg/investigations/insightsoperatordown/insightsoperatordown.go
@@ -92,7 +92,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		logging.Infof("Network verifier reported failure: %s", failureReason)
 		// XXX: metrics.Inc(metrics.ServicelogPrepared, investigationName)
 		result.ServiceLogPrepared = investigation.InvestigationStep{Performed: true, Labels: nil}
-		notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=%s", r.Cluster.ID(), failureReason)
+		notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post --cluster-id %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=%s", r.Cluster.ID(), failureReason)
 
 		// In the future, we want to send a service log in this case
 		err = r.PdClient.AddNote(notes.String())


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

We need this change to help primary easily copy and paste `osdctl servicelog post` commands without needing to manually add a parameter name.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
