### PR TITLE
Fix: nilptr deref in ccam.go

### DIFF
--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -24,7 +24,8 @@ var ccamLimitedSupport = &ocm.LimitedSupportReason{
 func (c *CloudCredentialsCheck) Run(r investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
 	// Apart from the defaults this investigation requires an AWS client which can fail to build
-	resources, err := r.WithAwsClient().Build()
+	// as well as a Cluster object.
+	resources, err := r.WithAwsClient().WithCluster().Build()
 	logging.Info("Investigating possible missing cloud credentials...")
 	if err != nil {
 		if customerRemovedPermissions := customerRemovedPermissions(err.Error()); !customerRemovedPermissions {


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Fixes access to `Cluster` object before initalizing it. 

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
