### PR TITLE
Handle an empty proxy URL in stage/prod

### DIFF
--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -145,7 +145,13 @@ func run(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not initialize ocm client: %w", err)
 	}
 
-	bpClient, err := backplane.NewClient(backplane.Config{OcmClient: ocmClient, BaseURL: backplaneURL, ProxyURL: backplaneProxy})
+	bpClient, err := backplane.NewClient(
+		backplane.Config{
+			OcmClient: ocmClient,
+			BaseURL:   backplaneURL,
+			ProxyURL:  backplaneProxy,
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("could not initialize backplane client: %w", err)
 	}

--- a/pkg/backplane/backplane.go
+++ b/pkg/backplane/backplane.go
@@ -97,12 +97,19 @@ func (c *ClientImpl) CreateReport(ctx context.Context, clusterId string, summary
 }
 
 func httpDoerWithProxy(proxyURL string) (*http.Client, error) {
+	client := &http.Client{}
+
+	// If the caller passed an empty proxyURL, return a bare client without it
+	if proxyURL == "" {
+		return client, nil
+	}
+
 	proxy, err := url.Parse(proxyURL)
 	if err != nil {
 		return nil, err
 	}
 
-	return &http.Client{
-		Transport: &http.Transport{Proxy: http.ProxyURL(proxy)},
-	}, nil
+	client.Transport = &http.Transport{Proxy: http.ProxyURL(proxy)}
+
+	return client, nil
 }

--- a/pkg/backplane/backplane_test.go
+++ b/pkg/backplane/backplane_test.go
@@ -155,9 +155,10 @@ func TestCreateReport_DataEncoding(t *testing.T) {
 
 func TestHttpDoerWithProxy(t *testing.T) {
 	tests := []struct {
-		name        string
-		proxyURL    string
-		expectError bool
+		name                 string
+		proxyURL             string
+		expectError          bool
+		expectEmptyTransport bool
 	}{
 		{
 			name:        "Valid proxy URL",
@@ -170,9 +171,10 @@ func TestHttpDoerWithProxy(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "Empty proxy URL",
-			proxyURL:    "",
-			expectError: false,
+			name:                 "Empty proxy URL",
+			proxyURL:             "",
+			expectError:          false,
+			expectEmptyTransport: true,
 		},
 		{
 			name:        "Invalid proxy URL",
@@ -192,7 +194,13 @@ func TestHttpDoerWithProxy(t *testing.T) {
 				assert.NoError(t, err)
 				require.NotNil(t, client)
 				assert.IsType(t, &http.Client{}, client)
-				assert.NotNil(t, client.Transport)
+
+				// If the user passes an empty proxyURL in config, we omit the custom transport
+				if tt.expectEmptyTransport {
+					assert.Nil(t, client.Transport)
+				} else {
+					assert.NotNil(t, client.Transport)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / Why we need it?
In production and staging CAD, we do not use a proxy as the network is trusted and internal. This config led us to try and set a proxy, which then failed. The real fix is to handle an empty proxy, and allow the proxy to still work in local development modes.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
