### PR TITLE
SREP-3106: add task and pipeline for manual cadctl run

### DIFF
--- a/cadctl/cmd/manual/manual.go
+++ b/cadctl/cmd/manual/manual.go
@@ -12,6 +12,7 @@ var (
 	investigationFlag = ""
 	clusterIdFlag     = ""
 	dryRunFlag        = false
+	pipelineNameEnv   = ""
 )
 
 func NewManualCmd() (*cobra.Command, error) {
@@ -33,9 +34,9 @@ func NewManualCmd() (*cobra.Command, error) {
 		return nil, err
 	}
 
-	if envLogLevel, exists := os.LookupEnv("LOG_LEVEL"); exists {
-		logLevelFlag = envLogLevel
-	}
+	logLevelFlag = os.Getenv("LOG_LEVEL")
+	pipelineNameEnv = os.Getenv("PIPELINE_NAME")
+
 	return cmd, nil
 }
 
@@ -43,7 +44,7 @@ func run(_ *cobra.Command, _ []string) error {
 	opts := controller.ControllerOptions{
 		Common: controller.CommonConfig{
 			LogLevel:   logLevelFlag,
-			Identifier: "",
+			Identifier: pipelineNameEnv,
 		},
 		Pd: nil,
 		Manual: &controller.ManualConfig{

--- a/docs/manual-investigation-pipeline.md
+++ b/docs/manual-investigation-pipeline.md
@@ -1,0 +1,158 @@
+# Manual Investigation Pipeline
+
+The manual investigation pipeline allows running specific CAD investigations on-demand via Tekton, without requiring a PagerDuty alert webhook.
+
+## Overview
+
+This pipeline uses the `cadctl run` command to execute a specific investigation against a target cluster. It is triggered by directly creating a PipelineRun manifest in the CAD cluster.
+
+## Components
+
+### Pipeline: `cad-manual-investigation-pipeline`
+
+A Tekton Pipeline that orchestrates the execution of a manual investigation.
+
+**Parameters:**
+- `cluster-id` (required, string): The cluster ID to investigate
+- `investigation` (required, string): The investigation name to run
+- `dry-run` (optional, string, default: "false"): Run in dry-run mode without performing external operations
+
+**Tasks:**
+- `run-manual-investigation`: Executes the `cad-manual-investigation` task with the provided parameters
+
+### Task: `cad-manual-investigation`
+
+A Tekton Task that runs `cadctl run` with the specified parameters inside a container.
+
+## Architecture Details
+
+### How the Pipeline Works
+
+When you create a PipelineRun:
+
+1. **Kubernetes creates the PipelineRun resource** with your parameters
+2. **Tekton controller detects the new PipelineRun** and starts executing it
+3. **Pipeline passes parameters to the Task** including cluster-id, investigation, and dry-run flag
+4. **Task creates a Pod** using the CAD container image
+5. **Pod executes** `cadctl run --cluster-id <id> --investigation <name>` with access to secrets
+6. **Investigation runs** and produces output (logs, PagerDuty notes, service logs, etc.)
+7. **Pod completes** and Tekton marks the PipelineRun as succeeded or failed
+
+## Usage
+
+### Creating a PipelineRun Programmatically
+
+External tools should create a PipelineRun manifest and apply it to the cluster. Here's the basic structure:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: cad-manual-
+  namespace: configuration-anomaly-detection-production
+spec:
+  params:
+  - name: cluster-id
+    value: "<CLUSTER_ID>"
+  - name: investigation
+    value: "<INVESTIGATION_NAME>"
+  - name: dry-run
+    value: "false"
+  pipelineRef:
+    name: cad-manual-investigation-pipeline
+  serviceAccountName: cad-sa
+  timeout: 30m
+```
+
+**Key fields explained:**
+
+- `generateName: cad-manual-`: Kubernetes will append a unique suffix (e.g., `cad-manual-abc123`)
+- `namespace`: Must be `configuration-anomaly-detection` (or your CAD namespace)
+- `params`: The parameters passed to the pipeline
+- `pipelineRef.name`: Must match the pipeline name (`cad-manual-investigation-pipeline`)
+- `serviceAccountName`: Must be `cad-sa` to have access to secrets
+- `timeout`: Maximum time for the pipeline to run (default: 30m)
+
+### Example: Using oc/kubectl
+
+```bash
+oc create -f - <<EOF
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: cad-manual-
+  namespace: configuration-anomaly-detection
+spec:
+  params:
+  - name: cluster-id
+    value: "<CLUSTER_ID>"
+  - name: investigation
+    value: "<INVESTIGATION_NAME>"
+  - name: dry-run
+    value: "false"
+  pipelineRef:
+    name: cad-manual-investigation-pipeline
+  serviceAccountName: cad-sa
+  timeout: 30m
+EOF
+```
+
+### investigation (required)
+
+The short name of the investigation to run. This must match a registered investigation in the CAD system.
+
+**Type:** string
+
+**Available investigations:**
+- `chgm` - Cluster Has Gone Missing
+- `cmbb` - Cluster Monitoring Error Budget Burn
+- `can-not-retrieve-updates` - Cannot Retrieve Updates SRE
+- `ai` - AI Assisted
+- `cpd` - Cluster Provisioning Delay
+- `etcd-quota-low` - ETCD Database Quota Low Space
+- `insightsoperatordown` - Insights Operator Down
+- `machine-health-check` - Machine Health Check Unterminated Short Circuit SRE
+- `must-gather` - Must Gather
+- `upgrade-config` - Upgrade Config Sync Failure Over 4hr
+
+### dry-run (optional)
+
+When set to `"true"`, the investigation will run in dry-run mode.
+
+**Type:** string (must be `"true"` or `"false"` as a string)
+**Default:** `"false"`
+
+**Dry-run behavior:**
+- Investigation logic executes normally
+- No external operations are performed:
+  - No PagerDuty notes are posted
+  - No service logs are sent
+  - No cluster modifications are made
+- Results are logged locally only
+- Useful for testing investigations or debugging
+
+## Monitoring PipelineRuns
+
+### View Logs of a Specific Run
+
+You will need to connect to the CAD cluster in production.
+
+```bash
+# Get the PipelineRun name first
+oc get pipelineruns -n configuration-anomaly-detection-production
+
+# View logs
+oc logs \
+  -n configuration-anomaly-detection-production \
+  -l tekton.dev/pipelineRun=<PIPELINERUN_NAME> \
+  --all-containers \
+  --follow
+```
+
+### Automatic Cleanup
+
+A CronJob named `tekton-resource-pruner` runs hourly to clean up old PipelineRuns:
+- Keeps the most recent 100 PipelineRuns
+- Deletes older PipelineRuns automatically
+- Runs at the top of every hour
+

--- a/examples/manual-investigation-pipelinerun.yaml
+++ b/examples/manual-investigation-pipelinerun.yaml
@@ -1,0 +1,46 @@
+---
+# Example PipelineRun for manual investigation
+# This demonstrates how to trigger a manual CAD investigation using the cad-manual-investigation-pipeline
+#
+# Usage:
+#   1. Update the cluster-id and investigation parameters below
+#   2. Login to the CAD cluster "cadp01ue1"
+#   3. Apply to the CAD cluster:
+#      oc create -f manual-investigation-pipelinerun.yaml -n configuration-anomaly-detection
+#   4. Monitor progress:
+#      osdctl cluster reports
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: cad-manual-
+  namespace: configuration-anomaly-detection
+  labels:
+    investigation-type: manual
+    triggered-by: external-tool
+spec:
+  params:
+  # REQUIRED: The cluster ID to investigate
+  - name: cluster-id
+    value: "REPLACE_WITH_CLUSTER_ID"
+  # REQUIRED: The investigation to run (e.g., chgm, ccam, etc.)
+  - name: investigation
+    value: "REPLACE_WITH_INVESTIGATION_NAME"
+  # OPTIONAL: Set to "true" to run in dry-run mode (no external operations)
+  # Dry-run mode will execute investigation logic but won't post to PagerDuty or send service logs
+  - name: dry-run
+    value: "false"
+  pipelineRef:
+    name: cad-manual-investigation-pipeline
+  serviceAccountName: cad-sa
+
+  taskRunSpecs:
+  - computeResources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 64Mi
+    pipelineTaskName: run-manual-investigation
+  timeout: 30m

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -240,6 +240,35 @@ objects:
         value: $(context.pipelineRun.name)
       taskRef:
         name: cad-checks
+- apiVersion: tekton.dev/v1beta1
+  kind: Pipeline
+  metadata:
+    name: cad-manual-investigation-pipeline
+  spec:
+    params:
+    - description: The cluster ID to investigate
+      name: cluster-id
+      type: string
+    - description: The investigation name to run
+      name: investigation
+      type: string
+    - default: "false"
+      description: Run in dry-run mode (no external operations)
+      name: dry-run
+      type: string
+    tasks:
+    - name: run-manual-investigation
+      params:
+      - name: cluster-id
+        value: $(params.cluster-id)
+      - name: investigation
+        value: $(params.investigation)
+      - name: dry-run
+        value: $(params.dry-run)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
+      taskRef:
+        name: cad-manual-investigation
 - apiVersion: v1
   kind: ResourceQuota
   metadata:
@@ -360,6 +389,67 @@ objects:
           name: cad-backplane-secret
       image: ${REGISTRY_IMG}:${IMAGE_TAG}
       name: check-infrastructure
+      resources:
+        limits:
+          cpu: 100m
+          memory: 256Mi
+        requests:
+          cpu: 20m
+          memory: 128Mi
+- apiVersion: tekton.dev/v1beta1
+  kind: Task
+  metadata:
+    name: cad-manual-investigation
+  spec:
+    params:
+    - description: The cluster ID to investigate
+      name: cluster-id
+      type: string
+    - description: The investigation name to run
+      name: investigation
+      type: string
+    - default: "false"
+      description: Run in dry-run mode (no external operations)
+      name: dry-run
+      type: string
+    - description: The pipelinerun name
+      name: pipeline-name
+      type: string
+    steps:
+    - args:
+      - |-
+        PIPELINE_NAME=$(params.pipeline-name) cadctl run --cluster-id $(params.cluster-id) --investigation $(params.investigation) --dry-run=$(params.dry-run)
+      command:
+      - /bin/bash
+      - -c
+      env:
+      - name: CAD_PROMETHEUS_PUSHGATEWAY
+        value: aggregation-pushgateway:9091
+      - name: CAD_EXPERIMENTAL_ENABLED
+        value: ${CAD_EXPERIMENTAL_ENABLED}
+      - name: LOG_LEVEL
+        value: ${LOG_LEVEL}
+      - name: CAD_AI_AGENT_CONFIG
+        value: ${CAD_AI_AGENT_CONFIG}
+      - name: CAD_OCTOSQL_IMAGE
+        value: ${CAD_OCTOSQL_IMAGE}
+      - name: AGENTCORE_AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            key: aws_access_key_id
+            name: cad-ai-agent-aws-credentials
+      - name: AGENTCORE_AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            key: aws_secret_access_key
+            name: cad-ai-agent-aws-credentials
+      envFrom:
+      - secretRef:
+          name: cad-ocm-client-secret
+      - secretRef:
+          name: cad-backplane-secret
+      image: ${REGISTRY_IMG}:${IMAGE_TAG}
+      name: run-manual-investigation
       resources:
         limits:
           cpu: 100m

--- a/pkg/executor/action_builders.go
+++ b/pkg/executor/action_builders.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
@@ -246,6 +247,14 @@ func (b *BackplaneReportActionBuilder) Build() Action {
 }
 
 // Convenience functions for simple cases
+
+// NoteAndReportFrom writes both a PD note and a backplane report with the same content and prepends the current timestamp to the summary
+func NoteAndReportFrom(nw *notewriter.NoteWriter, clusterID, summary string) []Action {
+	return []Action{
+		NewBackplaneReportAction(clusterID, fmt.Sprintf("%s : %s", time.Now().UTC().Format(time.RFC3339), summary), nw.String()).Build(),
+		NoteFrom(nw),
+	}
+}
 
 // ServiceLog creates a basic service log action
 func ServiceLog(severity, summary, description string) Action {

--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre.go
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre.go
@@ -79,10 +79,10 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 	if len(targetMachines) == 0 {
 		i.notes.AppendWarning("no machines found for short-circuited machinehealthcheck objects")
-		result.Actions = []types.Action{
-			executor.NoteFrom(i.notes),
+		result.Actions = append(
+			executor.NoteAndReportFrom(i.notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("No machines found for short-circuited MHC objects"),
-		}
+		)
 		return result, nil
 	}
 
@@ -123,10 +123,10 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		i.notes.AppendSuccess("no recommended actions to take against cluster")
 	}
 
-	result.Actions = []types.Action{
-		executor.NoteFrom(i.notes),
+	result.Actions = append(
+		executor.NoteAndReportFrom(i.notes, r.Cluster.ID(), i.Name()),
 		executor.Escalate("MachineHealthCheck investigation complete"),
-	}
+	)
 	return result, nil
 }
 

--- a/pkg/investigations/mustgather/mustgather.go
+++ b/pkg/investigations/mustgather/mustgather.go
@@ -118,9 +118,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	r.Notes.AppendAutomation("CAD collected a must-gather and uploaded it to the Red Hat SFTP server under /anonymous/users/%s/%s", username, path.Base(tarfile.Name()))
 	result.MustGatherPerformed = investigation.InvestigationStep{Performed: true, Labels: []string{productName}}
-	result.Actions = []types.Action{
-		executor.NoteFrom(r.Notes),
-	}
+	result.Actions = executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), c.Name())
 	return result, nil
 }
 

--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
@@ -35,10 +35,10 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	userBannedStatus, userBannedNotes, err := ocm.CheckIfUserBanned(r.OcmClient, r.Cluster)
 	if err != nil {
 		notes.AppendWarning("encountered an issue when checking if the cluster owner is banned: %s\nPlease investigate.", err)
-		result.Actions = []types.Action{
-			executor.NoteFrom(notes),
+		result.Actions = append(
+			executor.NoteAndReportFrom(notes, r.Cluster.ID(), c.Name()),
 			executor.Escalate("Failed to check if user is banned"),
-		}
+		)
 		return result, nil
 	}
 	if userBannedStatus {
@@ -50,10 +50,10 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	logging.Infof("User ID is: %v", user.ID())
 	if err != nil {
 		notes.AppendWarning("Failed getting cluster creator from ocm: %s", err)
-		result.Actions = []types.Action{
-			executor.NoteFrom(notes),
+		result.Actions = append(
+			executor.NoteAndReportFrom(notes, r.Cluster.ID(), c.Name()),
 			executor.Escalate("Failed to get cluster creator from OCM"),
-		}
+		)
 		return result, nil
 	}
 
@@ -100,10 +100,10 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	} else {
 		notes.AppendWarning("Pull secret does not match on cluster and in OCM.")
 	}
-	result.Actions = []types.Action{
-		executor.NoteFrom(notes),
+	result.Actions = append(
+		executor.NoteAndReportFrom(notes, r.Cluster.ID(), c.Name()),
 		executor.Escalate("UpgradeConfigSyncFailure investigation complete"),
-	}
+	)
 	return result, nil
 }
 


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

Adds a new Tekton pipeline and task to enable on-demand manual CAD investigations without requiring a PagerDuty webhook trigger. It also changes the default action for each investigation to create both a backplane report and a pagerduty note, which is  required to see the results of a manual action.

  This allows external tools or SREs to programmatically run specific investigations against clusters by creating PipelineRun manifests, providing:
  - cad-manual-investigation-pipeline: Pipeline for orchestrating manual investigation execution
  - cad-manual-investigation task: Task that runs cadctl run with cluster ID and investigation parameters
  - Dry-run support for testing investigations without external operations

  The manual command now uses the PIPELINE_NAME environment variable as the identifier for better tracking and observability.

### Special notes for your reviewer

This has not been tested yet, as the CAD stage cluster is in production. Testing will need to occur in the production environment. 

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
