### PR TITLE
SREP-2648: Add organization-based escalation policy routing

### DIFF
--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -1,0 +1,147 @@
+package interceptor
+
+import (
+	"errors"
+	"testing"
+
+	ocmmock "github.com/openshift/configuration-anomaly-detection/pkg/ocm/mock"
+	pdmock "github.com/openshift/configuration-anomaly-detection/pkg/pagerduty/mock"
+	"go.uber.org/mock/gomock"
+)
+
+func TestReassignToOrgEscalationPolicy(t *testing.T) {
+	tests := []struct {
+		name                 string
+		orgMap               map[string]string
+		clusterID            string
+		clusterIDErr         error
+		orgID                string
+		orgIDErr             error
+		moveToEPErr          error
+		addNoteErr           error
+		expectMoveToEP       bool
+		expectMoveToEPPolicy string
+		expectAddNote        bool
+		expectNoteContains   string
+	}{
+		{
+			name:                 "scenario 1: cluster in mapped org should reassign",
+			orgMap:               map[string]string{"org-123": "POL123"},
+			clusterID:            "cluster-1",
+			orgID:                "org-123",
+			expectMoveToEP:       true,
+			expectMoveToEPPolicy: "POL123",
+			expectAddNote:        true,
+			expectNoteContains:   "Reassigned to organization org-123",
+		},
+		{
+			name:           "scenario 2: cluster in unmapped org should skip",
+			orgMap:         map[string]string{"org-123": "POL123"},
+			clusterID:      "cluster-1",
+			orgID:          "org-456",
+			expectMoveToEP: false,
+			expectAddNote:  false,
+		},
+		{
+			name:           "scenario 3: empty org mapping should skip",
+			orgMap:         map[string]string{},
+			clusterID:      "cluster-1",
+			orgID:          "org-123",
+			expectMoveToEP: false,
+			expectAddNote:  false,
+		},
+		{
+			name:           "scenario 4: retrieve cluster ID fails should skip",
+			orgMap:         map[string]string{"org-123": "POL123"},
+			clusterIDErr:   errors.New("failed to retrieve cluster ID"),
+			expectMoveToEP: false,
+			expectAddNote:  false,
+		},
+		{
+			name:           "scenario 5: get org ID fails should skip",
+			orgMap:         map[string]string{"org-123": "POL123"},
+			clusterID:      "cluster-1",
+			orgIDErr:       errors.New("OCM error"),
+			expectMoveToEP: false,
+			expectAddNote:  false,
+		},
+		{
+			name:                 "scenario 6: move to escalation policy fails should add failure note",
+			orgMap:               map[string]string{"org-123": "POL123"},
+			clusterID:            "cluster-1",
+			orgID:                "org-123",
+			moveToEPErr:          errors.New("invalid policy"),
+			expectMoveToEP:       true,
+			expectMoveToEPPolicy: "POL123",
+			expectAddNote:        true,
+			expectNoteContains:   "CAD failed to reassign",
+		},
+		{
+			name:           "scenario 7: empty org ID should skip",
+			orgMap:         map[string]string{"org-123": "POL123"},
+			clusterID:      "cluster-1",
+			orgID:          "",
+			expectMoveToEP: false,
+			expectAddNote:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockPD := pdmock.NewMockClient(ctrl)
+			mockOCM := ocmmock.NewMockClient(ctrl)
+
+			// Setup expectations
+			switch {
+			case len(tt.orgMap) == 0:
+				// Empty map, no expectations
+			case tt.clusterIDErr != nil:
+				mockPD.EXPECT().RetrieveClusterID().Return(tt.clusterID, tt.clusterIDErr).Times(1)
+			case tt.orgIDErr != nil || tt.orgID == "":
+				mockPD.EXPECT().RetrieveClusterID().Return(tt.clusterID, nil).Times(1)
+				mockOCM.EXPECT().GetOrganizationID(tt.clusterID).Return(tt.orgID, tt.orgIDErr).Times(1)
+			case tt.expectMoveToEP:
+				mockPD.EXPECT().RetrieveClusterID().Return(tt.clusterID, nil).Times(1)
+				mockOCM.EXPECT().GetOrganizationID(tt.clusterID).Return(tt.orgID, nil).Times(1)
+				mockPD.EXPECT().MoveToEscalationPolicy(tt.expectMoveToEPPolicy).Return(tt.moveToEPErr).Times(1)
+				if tt.expectAddNote {
+					mockPD.EXPECT().AddNote(gomock.Any()).DoAndReturn(func(note string) error {
+						if tt.expectNoteContains != "" && !contains(note, tt.expectNoteContains) {
+							t.Errorf("AddNote() note = %q, want to contain %q", note, tt.expectNoteContains)
+						}
+						return tt.addNoteErr
+					}).Times(1)
+				}
+			default:
+				// Org not in mapping
+				mockPD.EXPECT().RetrieveClusterID().Return(tt.clusterID, nil).Times(1)
+				mockOCM.EXPECT().GetOrganizationID(tt.clusterID).Return(tt.orgID, nil).Times(1)
+			}
+
+			// Execute
+			reassignToOrgEscalationPolicy(mockPD, mockOCM, tt.orgMap)
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && stringContains(s, substr)
+}
+
+func stringContains(s, substr string) bool {
+	if len(substr) == 0 {
+		return true
+	}
+	if len(s) < len(substr) {
+		return false
+	}
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -47,6 +47,11 @@ objects:
           envFrom:
           - secretRef:
               name: cad-pd-token
+          - secretRef:
+              name: cad-ocm-client-secret
+          - secretRef:
+              name: cad-org-policy-mapping-secret
+              optional: true
           image: ${REGISTRY_IMG}:${IMAGE_TAG}
           livenessProbe:
             failureThreshold: 3

--- a/pkg/ocm/mock/ocmmock.go
+++ b/pkg/ocm/mock/ocmmock.go
@@ -23,7 +23,6 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
-	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.
@@ -85,6 +84,21 @@ func (m *MockClient) GetConnection() *sdk.Connection {
 func (mr *MockClientMockRecorder) GetConnection() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnection", reflect.TypeOf((*MockClient)(nil).GetConnection))
+}
+
+// GetOrganizationID mocks base method.
+func (m *MockClient) GetOrganizationID(clusterID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrganizationID", clusterID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrganizationID indicates an expected call of GetOrganizationID.
+func (mr *MockClientMockRecorder) GetOrganizationID(clusterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizationID", reflect.TypeOf((*MockClient)(nil).GetOrganizationID), clusterID)
 }
 
 // GetServiceLog mocks base method.

--- a/pkg/pagerduty/mock/pagerdutymock.go
+++ b/pkg/pagerduty/mock/pagerdutymock.go
@@ -19,7 +19,6 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
-	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.
@@ -93,6 +92,35 @@ func (m *MockClient) GetServiceID() string {
 func (mr *MockClientMockRecorder) GetServiceID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceID", reflect.TypeOf((*MockClient)(nil).GetServiceID))
+}
+
+// MoveToEscalationPolicy mocks base method.
+func (m *MockClient) MoveToEscalationPolicy(escalationPolicyID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MoveToEscalationPolicy", escalationPolicyID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MoveToEscalationPolicy indicates an expected call of MoveToEscalationPolicy.
+func (mr *MockClientMockRecorder) MoveToEscalationPolicy(escalationPolicyID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveToEscalationPolicy", reflect.TypeOf((*MockClient)(nil).MoveToEscalationPolicy), escalationPolicyID)
+}
+
+// RetrieveClusterID mocks base method.
+func (m *MockClient) RetrieveClusterID() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RetrieveClusterID")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveClusterID indicates an expected call of RetrieveClusterID.
+func (mr *MockClientMockRecorder) RetrieveClusterID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveClusterID", reflect.TypeOf((*MockClient)(nil).RetrieveClusterID))
 }
 
 // SilenceIncident mocks base method.

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -38,6 +38,8 @@ type Client interface {
 	EscalateIncidentWithNote(notes string) error
 	EscalateIncident() error
 	UpdateIncidentTitle(title string) error
+	MoveToEscalationPolicy(escalationPolicyID string) error
+	RetrieveClusterID() (string, error)
 }
 
 // SdkClient will hold all the required fields for any SdkClient Operation
@@ -283,8 +285,8 @@ func (c *SdkClient) RetrieveClusterID() (string, error) {
 	return "", fmt.Errorf("could not find a clusterID in the given alerts")
 }
 
-// moveToEscalationPolicy will move the incident's EscalationPolicy to the new EscalationPolicy
-func (c *SdkClient) moveToEscalationPolicy(escalationPolicyID string) error {
+// MoveToEscalationPolicy will move the incident's EscalationPolicy to the new EscalationPolicy
+func (c *SdkClient) MoveToEscalationPolicy(escalationPolicyID string) error {
 	logging.Infof("Moving to escalation policy: %s", escalationPolicyID)
 
 	o := []sdk.ManageIncidentsOptions{
@@ -480,7 +482,7 @@ func commonErrorHandling(err error, sdkErr sdk.APIError) error {
 
 // SilenceIncident silences the alert by assigning the "Silent Test" escalation policy
 func (c *SdkClient) SilenceIncident() error {
-	return c.moveToEscalationPolicy(c.GetSilentEscalationPolicy())
+	return c.MoveToEscalationPolicy(c.GetSilentEscalationPolicy())
 }
 
 // SilenceIncidentWithNote annotates the PagerDuty alert with the given notes and silences it by

--- a/pkg/pagerduty/pagerduty_test.go
+++ b/pkg/pagerduty/pagerduty_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Pagerduty", func() {
 					w.WriteHeader(http.StatusUnauthorized)
 				})
 				// Act
-				err := p.moveToEscalationPolicy(escalationPolicyID)
+				err := p.MoveToEscalationPolicy(escalationPolicyID)
 				// Assert
 				Expect(err).Should(HaveOccurred())
 				Expect(err).Should(MatchError(InvalidTokenError{}))
@@ -70,7 +70,7 @@ var _ = Describe("Pagerduty", func() {
 					_, _ = fmt.Fprintf(w, `{"error":{"code":%d}}`, InvalidInputParamsErrorCode)
 				})
 				// Act
-				err := p.moveToEscalationPolicy(escalationPolicyID)
+				err := p.MoveToEscalationPolicy(escalationPolicyID)
 				// Assert
 				Expect(err).Should(HaveOccurred())
 
@@ -86,7 +86,7 @@ var _ = Describe("Pagerduty", func() {
 					_, _ = fmt.Fprint(w, `{}`)
 				})
 				// Act
-				err := p.moveToEscalationPolicy(escalationPolicyID)
+				err := p.MoveToEscalationPolicy(escalationPolicyID)
 				// Assert
 				Expect(err).ShouldNot(HaveOccurred())
 			})


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?
This PR implements organization-based escalation policy routing for CAD alerts. When alerts fire for clusters that belong to specific organizations (e.g., sovereign customers with dedicated support requirements), CAD now automatically reassigns those incidents to organization-specific escalation policies before running investigations. This ensures alerts are routed to the appropriate dedicated on-call teams rather than the general SRE pool.

Changes:
  - Exported MoveToEscalationPolicy() method in PagerDuty client for interceptor use
  - Added GetOrganizationID() helper to OCM client to check cluster organization membership
  - Implemented org-to-policy mapping logic in interceptor that loads from CAD_ORG_POLICY_MAPPING env var
  - Added test fixture with example mapping structure
  - Reassignment happens before investigation check, ensuring all subsequent escalations occur within the
  correct policy

### Special notes for your reviewer

  The mapping will be managed in a private repo as a Kubernetes secret and injected as an env var. The
  interceptor now requires OCM credentials (CAD_OCM_CLIENT_ID, CAD_OCM_CLIENT_SECRET, CAD_OCM_URL) which
  need to be added to the deployment.

  If reassignment fails, the alert continues processing but a warning note is added to the PagerDuty
  incident alerting SRE to manually route.


### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.


### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


TODO:
   - Finish local testing with mock PagerDuty webhooks and OCM data
  - Create sample mapping in staging and test end-to-end
  - Document deployment configuration for private repo (OCM creds, secret structure, env var setup)
  - Add documentation for onboarding new organizations to dedicated flow