### PR TITLE
add pagerduty alert data to error log

### DIFF
--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -424,7 +424,7 @@ type notesData struct {
 func extractClusterIDFromAlertBody(data map[string]interface{}) (string, error) {
 	details, found := data["details"].(map[string]interface{})
 	if !found {
-		return "", errors.New("could not find alert details field")
+		return "", fmt.Errorf("could not find alert details field: %s", data)
 	}
 
 	// PARSE OPTION 1 (new format): cluster_id directly contained in custom details


### PR DESCRIPTION
### What this PR does / Why we need it?
When failing to parse the alert data from pagerduty, adds the data to the error log, so that we can debug what happens


### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
