### PR TITLE
Update OCP documentation links to latest versions

### DIFF
--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/testing/README.md
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/testing/README.md
@@ -79,5 +79,5 @@ The following pages may be useful if the information in this guide is insufficie
 
 - [Machine API Brief](https://github.com/openshift/machine-api-operator/blob/main/docs/user/machine-api-operator-overview.md)
 - [Machine API FAQ](https://github.com/openshift/machine-api-operator/blob/main/FAQ.md)
-- [MachineHealthCheck documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/machine_management/deploying-machine-health-checks#machine-health-checks-resource_deploying-machine-health-checks)
+- [MachineHealthCheck documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/machine_management/deploying-machine-health-checks#machine-health-checks-resource_deploying-machine-health-checks)
 - [Alert SOP](https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md)


### PR DESCRIPTION
This PR updates OpenShift Container Platform documentation URLs to point to the latest available versions.

## Changes
- Automatically updated OCP documentation links using [ocp-doc-checker](https://github.com/sebrandon1/ocp-doc-checker)
- All documentation URLs now point to current versions

## Tool Information
This PR was created automatically by scanning the repository with `ocp-doc-checker`, which identifies and updates outdated OpenShift documentation links.

Repository: https://github.com/sebrandon1/ocp-doc-checker

---

**Tracking Issue:** https://github.com/sebrandon1/ocp-doc-checker/issues/18