### PR TITLE
Improve error messages in MachineHealthCheckUnterminatedShortCircuitSRE investigation

### DIFF
--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre_test.go
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre_test.go
@@ -135,7 +135,7 @@ func TestInvestigation_investigateFailingMachine(t *testing.T) {
 			want: result{
 				err:    false,
 				action: recommendationInvestigateMachine,
-				notes:  "Red Hat-owned machine in state",
+				notes:  "Red Hat-owned machine in terminal error state",
 			},
 		},
 		{


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

 - Fixed confusing error messages for Red Hat-owned machines with missing error reasons
 - Improved readability of node status messages by converting Kubernetes condition values to human-readable text
 

The investigation was generating unclear PagerDuty notes in two scenarios:

1. Red Hat-owned machines: When errorReason was nil/empty, notes would read:
    `Red Hat-owned machine in state "" due to "can't find created instance"`
    The empty quotes for the state were confusing. This would happen if the customer terminated the AWS instance.
2. Node status conditions: Raw Kubernetes condition values were printed, resulting in:
    `node has been "False" for 4m47s`


machine.Status.ErrorReason and machine.Status.ErrorMessage both express the machine error, but ErrorReason is a machine readable enum and ErrorMessage is meant for logging.
