### PR TITLE
exit gracefully when stop investigation is set

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -184,7 +184,8 @@ func run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if result.StopInvestigations != nil {
-		return result.StopInvestigations
+		logging.Errorf("Stopping investigations due to: %w", result.StopInvestigations)
+		return nil
 	}
 
 	ccamInvestigation := ccam.CloudCredentialsCheck{}


### PR DESCRIPTION
### What type of PR is this?

(feature/bug/documentation/other)

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
