### PR TITLE
fix e2e when cfg and err is nil

### DIFF
--- a/test/e2e/configuration_anomaly_detection_tests.go
+++ b/test/e2e/configuration_anomaly_detection_tests.go
@@ -54,7 +54,7 @@ var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 		Expect(clusterID).NotTo(BeEmpty(), "CLUSTER_ID must be set")
 
 		cfg, err := ocmConfig.Load()
-		if err != nil {
+		if err != nil || cfg == nil {
 			// Fall back to environment variables
 			clientID := os.Getenv("OCM_CLIENT_ID")
 			clientSecret := os.Getenv("OCM_CLIENT_SECRET")


### PR DESCRIPTION
### What type of PR is this?

test fix

### What this PR does / Why we need it?
when when cfg and err is nil, e2e test fails with
```
In [BeforeAll] at: /go/src/github.com/openshift/configuration-anomaly-detection/test/e2e/configuration_anomaly_detection_tests.go:69 @ 09/25/25 20:27:23.491
      
      {
          Message: "Unable to build OCM connection\nUnexpected error:\n    <*errors.errorString | 0xc00011d180>: \n    Not logged in, credentials aren't set, run the 'login' command\n    {\n        s: \"Not logged in, credentials aren't set, run the 'login' command\",\n    }\noccurred",
          Type: "failed",
          Body: "[FAILED] Unable to build OCM connection\nUnexpected error:\n    <*errors.errorString | 0xc00011d180>: \n    Not logged in, credentials aren't set, run the 'login' command\n    {\n        s: \"Not logged in, credentials aren't set, run the 'login' command\",\n    }\noccurred\nIn [BeforeAll] at: /go/src/github.com/openshift/configuration-anomaly-detection/test/e2e/configuration_anomaly_detection_tests.go:69 @ 09/25/25 20:27:23.491\n",
      }
```

use env vars in that case to create ocm conn

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
