### PR TITLE
Update OCP documentation links to latest versions

### DIFF
--- a/ocp-docs-scan-results.txt
+++ b/ocp-docs-scan-results.txt
@@ -1,0 +1,31 @@
+Repository: openshift/multiarch-tuning-operator
+  GitHub URL: https://github.com/openshift/multiarch-tuning-operator
+  Default branch: main
+  Using ocp-doc-checker: NO
+  Files with OCP documentation links:
+    - config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
+      Occurrences: 1
+      Sample URLs:
+        - https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/postinstallation_configuration/configuring-multi-architecture-compute-machines-on-an-openshift-cluster#multiarch-tuning-operator
+      GitHub: https://github.com/openshift/multiarch-tuning-operator/blob/main/config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
+
+    - bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+      Occurrences: 1
+      Sample URLs:
+        - https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/postinstallation_configuration/configuring-multi-architecture-compute-machines-on-an-openshift-cluster#multiarch-tuning-operator
+      GitHub: https://github.com/openshift/multiarch-tuning-operator/blob/main/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+
+
+Repository: openshift/cert-manager-operator
+  GitHub URL: https://github.com/openshift/cert-manager-operator
+  Default branch: master
+  Using ocp-doc-checker: NO
+  Files with OCP documentation links:
+    - docs/operand_metrics.md
+      Occurrences: 2
+      Sample URLs:
+        - https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/monitoring/configuring-user-workload-monitoring).
+        - https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/monitoring/accessing-metrics).
+      GitHub: https://github.com/openshift/cert-manager-operator/blob/master/docs/operand_metrics.md
+
+

--- a/ocp-docs-scan-results.txt.prs
+++ b/ocp-docs-scan-results.txt.prs
@@ -1,0 +1,1 @@
+https://github.com/openshift/configuration-anomaly-detection/pull/580

--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/testing/README.md
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/testing/README.md
@@ -79,5 +79,5 @@ The following pages may be useful if the information in this guide is insufficie
 
 - [Machine API Brief](https://github.com/openshift/machine-api-operator/blob/main/docs/user/machine-api-operator-overview.md)
 - [Machine API FAQ](https://github.com/openshift/machine-api-operator/blob/main/FAQ.md)
-- [MachineHealthCheck documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/machine_management/deploying-machine-health-checks#machine-health-checks-resource_deploying-machine-health-checks)
+- [MachineHealthCheck documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/machine_management/deploying-machine-health-checks#machine-health-checks-resource_deploying-machine-health-checks)
 - [Alert SOP](https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md)


### PR DESCRIPTION
This PR updates OpenShift Container Platform documentation URLs to point to the latest available versions.

## Changes
- Automatically updated OCP documentation links using [ocp-doc-checker](https://github.com/sebrandon1/ocp-doc-checker)
- All documentation URLs now point to current versions

## Tool Information
This PR was created automatically by scanning the repository with `ocp-doc-checker`, which identifies and updates outdated OpenShift documentation links.

Repository: https://github.com/sebrandon1/ocp-doc-checker