### PR TITLE
[SREP-1976] Update regex to match more generic access failures.

### DIFF
--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -99,7 +99,7 @@ var userCausedErrors = []string{
 
 	// This error is the response from backplane calls when:
 	// trust policy of ManagedOpenShift-Support-Role is changed
-	".*could not assume support role in customer's account: AccessDenied:.*",
+	".*could not assume support role in customer's account: .*AccessDenied:.*",
 
 	// Customer removed the `GetRole` permission from the Installer role.
 	// Failed to get role: User: arn:aws:sts::<id>:assumed-role/ManagedOpenShift-Installer-Role/OCM is not authorized to perform: iam:GetRole on resource: role ManagedOpenShift-Support-Role because no identity-based policy allows the iam:GetRole action

--- a/pkg/investigations/ccam/ccam_test.go
+++ b/pkg/investigations/ccam/ccam_test.go
@@ -60,6 +60,11 @@ func TestCustomerRemovedPermissions(t *testing.T) {
 			expectedMatch: true,
 		},
 		{
+			name:          "Matching error 6",
+			errorMessage:  "unable to assume-role chain: could not assume support role in customer's account: operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: <opid>, api error AccessDenied: User: <user> is not authorized to perform: sts:AssumeRole on resource: <role>",
+			expectedMatch: true,
+		},
+		{
 			name:          "Non-matching error",
 			errorMessage:  "Some timeout error",
 			expectedMatch: false,


### PR DESCRIPTION
Update test cases to cover STS based failure.

### What type of PR is this?

bug

### What this PR does / Why we need it?

Fix regex to match more accessdenied failures.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [X] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
