### PR TITLE
[SREP-3107] Add dry run mode to the 'run' command.

### DIFF
--- a/cadctl/cmd/manual/manual.go
+++ b/cadctl/cmd/manual/manual.go
@@ -11,6 +11,7 @@ var (
 	logLevelFlag      = ""
 	investigationFlag = ""
 	clusterIdFlag     = ""
+	dryRunFlag        = false
 )
 
 func NewManualCmd() (*cobra.Command, error) {
@@ -22,6 +23,7 @@ func NewManualCmd() (*cobra.Command, error) {
 	}
 	cmd.Flags().StringVarP(&clusterIdFlag, "cluster-id", "c", "", "the cluster to run an investigation againstk")
 	cmd.Flags().StringVarP(&investigationFlag, "investigation", "i", "", "the investigation to run manually")
+	cmd.Flags().BoolVarP(&dryRunFlag, "dry-run", "d", false, "run investigation without performing any external operations")
 	err := cmd.MarkFlagRequired("cluster-id")
 	if err != nil {
 		return nil, err
@@ -47,6 +49,7 @@ func run(_ *cobra.Command, _ []string) error {
 		Manual: &controller.ManualConfig{
 			ClusterId:         clusterIdFlag,
 			InvestigationName: investigationFlag,
+			DryRun:            dryRunFlag,
 		},
 	}
 	return controller.Run(opts)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -39,6 +39,7 @@ func (p *PagerDutyConfig) Validate() error {
 type ManualConfig struct {
 	ClusterId         string
 	InvestigationName string
+	DryRun            bool
 }
 
 func (p *ManualConfig) Validate() error {
@@ -63,6 +64,7 @@ type investigationRunner struct {
 	executor     executor.Executor
 	logger       *zap.SugaredLogger
 	dependencies *Dependencies
+	dryRun       bool
 }
 
 type ControllerOptions struct {
@@ -237,6 +239,7 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 				executor:     executor.NewManualExecutor(deps.OCMClient, deps.BackplaneClient, logger),
 				logger:       logger,
 				dependencies: deps,
+				dryRun:       opts.Manual.DryRun,
 			},
 		}, nil
 	}
@@ -464,7 +467,7 @@ func (c *investigationRunner) executeActions(
 		Cluster:           resources.Cluster,
 		Notes:             resources.Notes,
 		Options: executor.ExecutionOptions{
-			DryRun:            false,
+			DryRun:            c.dryRun,
 			StopOnError:       false, // Continue executing actions even if one fails
 			MaxRetries:        3,
 			ConcurrentActions: true, // Use concurrent execution for better performance

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -42,6 +42,10 @@ func getInvestigation(name string, experimental bool) investigation.Investigatio
 }
 
 func (c *ManualController) Investigate(ctx context.Context) error {
+	if c.manual.DryRun {
+		c.logger.Info("🔍 DRY RUN MODE: Investigation will run without performing any external operations")
+	}
+
 	experimentalEnabledVar := os.Getenv("CAD_EXPERIMENTAL_ENABLED")
 	experimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
 	alertInvestigation := getInvestigation(c.manual.InvestigationName, experimentalEnabled)


### PR DESCRIPTION
This will skip running any actions and just print what would have been run.

### What type of PR is this?

feature

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
