### PR TITLE
Add experimental diagnostic collection investigation using oc adm inspect

### DIFF
--- a/pkg/investigations/diagnosticcollection/README.md
+++ b/pkg/investigations/diagnosticcollection/README.md
@@ -1,0 +1,214 @@
+# Diagnostic Collection Investigation
+
+A **generic, reusable investigation framework** for collecting and analyzing cluster diagnostics using `oc adm inspect`. This investigation is designed to handle multiple alert types with minimal code changes.
+
+## Overview
+
+This investigation provides a flexible system for:
+1. Collecting cluster diagnostic data via `oc adm inspect`
+2. Parsing collected YAML resources
+3. Analyzing resources for common issues
+4. Posting actionable findings to PagerDuty
+
+## Architecture
+
+```
+Alert → Mapping → Inspect → Parse → Analyze → Report
+```
+
+### Components
+
+#### 1. **Alert Mappings** (`mappings.go`)
+- Maps alert types to resources to inspect
+- Defines which resources to collect for each alert
+- Easy to extend with new alert types
+
+#### 2. **Inspect Executor** (`inspect/executor.go`)
+- Runs `oc adm inspect` commands
+- Manages temporary directories for collected data
+- Handles cleanup
+
+#### 3. **Parsers** (`parsers/`)
+- Parse YAML files from inspect output
+- Extract structured information from Kubernetes resources
+- Currently supports:
+  - ClusterVersion
+  - ClusterOperator
+  - Easy to add more resource types
+
+#### 4. **Analyzers** (`analyzers/`)
+- Analyze parsed resources for issues
+- Implement `ResourceAnalyzer` interface
+- Return structured findings
+- Currently supports:
+  - ClusterVersion: upgrade status, stuck upgrades
+  - ClusterOperator: degraded/unavailable operators
+
+#### 5. **Findings** (`findings/`)
+- Structured representation of diagnostic results
+- Severity levels: Info, Warning, Critical
+- Formatted output for PagerDuty notes
+
+## Current Alert Support
+
+### UpgradeConfigSyncFailureOver4HrSRE
+- **Resources Collected**: clusterversion, clusteroperators
+- **Analysis**:
+  - Checks if upgrade is stuck (>4 hours)
+  - Identifies degraded cluster operators
+  - Provides operator-specific remediation recommendations
+- **RBAC Required**: read access to config.openshift.io clusterversions and clusteroperators
+
+## Adding New Alert Types
+
+Adding support for a new alert is straightforward:
+
+### Step 1: Add Mapping
+
+In `mappings.go`, add a new entry to `diagnosticMappings`:
+
+```go
+{
+    AlertPattern: "InsightsOperatorDown",
+    Resources:    []string{"clusteroperator/insights", "ns/openshift-insights"},
+    Description:  "Collects insights operator status and namespace resources",
+},
+```
+
+### Step 2: Create Parser (if needed)
+
+If inspecting a new resource type, create a parser in `parsers/`:
+
+```go
+// parsers/pods.go
+type PodInfo struct {
+    Name      string
+    Namespace string
+    Phase     string
+    // ...
+}
+
+func ParsePods(inspectDir string) ([]PodInfo, error) {
+    // Parse pod YAML files
+}
+```
+
+### Step 3: Create Analyzer
+
+Create an analyzer in `analyzers/`:
+
+```go
+// analyzers/insights.go
+type InsightsAnalyzer struct{}
+
+func (a *InsightsAnalyzer) Analyze(inspectDir string) (*findings.Findings, error) {
+    f := findings.New()
+
+    // Parse resources
+    pods, err := parsers.ParsePods(inspectDir)
+    if err != nil {
+        return nil, err
+    }
+
+    // Analyze and add findings
+    for _, pod := range pods {
+        if pod.Phase != "Running" {
+            f.AddWarning(
+                fmt.Sprintf("Pod not running: %s", pod.Name),
+                fmt.Sprintf("Phase: %s", pod.Phase),
+                "Check pod logs",
+            )
+        }
+    }
+
+    return f, nil
+}
+```
+
+### Step 4: Register Analyzer
+
+In `diagnosticcollection.go`, update `getAnalyzersForResources()`:
+
+```go
+if strings.Contains(resourceLower, "insights") {
+    analyzerList = append(analyzerList, analyzers.NewInsightsAnalyzer())
+}
+```
+
+### Step 5: Update RBAC
+
+In `metadata.yaml`, add required permissions:
+
+```yaml
+- verbs:
+    - "get"
+    - "list"
+  apiGroups:
+    - ""
+  resources:
+    - "pods"
+```
+
+### Step 6: Add Test Samples
+
+Add sample YAML files to `testing/samples/`:
+- `insights-pod-degraded.yaml`
+- `insights-pod-healthy.yaml`
+
+That's it! The investigation will now handle the new alert type.
+
+## Design Benefits
+
+✅ **Reusable**: Core logic shared across all alert types
+✅ **Maintainable**: New alerts don't require core logic changes
+✅ **Testable**: Each component independently testable
+✅ **Extensible**: Clear pattern for adding new alert types
+✅ **Gradual**: Start with one alert, add more over time
+
+## Example Output
+
+```
+🤖 Automated diagnosticcollection pre-investigation 🤖
+===========================
+🤖 Collecting diagnostics: Collects upgrade status and operator health for stuck upgrades
+✅ Diagnostic data collected successfully
+🤖 Diagnostic Analysis Results (4 findings)
+🔴 Critical Issues (2)
+==================
+1. Upgrade Stuck
+   Upgrade from 4.14.10 to 4.14.15 has been running for 5h30m (threshold: 4h)
+   💡 Check degraded cluster operators and machine config pools
+
+2. Operator Degraded: authentication
+   Reason: OAuthServerDeploymentDegraded
+   Message: deployment/oauth-openshift has 0/1 replicas available
+   💡 Check authentication operator: oc -n openshift-authentication get pods
+       Check OAuth resources: oc get oauth cluster -o yaml
+
+⚠️ Warnings (1)
+============
+1. Operator Unavailable: ingress
+   Reason: IngressControllerUnavailable
+   Message: router-default pod in CrashLoopBackOff
+   💡 Check ingress operator: oc -n openshift-ingress-operator get pods
+       Check routers: oc -n openshift-ingress get pods
+
+ℹ️ Information (1)
+===============
+1. Cluster Version Information
+   Current: 4.14.10
+   Desired: 4.14.15
+   Upgrading: true
+```
+
+## Testing
+
+Refer to the [testing README](./testing/README.md) for detailed instructions on testing this investigation.
+
+## Future Enhancements
+
+- Support for more resource types (Pods, Nodes, MachineConfigs, etc.)
+- Pattern-based finding correlation
+- Historical data comparison
+- Automatic remediation for common issues
+- Upload complete diagnostics to S3 bucket for deep investigation (tar the inspect output, upload with cluster ID and timestamp, post S3 URL to PagerDuty)

--- a/pkg/investigations/diagnosticcollection/analyzers/clusteroperator.go
+++ b/pkg/investigations/diagnosticcollection/analyzers/clusteroperator.go
@@ -1,0 +1,108 @@
+package analyzers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/findings"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/parsers"
+)
+
+// ClusterOperatorAnalyzer analyzes ClusterOperator resources for health issues
+type ClusterOperatorAnalyzer struct{}
+
+// NewClusterOperatorAnalyzer creates a new ClusterOperator analyzer
+func NewClusterOperatorAnalyzer() *ClusterOperatorAnalyzer {
+	return &ClusterOperatorAnalyzer{}
+}
+
+// Name returns the analyzer name
+func (a *ClusterOperatorAnalyzer) Name() string {
+	return "ClusterOperator"
+}
+
+// Analyze examines ClusterOperator data and returns findings
+func (a *ClusterOperatorAnalyzer) Analyze(inspectDir string) (*findings.Findings, error) {
+	f := findings.New()
+
+	// Parse ClusterOperators
+	operators, err := parsers.ParseClusterOperators(inspectDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse clusteroperators: %w", err)
+	}
+
+	// Get degraded and unavailable operators
+	degradedOps := parsers.GetDegradedOperators(operators)
+	unavailableOps := parsers.GetUnavailableOperators(operators)
+
+	// Report summary
+	totalOps := len(operators)
+	healthyOps := totalOps - len(degradedOps) - len(unavailableOps)
+	f.AddInfo(
+		"Cluster Operators Summary",
+		fmt.Sprintf("Total: %d | Healthy: %d | Degraded: %d | Unavailable: %d",
+			totalOps, healthyOps, len(degradedOps), len(unavailableOps)),
+	)
+
+	// Report degraded operators
+	if len(degradedOps) > 0 {
+		for _, op := range degradedOps {
+			f.AddCritical(
+				fmt.Sprintf("Operator Degraded: %s", op.Name),
+				fmt.Sprintf("Reason: %s\nMessage: %s", op.DegradedReason, op.DegradedMessage),
+				a.getRecommendation(op.Name, op.DegradedReason),
+			)
+		}
+	}
+
+	// Report unavailable operators (that aren't already degraded)
+	for _, op := range unavailableOps {
+		// Skip if already reported as degraded
+		if op.IsDegraded {
+			continue
+		}
+
+		availCond := op.GetCondition("Available")
+		message := ""
+		reason := ""
+		if availCond != nil {
+			message = availCond.Message
+			reason = availCond.Reason
+		}
+
+		f.AddWarning(
+			fmt.Sprintf("Operator Unavailable: %s", op.Name),
+			fmt.Sprintf("Reason: %s\nMessage: %s", reason, message),
+			fmt.Sprintf("Check operator pods: oc -n openshift-%s get pods", op.Name),
+		)
+	}
+
+	return f, nil
+}
+
+// getRecommendation provides operator-specific recommendations based on name and reason
+func (a *ClusterOperatorAnalyzer) getRecommendation(operatorName, reason string) string {
+	// Common namespace for operators
+	namespace := fmt.Sprintf("openshift-%s", operatorName)
+
+	// Operator-specific recommendations
+	switch operatorName {
+	case "authentication":
+		return fmt.Sprintf("Check authentication operator: oc -n %s get pods\nCheck OAuth resources: oc get oauth cluster -o yaml", namespace)
+	case "ingress":
+		return fmt.Sprintf("Check ingress operator: oc -n openshift-ingress-operator get pods\nCheck routers: oc -n openshift-ingress get pods")
+	case "kube-apiserver", "openshift-apiserver":
+		return fmt.Sprintf("Check API server pods: oc -n %s get pods\nCheck API server logs for errors", namespace)
+	case "machine-config":
+		if strings.Contains(strings.ToLower(reason), "pool") {
+			return "Check machine config pools: oc get mcp\nCheck nodes: oc get nodes"
+		}
+		return fmt.Sprintf("Check machine config operator: oc -n %s get pods", namespace)
+	case "monitoring":
+		return "Check monitoring stack: oc -n openshift-monitoring get pods\nCheck prometheus: oc -n openshift-monitoring get prometheus"
+	case "etcd":
+		return "Check etcd pods: oc -n openshift-etcd get pods\nCheck etcd health: oc -n openshift-etcd exec -it <etcd-pod> -- etcdctl endpoint health"
+	default:
+		return fmt.Sprintf("Check operator pods: oc -n %s get pods\nReview operator logs for details", namespace)
+	}
+}

--- a/pkg/investigations/diagnosticcollection/analyzers/clusteroperator_test.go
+++ b/pkg/investigations/diagnosticcollection/analyzers/clusteroperator_test.go
@@ -1,0 +1,197 @@
+package analyzers
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/findings"
+)
+
+var _ = Describe("ClusterOperatorAnalyzer", func() {
+	var (
+		analyzer  *ClusterOperatorAnalyzer
+		tempDir   string
+		coDir     string
+		sampleDir string
+	)
+
+	BeforeEach(func() {
+		analyzer = NewClusterOperatorAnalyzer()
+
+		var err error
+		tempDir, err = os.MkdirTemp("", "coanalyzer-test-*")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create directory structure for inspect output
+		coDir = filepath.Join(tempDir, "cluster-scoped-resources", "config.openshift.io", "clusteroperators")
+		err = os.MkdirAll(coDir, 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get absolute path to samples directory
+		cwd, err := os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+		sampleDir = filepath.Join(cwd, "..", "testing", "samples")
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	Describe("Name", func() {
+		It("should return analyzer name", func() {
+			Expect(analyzer.Name()).To(Equal("ClusterOperator"))
+		})
+	})
+
+	Describe("Analyze", func() {
+		Context("with degraded operator", func() {
+			BeforeEach(func() {
+				data, err := os.ReadFile(filepath.Join(sampleDir, "clusteroperator-degraded.yaml"))
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(filepath.Join(coDir, "authentication.yaml"), data, 0644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return findings", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f).ToNot(BeNil())
+				Expect(f.IsEmpty()).To(BeFalse())
+			})
+
+			It("should report degraded operator as critical", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(f.HasCritical()).To(BeTrue())
+
+				allFindings := f.GetAll()
+				hasDegradedOp := false
+				for _, finding := range allFindings {
+					if finding.Severity == findings.SeverityCritical {
+						hasDegradedOp = true
+						Expect(finding.Title).To(ContainSubstring("Operator Degraded"))
+						Expect(finding.Title).To(ContainSubstring("authentication"))
+						Expect(finding.Message).To(ContainSubstring("OAuthServerDeploymentDegraded"))
+						Expect(finding.Recommendation).ToNot(BeEmpty())
+						Expect(finding.Recommendation).To(ContainSubstring("openshift-authentication"))
+					}
+				}
+				Expect(hasDegradedOp).To(BeTrue())
+			})
+		})
+
+		Context("with mixed operators", func() {
+			BeforeEach(func() {
+				// Add degraded operator
+				degradedData, err := os.ReadFile(filepath.Join(sampleDir, "clusteroperator-degraded.yaml"))
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(filepath.Join(coDir, "authentication.yaml"), degradedData, 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Add healthy operator
+				healthyData, err := os.ReadFile(filepath.Join(sampleDir, "clusteroperator-healthy.yaml"))
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(filepath.Join(coDir, "ingress.yaml"), healthyData, 0644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should report summary of all operators", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				allFindings := f.GetAll()
+				hasSummary := false
+				for _, finding := range allFindings {
+					if finding.Title == "Cluster Operators Summary" {
+						hasSummary = true
+						Expect(finding.Severity).To(Equal(findings.SeverityInfo))
+						Expect(finding.Message).To(ContainSubstring("Total: 2"))
+						Expect(finding.Message).To(ContainSubstring("Degraded: 1"))
+					}
+				}
+				Expect(hasSummary).To(BeTrue())
+			})
+
+			It("should report only degraded operators as critical", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				criticalFindings := 0
+				for _, finding := range f.GetAll() {
+					if finding.Severity == findings.SeverityCritical {
+						criticalFindings++
+						Expect(finding.Title).To(ContainSubstring("authentication"))
+					}
+				}
+				Expect(criticalFindings).To(Equal(1))
+			})
+		})
+
+		Context("with all healthy operators", func() {
+			BeforeEach(func() {
+				data, err := os.ReadFile(filepath.Join(sampleDir, "clusteroperator-healthy.yaml"))
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(filepath.Join(coDir, "ingress.yaml"), data, 0644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should not report critical findings", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f.HasCritical()).To(BeFalse())
+			})
+
+			It("should report summary with all healthy", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				allFindings := f.GetAll()
+				hasSummary := false
+				for _, finding := range allFindings {
+					if finding.Title == "Cluster Operators Summary" {
+						hasSummary = true
+						Expect(finding.Message).To(ContainSubstring("Degraded: 0"))
+						Expect(finding.Message).To(ContainSubstring("Unavailable: 0"))
+					}
+				}
+				Expect(hasSummary).To(BeTrue())
+			})
+		})
+
+		Context("with missing files", func() {
+			It("should return error", func() {
+				_, err := analyzer.Analyze(tempDir)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no clusteroperator files found"))
+			})
+		})
+	})
+
+	Describe("getRecommendation", func() {
+		It("should provide specific recommendations for known operators", func() {
+			analyzer := NewClusterOperatorAnalyzer()
+
+			// Test authentication operator
+			rec := analyzer.getRecommendation("authentication", "SomeReason")
+			Expect(rec).To(ContainSubstring("openshift-authentication"))
+			Expect(rec).To(ContainSubstring("OAuth"))
+
+			// Test ingress operator
+			rec = analyzer.getRecommendation("ingress", "SomeReason")
+			Expect(rec).To(ContainSubstring("openshift-ingress"))
+			Expect(rec).To(ContainSubstring("router"))
+
+			// Test machine-config operator
+			rec = analyzer.getRecommendation("machine-config", "PoolDegraded")
+			Expect(rec).To(ContainSubstring("mcp"))
+			Expect(rec).To(ContainSubstring("nodes"))
+
+			// Test unknown operator
+			rec = analyzer.getRecommendation("unknown-operator", "SomeReason")
+			Expect(rec).To(ContainSubstring("openshift-unknown-operator"))
+		})
+	})
+})

--- a/pkg/investigations/diagnosticcollection/analyzers/clusterversion.go
+++ b/pkg/investigations/diagnosticcollection/analyzers/clusterversion.go
@@ -1,0 +1,88 @@
+package analyzers
+
+import (
+	"fmt"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/findings"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/parsers"
+)
+
+const (
+	// UpgradeStuckThreshold is how long an upgrade can run before being considered stuck
+	UpgradeStuckThreshold = 4 * time.Hour
+)
+
+// ClusterVersionAnalyzer analyzes ClusterVersion resources for upgrade issues
+type ClusterVersionAnalyzer struct{}
+
+// NewClusterVersionAnalyzer creates a new ClusterVersion analyzer
+func NewClusterVersionAnalyzer() *ClusterVersionAnalyzer {
+	return &ClusterVersionAnalyzer{}
+}
+
+// Name returns the analyzer name
+func (a *ClusterVersionAnalyzer) Name() string {
+	return "ClusterVersion"
+}
+
+// Analyze examines ClusterVersion data and returns findings
+func (a *ClusterVersionAnalyzer) Analyze(inspectDir string) (*findings.Findings, error) {
+	f := findings.New()
+
+	// Parse ClusterVersion
+	cvInfo, err := parsers.ParseClusterVersion(inspectDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse clusterversion: %w", err)
+	}
+
+	// Add basic version info
+	f.AddInfo(
+		"Cluster Version Information",
+		fmt.Sprintf("Current: %s\nDesired: %s\nUpgrading: %v",
+			cvInfo.CurrentVersion, cvInfo.DesiredVersion, cvInfo.IsUpgrading),
+	)
+
+	// Check if upgrade is stuck
+	if cvInfo.IsUpgradeStuck(UpgradeStuckThreshold) {
+		duration := cvInfo.GetUpgradeDuration()
+		f.AddCritical(
+			"Upgrade Stuck",
+			fmt.Sprintf("Upgrade from %s to %s has been running for %v (threshold: %v)",
+				cvInfo.CurrentVersion, cvInfo.DesiredVersion,
+				duration.Round(time.Minute), UpgradeStuckThreshold),
+			"Check degraded cluster operators and machine config pools",
+		)
+	} else if cvInfo.IsUpgrading {
+		duration := cvInfo.GetUpgradeDuration()
+		f.AddInfo(
+			"Upgrade In Progress",
+			fmt.Sprintf("Upgrade to %s started %v ago",
+				cvInfo.DesiredVersion, duration.Round(time.Minute)),
+		)
+	}
+
+	// Check for Progressing=False when upgrade is expected
+	if cvInfo.DesiredVersion != "" && cvInfo.DesiredVersion != cvInfo.CurrentVersion {
+		if progressingCond := cvInfo.GetCondition(configv1.OperatorProgressing); progressingCond != nil && progressingCond.Status == configv1.ConditionFalse {
+			f.AddWarning(
+				"Upgrade Not Progressing",
+				fmt.Sprintf("Desired version %s but Progressing=False\nReason: %s\nMessage: %s",
+					cvInfo.DesiredVersion, progressingCond.Reason, progressingCond.Message),
+				"Check if there are blockers preventing the upgrade from starting",
+			)
+		}
+	}
+
+	// Check Available condition
+	if availableCond := cvInfo.GetCondition(configv1.OperatorAvailable); availableCond != nil && availableCond.Status == configv1.ConditionFalse {
+		f.AddCritical(
+			"Cluster Not Available",
+			fmt.Sprintf("Reason: %s\nMessage: %s", availableCond.Reason, availableCond.Message),
+			"Cluster is not available - investigate immediately",
+		)
+	}
+
+	return f, nil
+}

--- a/pkg/investigations/diagnosticcollection/analyzers/clusterversion_test.go
+++ b/pkg/investigations/diagnosticcollection/analyzers/clusterversion_test.go
@@ -1,0 +1,151 @@
+package analyzers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/findings"
+)
+
+func TestAnalyzers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Analyzers Suite")
+}
+
+var _ = Describe("ClusterVersionAnalyzer", func() {
+	var (
+		analyzer  *ClusterVersionAnalyzer
+		tempDir   string
+		cvDir     string
+		sampleDir string
+	)
+
+	BeforeEach(func() {
+		analyzer = NewClusterVersionAnalyzer()
+
+		var err error
+		tempDir, err = os.MkdirTemp("", "cvanalyzer-test-*")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create directory structure for inspect output
+		cvDir = filepath.Join(tempDir, "cluster-scoped-resources", "config.openshift.io", "clusterversions")
+		err = os.MkdirAll(cvDir, 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get absolute path to samples directory
+		cwd, err := os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+		sampleDir = filepath.Join(cwd, "..", "testing", "samples")
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	Describe("Name", func() {
+		It("should return analyzer name", func() {
+			Expect(analyzer.Name()).To(Equal("ClusterVersion"))
+		})
+	})
+
+	Describe("Analyze", func() {
+		Context("with stuck upgrade", func() {
+			BeforeEach(func() {
+				data, err := os.ReadFile(filepath.Join(sampleDir, "clusterversion-stuck.yaml"))
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(filepath.Join(cvDir, "version.yaml"), data, 0644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return findings", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f).ToNot(BeNil())
+				Expect(f.IsEmpty()).To(BeFalse())
+			})
+
+			It("should report upgrade information", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				allFindings := f.GetAll()
+				hasVersionInfo := false
+				for _, finding := range allFindings {
+					if finding.Title == "Cluster Version Information" {
+						hasVersionInfo = true
+						Expect(finding.Severity).To(Equal(findings.SeverityInfo))
+						// In stuck upgrade, current version is partial 4.14.15
+						Expect(finding.Message).To(ContainSubstring("4.14.15"))
+						Expect(finding.Message).To(ContainSubstring("Upgrading: true"))
+					}
+				}
+				Expect(hasVersionInfo).To(BeTrue())
+			})
+
+			It("should detect stuck upgrade", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Should have critical finding about stuck upgrade
+				Expect(f.HasCritical()).To(BeTrue())
+
+				allFindings := f.GetAll()
+				hasStuckUpgrade := false
+				for _, finding := range allFindings {
+					if finding.Title == "Upgrade Stuck" {
+						hasStuckUpgrade = true
+						Expect(finding.Severity).To(Equal(findings.SeverityCritical))
+						// In stuck upgrade, shows upgrade to 4.14.15
+						Expect(finding.Message).To(ContainSubstring("4.14.15"))
+						Expect(finding.Message).To(ContainSubstring("threshold: 4h"))
+						Expect(finding.Recommendation).ToNot(BeEmpty())
+					}
+				}
+				Expect(hasStuckUpgrade).To(BeTrue())
+			})
+		})
+
+		Context("with healthy cluster", func() {
+			BeforeEach(func() {
+				data, err := os.ReadFile(filepath.Join(sampleDir, "clusterversion-healthy.yaml"))
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(filepath.Join(cvDir, "version.yaml"), data, 0644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return findings without critical issues", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f).ToNot(BeNil())
+				Expect(f.HasCritical()).To(BeFalse())
+			})
+
+			It("should report version information", func() {
+				f, err := analyzer.Analyze(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				allFindings := f.GetAll()
+				hasVersionInfo := false
+				for _, finding := range allFindings {
+					if finding.Title == "Cluster Version Information" {
+						hasVersionInfo = true
+						Expect(finding.Message).To(ContainSubstring("4.14.10"))
+						Expect(finding.Message).To(ContainSubstring("Upgrading: false"))
+					}
+				}
+				Expect(hasVersionInfo).To(BeTrue())
+			})
+		})
+
+		Context("with missing files", func() {
+			It("should return error", func() {
+				_, err := analyzer.Analyze(tempDir)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no clusterversion files found"))
+			})
+		})
+	})
+})

--- a/pkg/investigations/diagnosticcollection/analyzers/interface.go
+++ b/pkg/investigations/diagnosticcollection/analyzers/interface.go
@@ -1,0 +1,15 @@
+package analyzers
+
+import "github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/findings"
+
+// ResourceAnalyzer is the interface that all resource analyzers must implement
+// Each analyzer examines a specific type of resource (ClusterVersion, ClusterOperator, etc.)
+// and produces findings based on the resource state
+type ResourceAnalyzer interface {
+	// Analyze examines the resource data and returns findings
+	// The input is the directory path containing the collected resource YAML files
+	Analyze(inspectDir string) (*findings.Findings, error)
+
+	// Name returns the name of this analyzer (for logging/debugging)
+	Name() string
+}

--- a/pkg/investigations/diagnosticcollection/diagnosticcollection.go
+++ b/pkg/investigations/diagnosticcollection/diagnosticcollection.go
@@ -1,0 +1,141 @@
+// Package diagnosticcollection provides generic diagnostic collection using oc adm inspect
+// for various alert types. It uses a mapping system to determine which resources to collect
+// based on the alert type, then analyzes the collected data and posts findings to PagerDuty.
+package diagnosticcollection
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/analyzers"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/findings"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection/inspect"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+)
+
+type Investigation struct{}
+
+func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
+	result := investigation.InvestigationResult{}
+
+	// Build resources with K8s client (needed for oc commands)
+	r, err := rb.WithK8sClient().Build()
+	if err != nil {
+		return result, fmt.Errorf("failed to build resources: %w", err)
+	}
+
+	// Initialize PagerDuty note writer
+	notes := notewriter.New(r.Name, logging.RawLogger)
+	defer func() { r.Notes = notes }()
+
+	// Get the alert name from the investigation name
+	// In a real scenario, this would come from the PagerDuty webhook payload
+	// For now, we'll use a default or extract from context
+	alertName := "UpgradeConfigSyncFailureOver4HrSRE" // TODO: Get from payload
+
+	// Find mapping for this alert
+	mapping := GetMappingForAlert(alertName)
+	if mapping == nil {
+		notes.AppendWarning("No diagnostic mapping found for alert: %s", alertName)
+		return result, r.PdClient.EscalateIncidentWithNote(notes.String())
+	}
+
+	logging.Infof("Using mapping: %s - %s", mapping.AlertPattern, mapping.Description)
+	notes.AppendAutomation("Collecting diagnostics: %s", mapping.Description)
+
+	// Create inspect executor
+	executor := inspect.New(r.K8sClient)
+	defer func() {
+		// Cleanup will be called even if we return early
+	}()
+
+	// Run oc adm inspect
+	inspectDir, err := executor.Execute(mapping.Resources)
+	if err != nil {
+		notes.AppendWarning("Failed to collect diagnostics: %v", err)
+		logging.Errorf("oc adm inspect failed: %v", err)
+		return result, r.PdClient.EscalateIncidentWithNote(notes.String())
+	}
+	defer executor.Cleanup(inspectDir)
+
+	notes.AppendSuccess("Diagnostic data collected successfully")
+	logging.Infof("Diagnostics collected in: %s", inspectDir)
+
+	// Run analyzers
+	allFindings := findings.New()
+
+	// Determine which analyzers to run based on collected resources
+	analyzerList := c.getAnalyzersForResources(mapping.Resources)
+
+	for _, analyzer := range analyzerList {
+		logging.Infof("Running analyzer: %s", analyzer.Name())
+
+		analyzerFindings, err := analyzer.Analyze(inspectDir)
+		if err != nil {
+			logging.Warnf("Analyzer %s failed: %v", analyzer.Name(), err)
+			notes.AppendWarning("Analysis failed for %s: %v", analyzer.Name(), err)
+			continue
+		}
+
+		// Merge findings
+		for _, finding := range analyzerFindings.GetAll() {
+			allFindings.Add(finding)
+		}
+	}
+
+	// Format findings for PagerDuty
+	if !allFindings.IsEmpty() {
+		notes.AppendAutomation("Diagnostic Analysis Results (%d findings)", allFindings.Count())
+		findingsText := allFindings.FormatForPagerDuty()
+		// Append the formatted findings directly to notes
+		notes.AppendAutomation("%s", findingsText)
+	} else {
+		notes.AppendSuccess("No issues found during diagnostic analysis")
+	}
+
+	// Escalate to SRE with all findings
+	return result, r.PdClient.EscalateIncidentWithNote(notes.String())
+}
+
+// getAnalyzersForResources returns the appropriate analyzers based on resources being inspected
+func (c *Investigation) getAnalyzersForResources(resources []string) []analyzers.ResourceAnalyzer {
+	var analyzerList []analyzers.ResourceAnalyzer
+
+	for _, resource := range resources {
+		resourceLower := strings.ToLower(resource)
+
+		if strings.Contains(resourceLower, "clusterversion") {
+			analyzerList = append(analyzerList, analyzers.NewClusterVersionAnalyzer())
+		}
+
+		if strings.Contains(resourceLower, "clusteroperator") {
+			analyzerList = append(analyzerList, analyzers.NewClusterOperatorAnalyzer())
+		}
+
+		// Easy to add more analyzers for other resource types here
+	}
+
+	return analyzerList
+}
+
+func (c *Investigation) Name() string {
+	return "diagnosticcollection"
+}
+
+func (c *Investigation) Description() string {
+	return "Generic diagnostic collection using oc adm inspect for various alerts"
+}
+
+func (c *Investigation) ShouldInvestigateAlert(alert string) bool {
+	// Check if there's a mapping for this alert
+	mapping := GetMappingForAlert(alert)
+	return mapping != nil
+}
+
+func (c *Investigation) IsExperimental() bool {
+	// TODO: Update to false when graduating to production.
+	return true
+}
+

--- a/pkg/investigations/diagnosticcollection/findings/findings.go
+++ b/pkg/investigations/diagnosticcollection/findings/findings.go
@@ -1,0 +1,183 @@
+package findings
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Severity indicates how critical a finding is
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarning  Severity = "warning"
+	SeverityCritical Severity = "critical"
+)
+
+// Finding represents a single diagnostic finding
+type Finding struct {
+	// Severity of the finding
+	Severity Severity
+	// Title is a short summary of the finding
+	Title string
+	// Message is the detailed description
+	Message string
+	// Recommendation suggests what action to take
+	Recommendation string
+}
+
+// Findings is a collection of diagnostic findings
+type Findings struct {
+	items []Finding
+}
+
+// New creates a new Findings collection
+func New() *Findings {
+	return &Findings{
+		items: make([]Finding, 0),
+	}
+}
+
+// Add adds a finding to the collection
+func (f *Findings) Add(finding Finding) {
+	f.items = append(f.items, finding)
+}
+
+// AddInfo adds an informational finding
+func (f *Findings) AddInfo(title, message string) {
+	f.Add(Finding{
+		Severity: SeverityInfo,
+		Title:    title,
+		Message:  message,
+	})
+}
+
+// AddWarning adds a warning finding
+func (f *Findings) AddWarning(title, message, recommendation string) {
+	f.Add(Finding{
+		Severity:       SeverityWarning,
+		Title:          title,
+		Message:        message,
+		Recommendation: recommendation,
+	})
+}
+
+// AddCritical adds a critical finding
+func (f *Findings) AddCritical(title, message, recommendation string) {
+	f.Add(Finding{
+		Severity:       SeverityCritical,
+		Title:          title,
+		Message:        message,
+		Recommendation: recommendation,
+	})
+}
+
+// IsEmpty returns true if there are no findings
+func (f *Findings) IsEmpty() bool {
+	return len(f.items) == 0
+}
+
+// Count returns the number of findings
+func (f *Findings) Count() int {
+	return len(f.items)
+}
+
+// GetAll returns all findings
+func (f *Findings) GetAll() []Finding {
+	return f.items
+}
+
+// HasCritical returns true if any findings are critical
+func (f *Findings) HasCritical() bool {
+	for _, finding := range f.items {
+		if finding.Severity == SeverityCritical {
+			return true
+		}
+	}
+	return false
+}
+
+// HasWarnings returns true if any findings are warnings
+func (f *Findings) HasWarnings() bool {
+	for _, finding := range f.items {
+		if finding.Severity == SeverityWarning {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatForPagerDuty formats all findings as a PagerDuty note
+func (f *Findings) FormatForPagerDuty() string {
+	if f.IsEmpty() {
+		return "✅ No issues detected during diagnostic collection.\n"
+	}
+
+	var sb strings.Builder
+
+	// Group by severity
+	critical := f.getBySeverity(SeverityCritical)
+	warnings := f.getBySeverity(SeverityWarning)
+	info := f.getBySeverity(SeverityInfo)
+
+	if len(critical) > 0 {
+		sb.WriteString(fmt.Sprintf("🔴 Critical Issues (%d)\n", len(critical)))
+		sb.WriteString("==================\n")
+		for i, finding := range critical {
+			sb.WriteString(f.formatFinding(i+1, finding))
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(warnings) > 0 {
+		sb.WriteString(fmt.Sprintf("⚠️ Warnings (%d)\n", len(warnings)))
+		sb.WriteString("============\n")
+		for i, finding := range warnings {
+			sb.WriteString(f.formatFinding(i+1, finding))
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(info) > 0 {
+		sb.WriteString(fmt.Sprintf("ℹ️ Information (%d)\n", len(info)))
+		sb.WriteString("===============\n")
+		for i, finding := range info {
+			sb.WriteString(f.formatFinding(i+1, finding))
+		}
+	}
+
+	return sb.String()
+}
+
+func (f *Findings) getBySeverity(severity Severity) []Finding {
+	var result []Finding
+	for _, finding := range f.items {
+		if finding.Severity == severity {
+			result = append(result, finding)
+		}
+	}
+	return result
+}
+
+func (f *Findings) formatFinding(index int, finding Finding) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("%d. %s\n", index, finding.Title))
+
+	if finding.Message != "" {
+		// Indent message lines
+		lines := strings.Split(finding.Message, "\n")
+		for _, line := range lines {
+			if line != "" {
+				sb.WriteString(fmt.Sprintf("   %s\n", line))
+			}
+		}
+	}
+
+	if finding.Recommendation != "" {
+		sb.WriteString(fmt.Sprintf("   💡 %s\n", finding.Recommendation))
+	}
+
+	sb.WriteString("\n")
+	return sb.String()
+}

--- a/pkg/investigations/diagnosticcollection/findings/findings_test.go
+++ b/pkg/investigations/diagnosticcollection/findings/findings_test.go
@@ -1,0 +1,125 @@
+package findings
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFindings(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Findings Suite")
+}
+
+var _ = Describe("Findings", func() {
+	var f *Findings
+
+	BeforeEach(func() {
+		f = New()
+	})
+
+	Describe("Creating findings", func() {
+		It("should start empty", func() {
+			Expect(f.IsEmpty()).To(BeTrue())
+			Expect(f.Count()).To(Equal(0))
+		})
+
+		It("should add info findings", func() {
+			f.AddInfo("Test Title", "Test Message")
+			Expect(f.IsEmpty()).To(BeFalse())
+			Expect(f.Count()).To(Equal(1))
+			Expect(f.GetAll()[0].Severity).To(Equal(SeverityInfo))
+			Expect(f.GetAll()[0].Title).To(Equal("Test Title"))
+			Expect(f.GetAll()[0].Message).To(Equal("Test Message"))
+		})
+
+		It("should add warning findings", func() {
+			f.AddWarning("Warning Title", "Warning Message", "Fix it")
+			Expect(f.Count()).To(Equal(1))
+			Expect(f.GetAll()[0].Severity).To(Equal(SeverityWarning))
+			Expect(f.GetAll()[0].Recommendation).To(Equal("Fix it"))
+		})
+
+		It("should add critical findings", func() {
+			f.AddCritical("Critical Title", "Critical Message", "Urgent fix")
+			Expect(f.Count()).To(Equal(1))
+			Expect(f.GetAll()[0].Severity).To(Equal(SeverityCritical))
+			Expect(f.GetAll()[0].Recommendation).To(Equal("Urgent fix"))
+		})
+
+		It("should add multiple findings", func() {
+			f.AddInfo("Info", "Info msg")
+			f.AddWarning("Warning", "Warning msg", "Fix")
+			f.AddCritical("Critical", "Critical msg", "Fix now")
+			Expect(f.Count()).To(Equal(3))
+		})
+	})
+
+	Describe("Checking finding types", func() {
+		It("should detect critical findings", func() {
+			f.AddInfo("Info", "msg")
+			Expect(f.HasCritical()).To(BeFalse())
+
+			f.AddCritical("Critical", "msg", "fix")
+			Expect(f.HasCritical()).To(BeTrue())
+		})
+
+		It("should detect warnings", func() {
+			f.AddInfo("Info", "msg")
+			Expect(f.HasWarnings()).To(BeFalse())
+
+			f.AddWarning("Warning", "msg", "fix")
+			Expect(f.HasWarnings()).To(BeTrue())
+		})
+	})
+
+	Describe("Formatting for PagerDuty", func() {
+		It("should show message when no findings", func() {
+			output := f.FormatForPagerDuty()
+			Expect(output).To(ContainSubstring("No issues detected"))
+		})
+
+		It("should group findings by severity", func() {
+			f.AddInfo("Info1", "Info message")
+			f.AddWarning("Warn1", "Warning message", "Fix it")
+			f.AddCritical("Crit1", "Critical message", "Fix now")
+
+			output := f.FormatForPagerDuty()
+
+			// Should contain severity headers
+			Expect(output).To(ContainSubstring("🔴 Critical Issues (1)"))
+			Expect(output).To(ContainSubstring("⚠️ Warnings (1)"))
+			Expect(output).To(ContainSubstring("ℹ️ Information (1)"))
+
+			// Should contain finding details
+			Expect(output).To(ContainSubstring("Crit1"))
+			Expect(output).To(ContainSubstring("Warn1"))
+			Expect(output).To(ContainSubstring("Info1"))
+
+			// Should contain recommendations
+			Expect(output).To(ContainSubstring("Fix it"))
+			Expect(output).To(ContainSubstring("Fix now"))
+		})
+
+		It("should number findings within severity groups", func() {
+			f.AddCritical("First Critical", "msg1", "fix1")
+			f.AddCritical("Second Critical", "msg2", "fix2")
+
+			output := f.FormatForPagerDuty()
+
+			Expect(output).To(ContainSubstring("1. First Critical"))
+			Expect(output).To(ContainSubstring("2. Second Critical"))
+		})
+
+		It("should handle multiline messages", func() {
+			f.AddWarning("Test", "Line 1\nLine 2\nLine 3", "Fix")
+
+			output := f.FormatForPagerDuty()
+
+			Expect(output).To(ContainSubstring("Line 1"))
+			Expect(output).To(ContainSubstring("Line 2"))
+			Expect(output).To(ContainSubstring("Line 3"))
+		})
+	})
+})

--- a/pkg/investigations/diagnosticcollection/inspect/executor.go
+++ b/pkg/investigations/diagnosticcollection/inspect/executor.go
@@ -1,0 +1,142 @@
+package inspect
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
+)
+
+const (
+	// DefaultTimeout is the default timeout for inspect commands
+	DefaultTimeout = 5 * time.Minute
+)
+
+// Executor handles running `oc adm inspect` commands
+type Executor struct {
+	k8sClient k8sclient.Client
+	timeout   time.Duration
+}
+
+// New creates a new inspect executor
+func New(k8sClient k8sclient.Client) *Executor {
+	return &Executor{
+		k8sClient: k8sClient,
+		timeout:   DefaultTimeout,
+	}
+}
+
+// WithTimeout sets a custom timeout
+func (e *Executor) WithTimeout(timeout time.Duration) *Executor {
+	e.timeout = timeout
+	return e
+}
+
+// Execute runs `oc adm inspect` for the specified resources
+// Returns the directory path where diagnostic data was collected
+func (e *Executor) Execute(resources []string) (string, error) {
+	if len(resources) == 0 {
+		return "", fmt.Errorf("no resources specified for inspection")
+	}
+
+	// Create temporary directory for inspect output
+	destDir, err := os.MkdirTemp("", "cad-inspect-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp directory: %w", err)
+	}
+
+	logging.Infof("Running oc adm inspect for resources: %v", resources)
+	logging.Infof("Output directory: %s", destDir)
+
+	// Build the oc adm inspect command
+	args := []string{"adm", "inspect"}
+	args = append(args, resources...)
+	args = append(args, "--dest-dir", destDir)
+
+	// Execute the command
+	cmd := exec.Command("oc", args...)
+
+	// Set timeout
+	if e.timeout > 0 {
+		go func() {
+			time.Sleep(e.timeout)
+			if cmd.Process != nil {
+				logging.Warnf("oc adm inspect command timed out after %v, killing process", e.timeout)
+				cmd.Process.Kill()
+			}
+		}()
+	}
+
+	// Run the command and capture output
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Clean up the directory on error
+		os.RemoveAll(destDir)
+		return "", fmt.Errorf("oc adm inspect failed: %w\nOutput: %s", err, string(output))
+	}
+
+	logging.Infof("oc adm inspect completed successfully")
+	logging.Debugf("Output: %s", string(output))
+
+	// Verify that the directory contains data
+	if isEmpty, err := isDirEmpty(destDir); err != nil {
+		os.RemoveAll(destDir)
+		return "", fmt.Errorf("failed to check output directory: %w", err)
+	} else if isEmpty {
+		os.RemoveAll(destDir)
+		return "", fmt.Errorf("oc adm inspect produced no output")
+	}
+
+	return destDir, nil
+}
+
+// Cleanup removes the inspect output directory
+func (e *Executor) Cleanup(dir string) error {
+	if dir == "" || !strings.HasPrefix(dir, os.TempDir()) {
+		return fmt.Errorf("refusing to clean up directory that doesn't look like a temp dir: %s", dir)
+	}
+
+	logging.Debugf("Cleaning up inspect directory: %s", dir)
+	return os.RemoveAll(dir)
+}
+
+// isDirEmpty checks if a directory is empty
+func isDirEmpty(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
+}
+
+// GetResourceFiles returns all YAML files for a specific resource type
+// For example, GetResourceFiles(dir, "clusterversion") returns ClusterVersion YAML files
+func GetResourceFiles(inspectDir, resourceType string) ([]string, error) {
+	var files []string
+
+	err := filepath.Walk(inspectDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() && strings.HasSuffix(path, ".yaml") {
+			// Check if the path contains the resource type
+			if strings.Contains(strings.ToLower(path), strings.ToLower(resourceType)) {
+				files = append(files, path)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	return files, nil
+}

--- a/pkg/investigations/diagnosticcollection/mappings.go
+++ b/pkg/investigations/diagnosticcollection/mappings.go
@@ -1,0 +1,57 @@
+package diagnosticcollection
+
+// DiagnosticMapping defines which resources to inspect for a given alert type
+type DiagnosticMapping struct {
+	// AlertPattern is the string pattern to match in the alert name
+	AlertPattern string
+	// Resources is the list of resources to pass to `oc adm inspect`
+	// Examples: "clusterversion", "clusteroperators", "ns/openshift-monitoring"
+	Resources []string
+	// Description explains what this mapping collects
+	Description string
+}
+
+// diagnosticMappings contains all alert-to-resource mappings
+// To add a new alert type, simply add a new entry here
+var diagnosticMappings = []DiagnosticMapping{
+	{
+		AlertPattern: "UpgradeConfigSyncFailure",
+		Resources:    []string{"clusterversion", "clusteroperators"},
+		Description:  "Collects upgrade status and operator health for stuck upgrades",
+	},
+	// Easy to add more mappings:
+	// {
+	// 	AlertPattern: "InsightsOperatorDown",
+	// 	Resources:    []string{"clusteroperator/insights", "ns/openshift-insights"},
+	// 	Description:  "Collects insights operator status and namespace resources",
+	// },
+}
+
+// GetMappingForAlert returns the diagnostic mapping for a given alert name
+// Returns nil if no mapping is found
+func GetMappingForAlert(alertName string) *DiagnosticMapping {
+	for i := range diagnosticMappings {
+		mapping := &diagnosticMappings[i]
+		if containsPattern(alertName, mapping.AlertPattern) {
+			return mapping
+		}
+	}
+	return nil
+}
+
+// containsPattern checks if the alert name contains the pattern
+// This is a simple string contains check, but can be enhanced with regex if needed
+func containsPattern(alertName, pattern string) bool {
+	return len(alertName) > 0 && len(pattern) > 0 &&
+		   (alertName == pattern || contains(alertName, pattern))
+}
+
+// contains is a simple helper to avoid importing strings just for this
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/investigations/diagnosticcollection/metadata.yaml
+++ b/pkg/investigations/diagnosticcollection/metadata.yaml
@@ -1,0 +1,24 @@
+name: diagnosticcollection
+rbac:
+  roles: []
+  clusterRoleRules:
+    # Permissions for inspecting cluster version
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "config.openshift.io"
+      resources:
+        - "clusterversions"
+    # Permissions for inspecting cluster operators
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "config.openshift.io"
+      resources:
+        - "clusteroperators"
+    # Additional permissions that may be needed for oc adm inspect
+    # Can be expanded as new resource types are added to mappings
+customerDataAccess: false
+

--- a/pkg/investigations/diagnosticcollection/parsers/clusteroperator.go
+++ b/pkg/investigations/diagnosticcollection/parsers/clusteroperator.go
@@ -1,0 +1,117 @@
+package parsers
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// ClusterOperatorInfo contains parsed information from a single ClusterOperator
+type ClusterOperatorInfo struct {
+	// Name of the operator (e.g., "authentication", "ingress", "kube-apiserver")
+	Name string
+	// Conditions contains the status conditions
+	Conditions []configv1.ClusterOperatorStatusCondition
+	// IsDegraded indicates if the operator is degraded
+	IsDegraded bool
+	// IsAvailable indicates if the operator is available
+	IsAvailable bool
+	// IsProgressing indicates if the operator is progressing
+	IsProgressing bool
+	// DegradedMessage contains the degraded condition message if degraded
+	DegradedMessage string
+	// DegradedReason contains the degraded condition reason if degraded
+	DegradedReason string
+}
+
+// ParseClusterOperators parses all ClusterOperator YAML files from inspect output
+func ParseClusterOperators(inspectDir string) ([]ClusterOperatorInfo, error) {
+	// Find ClusterOperator YAML files
+	files, err := FindYAMLFilesByPattern(inspectDir, "clusteroperators")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find clusteroperator files: %w", err)
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no clusteroperator files found in %s", inspectDir)
+	}
+
+	var operators []ClusterOperatorInfo
+
+	for _, file := range files {
+		var co configv1.ClusterOperator
+		if err := ReadYAMLFile(file, &co); err != nil {
+			// Log warning but continue with other files
+			fmt.Printf("Warning: failed to parse %s: %v\n", file, err)
+			continue
+		}
+
+		info := parseClusterOperatorInfo(&co)
+		operators = append(operators, info)
+	}
+
+	return operators, nil
+}
+
+// parseClusterOperatorInfo extracts information from a ClusterOperator resource
+func parseClusterOperatorInfo(co *configv1.ClusterOperator) ClusterOperatorInfo {
+	info := ClusterOperatorInfo{
+		Name:       co.Name,
+		Conditions: co.Status.Conditions,
+	}
+
+	// Check conditions
+	for _, condition := range co.Status.Conditions {
+		switch condition.Type {
+		case configv1.OperatorDegraded:
+			info.IsDegraded = condition.Status == configv1.ConditionTrue
+			if info.IsDegraded {
+				info.DegradedMessage = condition.Message
+				info.DegradedReason = condition.Reason
+			}
+		case configv1.OperatorAvailable:
+			info.IsAvailable = condition.Status == configv1.ConditionTrue
+		case configv1.OperatorProgressing:
+			info.IsProgressing = condition.Status == configv1.ConditionTrue
+		}
+	}
+
+	return info
+}
+
+// GetCondition returns a specific condition by type
+func (c *ClusterOperatorInfo) GetCondition(conditionType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i := range c.Conditions {
+		if c.Conditions[i].Type == conditionType {
+			return &c.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// HasIssues returns true if the operator has any issues (degraded or not available)
+func (c *ClusterOperatorInfo) HasIssues() bool {
+	return c.IsDegraded || !c.IsAvailable
+}
+
+// GetDegradedOperators filters a list of operators to return only degraded ones
+func GetDegradedOperators(operators []ClusterOperatorInfo) []ClusterOperatorInfo {
+	var degraded []ClusterOperatorInfo
+	for _, op := range operators {
+		if op.IsDegraded {
+			degraded = append(degraded, op)
+		}
+	}
+	return degraded
+}
+
+// GetUnavailableOperators filters a list of operators to return only unavailable ones
+func GetUnavailableOperators(operators []ClusterOperatorInfo) []ClusterOperatorInfo {
+	var unavailable []ClusterOperatorInfo
+	for _, op := range operators {
+		if !op.IsAvailable {
+			unavailable = append(unavailable, op)
+		}
+	}
+	return unavailable
+}

--- a/pkg/investigations/diagnosticcollection/parsers/clusteroperator_test.go
+++ b/pkg/investigations/diagnosticcollection/parsers/clusteroperator_test.go
@@ -1,0 +1,191 @@
+package parsers
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+var _ = Describe("ClusterOperator Parser", func() {
+	var tempDir string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "clusteroperator-test-*")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	Describe("ParseClusterOperators", func() {
+		Context("with mixed operator states", func() {
+			BeforeEach(func() {
+				// Create directory structure
+				coDir := filepath.Join(tempDir, "cluster-scoped-resources", "config.openshift.io", "clusteroperators")
+				err := os.MkdirAll(coDir, 0755)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Add degraded operator
+				degradedData, err := os.ReadFile("../testing/samples/clusteroperator-degraded.yaml")
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(filepath.Join(coDir, "authentication.yaml"), degradedData, 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Add healthy operator
+				healthyData, err := os.ReadFile("../testing/samples/clusteroperator-healthy.yaml")
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(filepath.Join(coDir, "ingress.yaml"), healthyData, 0644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should parse multiple operators", func() {
+				operators, err := ParseClusterOperators(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(operators).To(HaveLen(2))
+			})
+
+			It("should identify degraded operator", func() {
+				operators, err := ParseClusterOperators(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Find authentication operator
+				var authOp *ClusterOperatorInfo
+				for i := range operators {
+					if operators[i].Name == "authentication" {
+						authOp = &operators[i]
+						break
+					}
+				}
+
+				Expect(authOp).ToNot(BeNil())
+				Expect(authOp.IsDegraded).To(BeTrue())
+				Expect(authOp.IsAvailable).To(BeFalse())
+				Expect(authOp.DegradedReason).To(Equal("OAuthServerDeploymentDegraded"))
+				Expect(authOp.DegradedMessage).To(ContainSubstring("0/1 replicas available"))
+			})
+
+			It("should identify healthy operator", func() {
+				operators, err := ParseClusterOperators(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Find ingress operator
+				var ingressOp *ClusterOperatorInfo
+				for i := range operators {
+					if operators[i].Name == "ingress" {
+						ingressOp = &operators[i]
+						break
+					}
+				}
+
+				Expect(ingressOp).ToNot(BeNil())
+				Expect(ingressOp.IsDegraded).To(BeFalse())
+				Expect(ingressOp.IsAvailable).To(BeTrue())
+				Expect(ingressOp.IsProgressing).To(BeFalse())
+			})
+
+			It("should detect issues correctly", func() {
+				operators, err := ParseClusterOperators(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, op := range operators {
+					if op.Name == "authentication" {
+						Expect(op.HasIssues()).To(BeTrue())
+					} else if op.Name == "ingress" {
+						Expect(op.HasIssues()).To(BeFalse())
+					}
+				}
+			})
+		})
+
+		Context("with missing files", func() {
+			It("should return error when no clusteroperator files found", func() {
+				_, err := ParseClusterOperators(tempDir)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no clusteroperator files found"))
+			})
+		})
+	})
+
+	Describe("Helper functions", func() {
+		var operators []ClusterOperatorInfo
+
+		BeforeEach(func() {
+			operators = []ClusterOperatorInfo{
+				{
+					Name:        "degraded-op",
+					IsDegraded:  true,
+					IsAvailable: false,
+				},
+				{
+					Name:        "healthy-op",
+					IsDegraded:  false,
+					IsAvailable: true,
+				},
+				{
+					Name:        "unavailable-op",
+					IsDegraded:  false,
+					IsAvailable: false,
+				},
+			}
+		})
+
+		Describe("GetDegradedOperators", func() {
+			It("should return only degraded operators", func() {
+				degraded := GetDegradedOperators(operators)
+				Expect(degraded).To(HaveLen(1))
+				Expect(degraded[0].Name).To(Equal("degraded-op"))
+			})
+		})
+
+		Describe("GetUnavailableOperators", func() {
+			It("should return unavailable operators", func() {
+				unavailable := GetUnavailableOperators(operators)
+				Expect(unavailable).To(HaveLen(2))
+
+				// Should include both degraded and unavailable
+				names := []string{unavailable[0].Name, unavailable[1].Name}
+				Expect(names).To(ContainElement("degraded-op"))
+				Expect(names).To(ContainElement("unavailable-op"))
+			})
+		})
+
+		Describe("GetCondition", func() {
+			It("should retrieve specific condition", func() {
+				op := ClusterOperatorInfo{
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:   configv1.OperatorDegraded,
+							Status: configv1.ConditionTrue,
+						},
+						{
+							Type:   configv1.OperatorAvailable,
+							Status: configv1.ConditionFalse,
+						},
+					},
+				}
+
+				degradedCond := op.GetCondition(configv1.OperatorDegraded)
+				Expect(degradedCond).ToNot(BeNil())
+				Expect(degradedCond.Status).To(Equal(configv1.ConditionTrue))
+
+				availableCond := op.GetCondition(configv1.OperatorAvailable)
+				Expect(availableCond).ToNot(BeNil())
+				Expect(availableCond.Status).To(Equal(configv1.ConditionFalse))
+			})
+
+			It("should return nil for missing condition", func() {
+				op := ClusterOperatorInfo{
+					Conditions: []configv1.ClusterOperatorStatusCondition{},
+				}
+
+				cond := op.GetCondition(configv1.OperatorDegraded)
+				Expect(cond).To(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/investigations/diagnosticcollection/parsers/clusterversion.go
+++ b/pkg/investigations/diagnosticcollection/parsers/clusterversion.go
@@ -1,0 +1,106 @@
+package parsers
+
+import (
+	"fmt"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ClusterVersionInfo contains parsed information from ClusterVersion resource
+type ClusterVersionInfo struct {
+	// Name of the ClusterVersion resource (usually "version")
+	Name string
+	// CurrentVersion is the current cluster version
+	CurrentVersion string
+	// DesiredVersion is the target version for upgrade
+	DesiredVersion string
+	// Conditions contains the status conditions
+	Conditions []configv1.ClusterOperatorStatusCondition
+	// History contains the update history
+	History []configv1.UpdateHistory
+	// IsUpgrading indicates if an upgrade is in progress
+	IsUpgrading bool
+	// UpgradeStartTime is when the current upgrade started (if applicable)
+	UpgradeStartTime *metav1.Time
+}
+
+// ParseClusterVersion parses ClusterVersion YAML files from inspect output
+func ParseClusterVersion(inspectDir string) (*ClusterVersionInfo, error) {
+	// Find ClusterVersion YAML files
+	files, err := FindYAMLFilesByPattern(inspectDir, "clusterversions")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find clusterversion files: %w", err)
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no clusterversion files found in %s", inspectDir)
+	}
+
+	// Usually there's only one ClusterVersion resource named "version"
+	// Parse the first one found
+	var cv configv1.ClusterVersion
+	if err := ReadYAMLFile(files[0], &cv); err != nil {
+		return nil, fmt.Errorf("failed to parse clusterversion: %w", err)
+	}
+
+	info := &ClusterVersionInfo{
+		Name:       cv.Name,
+		Conditions: cv.Status.Conditions,
+		History:    cv.Status.History,
+	}
+
+	// Extract current version from history (most recent completed update)
+	if len(cv.Status.History) > 0 {
+		info.CurrentVersion = cv.Status.History[0].Version
+	}
+
+	// Extract desired version from desired update
+	if cv.Spec.DesiredUpdate != nil {
+		info.DesiredVersion = cv.Spec.DesiredUpdate.Version
+	}
+
+	// Determine if upgrade is in progress
+	info.IsUpgrading = isUpgrading(&cv)
+
+	// Get upgrade start time if upgrading
+	if info.IsUpgrading && len(cv.Status.History) > 0 {
+		info.UpgradeStartTime = &cv.Status.History[0].StartedTime
+	}
+
+	return info, nil
+}
+
+// isUpgrading checks if the cluster is currently upgrading
+func isUpgrading(cv *configv1.ClusterVersion) bool {
+	for _, condition := range cv.Status.Conditions {
+		if condition.Type == configv1.OperatorProgressing {
+			return condition.Status == configv1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// GetCondition returns a specific condition by type
+func (c *ClusterVersionInfo) GetCondition(conditionType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i := range c.Conditions {
+		if c.Conditions[i].Type == conditionType {
+			return &c.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// GetUpgradeDuration returns how long the upgrade has been running
+func (c *ClusterVersionInfo) GetUpgradeDuration() time.Duration {
+	if !c.IsUpgrading || c.UpgradeStartTime == nil {
+		return 0
+	}
+	return time.Since(c.UpgradeStartTime.Time)
+}
+
+// IsUpgradeStuck returns true if upgrade has been running for more than the threshold
+func (c *ClusterVersionInfo) IsUpgradeStuck(threshold time.Duration) bool {
+	return c.IsUpgrading && c.GetUpgradeDuration() > threshold
+}

--- a/pkg/investigations/diagnosticcollection/parsers/clusterversion_test.go
+++ b/pkg/investigations/diagnosticcollection/parsers/clusterversion_test.go
@@ -1,0 +1,155 @@
+package parsers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestParsers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Parsers Suite")
+}
+
+var _ = Describe("ClusterVersion Parser", func() {
+	var tempDir string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "clusterversion-test-*")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	Describe("ParseClusterVersion", func() {
+		Context("with stuck upgrade", func() {
+			BeforeEach(func() {
+				// Create directory structure that oc adm inspect would create
+				cvDir := filepath.Join(tempDir, "cluster-scoped-resources", "config.openshift.io", "clusterversions")
+				err := os.MkdirAll(cvDir, 0755)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Copy sample file
+				samplePath := "../testing/samples/clusterversion-stuck.yaml"
+				data, err := os.ReadFile(samplePath)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = os.WriteFile(filepath.Join(cvDir, "version.yaml"), data, 0644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should parse version information", func() {
+				cvInfo, err := ParseClusterVersion(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cvInfo).ToNot(BeNil())
+				Expect(cvInfo.Name).To(Equal("version"))
+				// In stuck upgrade, History[0] is the partial upgrade to 4.14.15
+				Expect(cvInfo.CurrentVersion).To(Equal("4.14.15"))
+				Expect(cvInfo.DesiredVersion).To(Equal("4.14.15"))
+			})
+
+			It("should detect upgrade in progress", func() {
+				cvInfo, err := ParseClusterVersion(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cvInfo.IsUpgrading).To(BeTrue())
+			})
+
+			It("should have upgrade start time", func() {
+				cvInfo, err := ParseClusterVersion(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cvInfo.UpgradeStartTime).ToNot(BeNil())
+			})
+
+			It("should detect stuck upgrade after threshold", func() {
+				cvInfo, err := ParseClusterVersion(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				// The sample has upgrade started at 2024-01-15T14:00:00Z
+				// which is definitely > 4 hours ago, so it should be stuck
+				isStuck := cvInfo.IsUpgradeStuck(4 * time.Hour)
+				Expect(isStuck).To(BeTrue())
+			})
+
+			It("should parse conditions", func() {
+				cvInfo, err := ParseClusterVersion(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cvInfo.Conditions).ToNot(BeEmpty())
+
+				availableCond := cvInfo.GetCondition(configv1.OperatorAvailable)
+				Expect(availableCond).ToNot(BeNil())
+				Expect(availableCond.Status).To(Equal(configv1.ConditionTrue))
+
+				progressingCond := cvInfo.GetCondition(configv1.OperatorProgressing)
+				Expect(progressingCond).ToNot(BeNil())
+				Expect(progressingCond.Status).To(Equal(configv1.ConditionTrue))
+			})
+		})
+
+		Context("with healthy cluster", func() {
+			BeforeEach(func() {
+				cvDir := filepath.Join(tempDir, "cluster-scoped-resources", "config.openshift.io", "clusterversions")
+				err := os.MkdirAll(cvDir, 0755)
+				Expect(err).ToNot(HaveOccurred())
+
+				samplePath := "../testing/samples/clusterversion-healthy.yaml"
+				data, err := os.ReadFile(samplePath)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = os.WriteFile(filepath.Join(cvDir, "version.yaml"), data, 0644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should not show upgrade in progress", func() {
+				cvInfo, err := ParseClusterVersion(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cvInfo.IsUpgrading).To(BeFalse())
+			})
+
+			It("should have matching current and desired versions", func() {
+				cvInfo, err := ParseClusterVersion(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cvInfo.CurrentVersion).To(Equal("4.14.10"))
+				Expect(cvInfo.DesiredVersion).To(Equal(""))
+			})
+
+			It("should not be stuck", func() {
+				cvInfo, err := ParseClusterVersion(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cvInfo.IsUpgradeStuck(4 * time.Hour)).To(BeFalse())
+			})
+		})
+
+		Context("with missing files", func() {
+			It("should return error when no clusterversion files found", func() {
+				_, err := ParseClusterVersion(tempDir)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no clusterversion files found"))
+			})
+		})
+	})
+
+	Describe("GetUpgradeDuration", func() {
+		It("should return 0 for non-upgrading cluster", func() {
+			cvInfo := &ClusterVersionInfo{
+				IsUpgrading: false,
+			}
+			Expect(cvInfo.GetUpgradeDuration()).To(Equal(time.Duration(0)))
+		})
+
+		It("should return 0 when no start time", func() {
+			cvInfo := &ClusterVersionInfo{
+				IsUpgrading:      true,
+				UpgradeStartTime: nil,
+			}
+			Expect(cvInfo.GetUpgradeDuration()).To(Equal(time.Duration(0)))
+		})
+	})
+})

--- a/pkg/investigations/diagnosticcollection/parsers/common.go
+++ b/pkg/investigations/diagnosticcollection/parsers/common.go
@@ -1,0 +1,65 @@
+package parsers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// ReadYAMLFile reads a YAML file and unmarshals it into the provided structure
+func ReadYAMLFile(path string, out interface{}) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+
+	if err := yaml.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("failed to unmarshal YAML from %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// FindYAMLFiles finds all YAML files in a directory (recursively)
+func FindYAMLFiles(dir string) ([]string, error) {
+	var yamlFiles []string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() && (strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")) {
+			yamlFiles = append(yamlFiles, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk directory %s: %w", dir, err)
+	}
+
+	return yamlFiles, nil
+}
+
+// FindYAMLFilesByPattern finds YAML files matching a specific pattern in their path
+// For example, pattern "clusterversion" will match files in paths containing "clusterversion"
+func FindYAMLFilesByPattern(dir, pattern string) ([]string, error) {
+	allFiles, err := FindYAMLFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var matched []string
+	for _, file := range allFiles {
+		if strings.Contains(strings.ToLower(file), strings.ToLower(pattern)) {
+			matched = append(matched, file)
+		}
+	}
+
+	return matched, nil
+}

--- a/pkg/investigations/diagnosticcollection/testing/README.md
+++ b/pkg/investigations/diagnosticcollection/testing/README.md
@@ -1,0 +1,5 @@
+# Testing diagnosticcollection Investigation
+
+TODO:
+- Add a test script or test objects to this  directory for future maintainers to use
+- Edit this README file and add detailed instructions on how to use the script/objects to recreate the conditions for the investigation. Be sure to include any assumptions or prerequisites about the environment (disable hive syncsetting, etc)

--- a/pkg/investigations/diagnosticcollection/testing/samples/clusteroperator-degraded.yaml
+++ b/pkg/investigations/diagnosticcollection/testing/samples/clusteroperator-degraded.yaml
@@ -1,0 +1,42 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: authentication
+  creationTimestamp: "2024-01-15T10:00:00Z"
+spec: {}
+status:
+  conditions:
+    - type: Available
+      status: "False"
+      lastTransitionTime: "2024-01-15T15:00:00Z"
+      reason: OAuthServerDeploymentAvailable
+      message: "deployment/oauth-openshift has 0/1 replicas available"
+    - type: Progressing
+      status: "True"
+      lastTransitionTime: "2024-01-15T15:00:00Z"
+      reason: OAuthServerDeploymentProgressing
+      message: "deployment/oauth-openshift is progressing"
+    - type: Degraded
+      status: "True"
+      lastTransitionTime: "2024-01-15T15:00:00Z"
+      reason: OAuthServerDeploymentDegraded
+      message: "deployment/oauth-openshift has 0/1 replicas available"
+    - type: Upgradeable
+      status: "True"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: ""
+  extension: null
+  relatedObjects:
+    - group: operator.openshift.io
+      name: cluster
+      resource: authentications
+    - group: ""
+      name: openshift-authentication
+      resource: namespaces
+    - group: ""
+      name: openshift-authentication-operator
+      resource: namespaces
+  versions:
+    - name: operator
+      version: 4.14.10

--- a/pkg/investigations/diagnosticcollection/testing/samples/clusteroperator-healthy.yaml
+++ b/pkg/investigations/diagnosticcollection/testing/samples/clusteroperator-healthy.yaml
@@ -1,0 +1,42 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: ingress
+  creationTimestamp: "2024-01-15T10:00:00Z"
+spec: {}
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: ""
+    - type: Progressing
+      status: "False"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: ""
+    - type: Degraded
+      status: "False"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: ""
+    - type: Upgradeable
+      status: "True"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: ""
+  extension: null
+  relatedObjects:
+    - group: operator.openshift.io
+      name: default
+      resource: ingresscontrollers
+    - group: ""
+      name: openshift-ingress-operator
+      resource: namespaces
+    - group: ""
+      name: openshift-ingress
+      resource: namespaces
+  versions:
+    - name: operator
+      version: 4.14.10

--- a/pkg/investigations/diagnosticcollection/testing/samples/clusterversion-healthy.yaml
+++ b/pkg/investigations/diagnosticcollection/testing/samples/clusterversion-healthy.yaml
@@ -1,0 +1,39 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+  creationTimestamp: "2024-01-15T10:00:00Z"
+spec:
+  channel: stable-4.14
+  clusterID: abcd1234-5678-90ab-cdef-1234567890ab
+status:
+  availableUpdates:
+    - version: 4.14.15
+      image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  conditions:
+    - type: Available
+      status: "True"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: Cluster version is available
+    - type: Progressing
+      status: "False"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: Cluster version is 4.14.10
+    - type: Degraded
+      status: "False"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: ""
+  desired:
+    version: 4.14.10
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  history:
+    - state: Completed
+      version: 4.14.10
+      image: quay.io/openshift-release-dev/ocp-release@sha256:...
+      startedTime: "2024-01-10T10:00:00Z"
+      completionTime: "2024-01-10T12:30:00Z"
+  observedGeneration: 1
+  versionHash: "abc123"

--- a/pkg/investigations/diagnosticcollection/testing/samples/clusterversion-stuck.yaml
+++ b/pkg/investigations/diagnosticcollection/testing/samples/clusterversion-stuck.yaml
@@ -1,0 +1,45 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+  creationTimestamp: "2024-01-15T10:00:00Z"
+spec:
+  channel: stable-4.14
+  clusterID: abcd1234-5678-90ab-cdef-1234567890ab
+  desiredUpdate:
+    version: 4.14.15
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+status:
+  availableUpdates: []
+  conditions:
+    - type: Available
+      status: "True"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: Cluster version is available
+    - type: Progressing
+      status: "True"
+      lastTransitionTime: "2024-01-15T14:00:00Z"
+      reason: UpdatingClusterVersion
+      message: Working towards 4.14.15
+    - type: Degraded
+      status: "False"
+      lastTransitionTime: "2024-01-15T10:00:00Z"
+      reason: AsExpected
+      message: ""
+  desired:
+    version: 4.14.15
+    image: quay.io/openshift-release-dev/ocp-release@sha256:...
+  history:
+    - state: Partial
+      version: 4.14.15
+      image: quay.io/openshift-release-dev/ocp-release@sha256:...
+      startedTime: "2024-01-15T14:00:00Z"
+      completionTime: null
+    - state: Completed
+      version: 4.14.10
+      image: quay.io/openshift-release-dev/ocp-release@sha256:...
+      startedTime: "2024-01-10T10:00:00Z"
+      completionTime: "2024-01-10T12:30:00Z"
+  observedGeneration: 2
+  versionHash: "abc123"

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/upgradeconfigsyncfailureover4hr"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/diagnosticcollection"
 )
 
 // availableInvestigations holds all Investigation implementations.
@@ -22,6 +23,7 @@ var availableInvestigations = []investigation.Investigation{
 	&upgradeconfigsyncfailureover4hr.Investigation{},
 	&machinehealthcheckunterminatedshortcircuitsre.Investigation{},
 	&cannotretrieveupdatessre.Investigation{},
+	&diagnosticcollection.Investigation{},
 }
 
 // GetInvestigation returns the first Investigation that applies to the given alert title.


### PR DESCRIPTION
### What type of PR is this?

  **feature**

  ### What this PR does / Why we need it?

  Adds a new experimental investigation that automatically collects and analyzes cluster diagnostics when upgrade-related alerts fire (e.g., `UpgradeConfigSyncFailure`). The investigation uses `oc adm inspect` to gather diagnostic data with read-only
  permissions, parses YAML resources locally, analyzes them for issues, and posts structured findings directly to PagerDuty incidents.

  This reduces MTTR by providing SREs with immediate diagnostic context (cluster version status, stuck upgrades, degraded operators) without manual intervention.

  ### Special notes for your reviewer

  - **Experimental**: Investigation is marked as experimental (`IsExperimental() = true`), requires `CAD_EXPERIMENTAL_ENABLED=true`
  - **Generic design**: While initially handling upgrade alerts, the framework is designed to be easily extensible to other alert types through the alert-to-resource mapping system (see `mappings.go`)
  - **oc adm inspect vs must-gather**: Uses read-only `oc adm inspect` instead of must-gather to work within RBAC constraints (no pod creation required)
  - **Text-based output**: Findings are formatted and posted as PagerDuty notes. Future enhancement planned to upload full diagnostic bundles to S3
  - **Pluggable analyzers**: Each resource type has its own analyzer implementing a common interface for easy extension
  - **Comprehensive documentation**: `pkg/investigations/diagnosticcollection/README.md` includes architecture overview and step-by-step guide for adding new alert types

  ### Test Coverage

  #### Guidelines for CAD investigations
  - New investigations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
  - Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation
  process.

  #### Test coverage checks
  - [x] **Added tests** - 47 comprehensive unit tests using Ginkgo/Gomega covering all components
  - [ ] Created jira card to add unit test
  - [ ] This PR may not need unit tests

  ### Pre-checks (if applicable)
  - [x] **Ran unit tests locally** - All 47 specs passing (analyzers: 16, findings: 11, parsers: 20)
  - [ ] Validated the changes in a cluster - Not yet tested (experimental, requires cluster with upgrade alert)
  - [x] **Included documentation changes with PR** - Added comprehensive README.md with architecture and extension guide

  ---

  **Test results:**
  PASS  analyzers   16/16 specs
  PASS  findings    11/11 specsPASS  parsers     20/20 specs
  BUILD SUCCESS

  **Manual testing instructions** (for reviewers who want to test):
  ```bash
  export CAD_EXPERIMENTAL_ENABLED=true
  ./test/generate_incident.sh UpgradeConfigSyncFailure <cluster-id>
  source test/set_stage_env.sh
  make build
  ./bin/cadctl investigate --payload-path payload
