### PR TITLE
Fix: nilptr in report writing

### DIFF
--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -130,8 +130,9 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	if err != nil {
 		r.Notes.AppendWarning("failed to create cluster report: %v", err)
 	}
-
-	r.Notes.AppendAutomation("%s", report.GenerateStringForNoteWriter())
+	if report != nil {
+		r.Notes.AppendAutomation("%s", report.GenerateStringForNoteWriter())
+	}
 
 	// Found no issues that CAD can handle by itself - forward notes to SRE.
 	return result, r.PdClient.EscalateIncidentWithNote(r.Notes.String())


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Fixes a nilptr in report writing.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
