### PR TITLE
fix remediation name for UpgradeConfigSyncFailureOver4h

### DIFF
--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
@@ -113,7 +113,7 @@ func getClusterPullSecret(k8scli client.Client) (secretToken string, note string
 }
 
 func (c *Investigation) Name() string {
-	return "UpgradeConfigSyncFailureOver4hr"
+	return "upgradeconfigsyncfailureover4hr"
 }
 
 func (c *Investigation) Description() string {


### PR DESCRIPTION
### What type of PR is this?

bug introduced here, as we always take the investigation.name now to build the kubernetes client https://github.com/openshift/configuration-anomaly-detection/pull/578
