### PR TITLE
Fix Dockerfile make targets

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,8 +3,8 @@ FROM quay.io/redhat-services-prod/openshift/boilerplate:image-v8.0.0 as builder
 ADD . /opt
 WORKDIR /opt
 
-RUN make CGO_ENABLED=0 build-cadctl
-RUN make CGO_ENABLED=0 build-interceptor
+RUN make CGO_ENABLED=0 build-cadctl-release
+RUN make CGO_ENABLED=0 build-interceptor-release
 
 
 FROM registry.access.redhat.com/ubi9-minimal:9.7 as runner


### PR DESCRIPTION
Fix failing builds due to missing build targets.

18:11:19 [1/2] STEP 4/5: RUN make CGO_ENABLED=0 build-cadctl
18:11:19 make: *** No rule to make target 'build-cadctl'.  Stop.
18:11:20 Error: building at STEP "RUN make CGO_ENABLED=0 build-cadctl": while running runtime: exit status 2