### PR TITLE
[SREP-2519] Add metrics to track EtcdDatabaseAnalysis and EtcdSnapshotCleanup

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -286,6 +286,9 @@ func updateMetrics(investigationName string, result *investigation.Investigation
 	if result.MustGatherPerformed.Performed {
 		metrics.Inc(metrics.MustGatherPerformed, append([]string{investigationName}, result.MustGatherPerformed.Labels...)...)
 	}
+	if result.EtcdDatabaseAnalysis.Performed {
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, append([]string{investigationName}, result.EtcdDatabaseAnalysis.Labels...)...)
+	}
 }
 
 func updateIncidentTitle(pdClient *pagerduty.SdkClient) error {

--- a/pkg/investigations/investigation/investigation.go
+++ b/pkg/investigations/investigation/investigation.go
@@ -27,10 +27,11 @@ type InvestigationStep struct {
 }
 
 type InvestigationResult struct {
-	LimitedSupportSet   InvestigationStep
-	ServiceLogPrepared  InvestigationStep
-	ServiceLogSent      InvestigationStep
-	MustGatherPerformed InvestigationStep
+	LimitedSupportSet    InvestigationStep
+	ServiceLogPrepared   InvestigationStep
+	ServiceLogSent       InvestigationStep
+	MustGatherPerformed  InvestigationStep
+	EtcdDatabaseAnalysis InvestigationStep
 
 	// If multiple investigations might be run this can indicate a fatal error that makes running additional investigations useless.
 	// If nil, investigations should continue. If not nil, should contain a meaningful error message explaining why investigations must stop.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,6 +20,8 @@ func Push() {
 		promPusher.Collector(ServicelogPrepared)
 		promPusher.Collector(ServicelogSent)
 		promPusher.Collector(MustGatherPerformed)
+		promPusher.Collector(EtcdDatabaseAnalysis)
+		promPusher.Collector(EtcdSnapshotCleanup)
 		err := promPusher.Add()
 		if err != nil {
 			logging.Errorf("failed to push metrics: %w", err)
@@ -81,4 +83,18 @@ var (
 			Name: "must_gather_performed_total",
 			Help: "counts the total number of must-gathers performed",
 		}, []string{alertTypeLabel, mustgatherLabel})
+	// EtcdDatabaseAnalysis tracks etcddatabasequotalowspace investigation outcomes
+	EtcdDatabaseAnalysis = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystemInvestigate,
+			Name: "etcd_database_analysis_total",
+			Help: "counts etcddatabasequotalowspace investigation outcomes by status and reason",
+		}, []string{alertTypeLabel, "status", "reason"})
+	// EtcdSnapshotCleanup tracks etcd snapshot cleanup success/failure
+	EtcdSnapshotCleanup = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystemInvestigate,
+			Name: "etcd_snapshot_cleanup_total",
+			Help: "counts etcd snapshot cleanup attempts by alert type and status",
+		}, []string{alertTypeLabel, "status"})
 )


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?
Add metrics to track EtcdDatabaseAnalysis and EtcdSnapshotCleanup

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
