### PR TITLE
SREP-3359: Add local retry logic to mustgather SFTP operations

### DIFF
--- a/pkg/investigations/mustgather/mustgather.go
+++ b/pkg/investigations/mustgather/mustgather.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/utils/tarball"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
+	"github.com/openshift/configuration-anomaly-detection/pkg/utils"
 )
 
 const (
@@ -36,6 +37,14 @@ const (
 	mustGatherOperatorNamespace     = "openshift-must-gather-operator" // permanent namespace to exclude from checks
 	mustGatherWaitTimeout           = 30 * time.Minute                 // timeout for waiting for existing must-gather namespace to be deleted
 	mustGatherPollInterval          = 60 * time.Second                 // interval for polling namespace existence
+
+	// SFTP retry configuration; retries transient failures locally to avoid
+	// re-running the must-gather collection due to the outer investigation retry
+	sftpRetryAttempts            = 3               // total attempts (1 initial + 2 retries)
+	sftpRetryInitialBackoff      = 2 * time.Second // exp. backoff
+	sftpCredentialAttemptTimeout = 30 * time.Second
+	sftpCredentialOverallTimeout = 2 * time.Minute
+	sftpUploadOverallTimeout     = time.Hour * 6
 
 	// label for metrics
 	productNameClassic = "ROSA classic"
@@ -138,10 +147,18 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		logging.Warnf("CAD was unable to close the must-gather tar file descriptor: %v\n Attempting to proceed anyway...", err)
 	}
 
-	// Get SFTP credentials with a reasonable timeout for the HTTP request
-	credCtx, credCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// Get SFTP credentials with retry logic to avoid re-running the must-gather
+	// on transient failures.
+	var username, token string
+	credCtx, credCancel := context.WithTimeout(context.Background(), sftpCredentialOverallTimeout)
 	defer credCancel()
-	username, token, err := getAnonymousSftpCredentials(credCtx, http.DefaultClient)
+	err = utils.WithRetriesContext(credCtx, sftpRetryAttempts, sftpRetryInitialBackoff, func() error {
+		attemptCtx, attemptCancel := context.WithTimeout(credCtx, sftpCredentialAttemptTimeout)
+		defer attemptCancel()
+		var credErr error
+		username, token, credErr = getAnonymousSftpCredentials(attemptCtx, http.DefaultClient)
+		return credErr
+	})
 	if err != nil {
 		return result, investigation.WrapInfrastructure(
 			fmt.Errorf("CAD was unable to get the Red Hat sftp server credentials: %w", err),
@@ -151,10 +168,13 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	logging.Infof("anonymous SFTP username: %s", username)
 
 	// Upload with extended timeout - during testing, uploading to the SFTP server was very slow at 10 MB/min
+	// retry logic shares the overall timeout (6 hours), as to avoid multiple such long timeouts
 	// FIXME: As in improvement, CAD could use its own service account to upload to the SFTP server.
-	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), time.Hour*6)
+	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), sftpUploadOverallTimeout)
 	defer uploadCancel()
-	err = sftpUpload(uploadCtx, tarfile.Name(), username, token)
+	err = utils.WithRetriesContext(uploadCtx, sftpRetryAttempts, sftpRetryInitialBackoff, func() error {
+		return sftpUpload(uploadCtx, tarfile.Name(), username, token)
+	})
 	if err != nil {
 		return result, investigation.WrapInfrastructure(
 			fmt.Errorf("CAD was unable to upload to the Red Hat sftp server: %w", err),

--- a/pkg/investigations/mustgather/sftpUpload_test.go
+++ b/pkg/investigations/mustgather/sftpUpload_test.go
@@ -8,8 +8,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/utils"
 )
 
 // errorReader simulates read errors
@@ -462,4 +465,126 @@ func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	req.URL.Scheme = "http"
 	req.URL.Host = strings.TrimPrefix(m.serverURL, "http://")
 	return http.DefaultClient.Do(req)
+}
+
+// createFlakySftpCredentialServer creates a mock server that fails for the first
+// N requests and then succeeds, simulating transient failures.
+func createFlakySftpCredentialServer(t *testing.T, failCount int) string {
+	t.Helper()
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&requestCount, 1)
+		if int(count) <= failCount {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error": "service temporarily unavailable"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"username": "retry-user",
+			"token": "retry-token",
+			"expiryDate": "2024-12-31T23:59:59Z"
+		}`))
+	}))
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+func TestGetAnonymousSftpCredentials_RetryOnTransientFailure(t *testing.T) {
+	tests := []struct {
+		name         string
+		failCount    int
+		maxAttempts  int
+		wantUsername string
+		wantToken    string
+		wantErr      bool
+		description  string
+	}{
+		{
+			name:         "succeeds after 1 transient failure",
+			failCount:    1,
+			maxAttempts:  3,
+			wantUsername: "retry-user",
+			wantToken:    "retry-token",
+			wantErr:      false,
+			description:  "Should succeed on second attempt after first returns 503",
+		},
+		{
+			name:         "succeeds after 2 transient failures",
+			failCount:    2,
+			maxAttempts:  3,
+			wantUsername: "retry-user",
+			wantToken:    "retry-token",
+			wantErr:      false,
+			description:  "Should succeed on third attempt after two 503 errors",
+		},
+		{
+			name:        "fails when all attempts exhausted",
+			failCount:   5,
+			maxAttempts: 3,
+			wantErr:     true,
+			description: "Should fail after all retry attempts are exhausted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serverURL := createFlakySftpCredentialServer(t, tt.failCount)
+			mockClient := &mockHTTPClient{serverURL: serverURL}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			var username, token string
+			err := utils.WithRetriesContext(ctx, tt.maxAttempts, 10*time.Millisecond, func() error {
+				attemptCtx, attemptCancel := context.WithTimeout(ctx, 5*time.Second)
+				defer attemptCancel()
+				var credErr error
+				username, token, credErr = getAnonymousSftpCredentials(attemptCtx, mockClient)
+				return credErr
+			})
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("%s: expected error but got none", tt.description)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("%s: unexpected error: %v", tt.description, err)
+				}
+				if username != tt.wantUsername {
+					t.Errorf("%s: expected username %q, got %q", tt.description, tt.wantUsername, username)
+				}
+				if token != tt.wantToken {
+					t.Errorf("%s: expected token %q, got %q", tt.description, tt.wantToken, token)
+				}
+			}
+		})
+	}
+}
+
+func TestGetAnonymousSftpCredentials_RetryRespectsContextCancellation(t *testing.T) {
+	// Create a server that always fails
+	serverURL := createFlakySftpCredentialServer(t, 100)
+	mockClient := &mockHTTPClient{serverURL: serverURL}
+
+	// Use a short timeout that will expire during backoff
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	var username, token string
+	err := utils.WithRetriesContext(ctx, 5, 1*time.Second, func() error {
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer attemptCancel()
+		var credErr error
+		username, token, credErr = getAnonymousSftpCredentials(attemptCtx, mockClient)
+		return credErr
+	})
+
+	if err == nil {
+		t.Fatal("expected error due to context cancellation, got nil")
+	}
+	if username != "" || token != "" {
+		t.Errorf("expected empty credentials on failure, got username=%q token=%q", username, token)
+	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,33 +2,38 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 )
 
-// WithRetries runs a function with up to 10 retries on error
-func WithRetries(fn func() error) error {
-	const defaultRetries = 10
-	const defaultInitialBackoff = time.Second * 2
-
-	return WithRetriesConfigurable(defaultRetries, defaultInitialBackoff, fn)
-}
-
-// WithRetriesConfigurable runs a function with a configurable retry count and backoff interval on error
-func WithRetriesConfigurable(count int, initialBackoff time.Duration, fn func() error) error {
+// WithRetriesContext runs a function with configurable retries and exponential backoff,
+// while respecting context cancellation. return immediately if the context is
+// cancelled or times out during a backoff wait. In such a case, most recent error is wrapped.
+func WithRetriesContext(ctx context.Context, count int, initialBackoff time.Duration, fn func() error) error {
 	var err error
 	for i := 0; i < count; i++ {
 		if i > 0 {
-			logging.Warnf("Retry %d: %s \n", i, err.Error())
-			time.Sleep(initialBackoff)
+			logging.Warnf("Retry %d/%d: %s", i, count-1, err.Error())
+
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("context cancelled during retry backoff (last error: %w): %w", err, ctx.Err())
+			case <-time.After(initialBackoff):
+			}
+
 			initialBackoff *= 2
 		}
+
 		err = fn()
 		if err == nil {
+			if i > 0 {
+				logging.Infof("Succeeded on attempt %d/%d", i+1, count)
+			}
 			return nil
 		}
 	}
-	return fmt.Errorf("failed after %d retries: %w", count, err)
+	return fmt.Errorf("failed after %d attempts: %w", count, err)
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,180 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWithRetriesContext_SucceedsFirstAttempt(t *testing.T) {
+	attempts := 0
+	err := WithRetriesContext(context.Background(), 3, 10*time.Millisecond, func() error {
+		attempts++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt, got %d", attempts)
+	}
+}
+
+func TestWithRetriesContext_SucceedsOnRetry(t *testing.T) {
+	attempts := 0
+	err := WithRetriesContext(context.Background(), 3, 10*time.Millisecond, func() error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("transient error")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestWithRetriesContext_ExhaustsAllRetries(t *testing.T) {
+	attempts := 0
+	originalErr := errors.New("persistent error")
+	err := WithRetriesContext(context.Background(), 3, 10*time.Millisecond, func() error {
+		attempts++
+		return originalErr
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+	if !strings.Contains(err.Error(), "failed after 3 attempts") {
+		t.Errorf("expected error message to contain 'failed after 3 attempts', got: %v", err)
+	}
+	if !errors.Is(err, originalErr) {
+		t.Errorf("expected wrapped error to contain original error")
+	}
+}
+
+func TestWithRetriesContext_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+
+	err := WithRetriesContext(ctx, 5, 1*time.Second, func() error {
+		attempts++
+		if attempts == 1 {
+			// Cancel context after first failure, so the backoff wait is interrupted
+			cancel()
+		}
+		return errors.New("transient error")
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt before context cancellation, got %d", attempts)
+	}
+	if !strings.Contains(err.Error(), "context cancelled during retry backoff") {
+		t.Errorf("expected context cancellation error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "transient error") {
+		t.Errorf("expected last operation error in message, got: %v", err)
+	}
+}
+
+func TestWithRetriesContext_RespectsContextTimeout(t *testing.T) {
+	// Create a context that times out before the backoff completes
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	attempts := 0
+	err := WithRetriesContext(ctx, 5, 1*time.Second, func() error {
+		attempts++
+		return errors.New("transient error")
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt before context timeout, got %d", attempts)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded in error chain, got: %v", err)
+	}
+}
+
+func TestWithRetriesContext_ExponentialBackoff(t *testing.T) {
+	attempts := 0
+	timestamps := []time.Time{}
+
+	err := WithRetriesContext(context.Background(), 3, 50*time.Millisecond, func() error {
+		attempts++
+		timestamps = append(timestamps, time.Now())
+		return errors.New("transient error")
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if len(timestamps) != 3 {
+		t.Fatalf("expected 3 timestamps, got %d", len(timestamps))
+	}
+
+	// First retry should wait ~50ms
+	firstBackoff := timestamps[1].Sub(timestamps[0])
+	if firstBackoff < 40*time.Millisecond || firstBackoff > 150*time.Millisecond {
+		t.Errorf("first backoff expected ~50ms, got %v", firstBackoff)
+	}
+
+	// Second retry should wait ~100ms (doubled)
+	secondBackoff := timestamps[2].Sub(timestamps[1])
+	if secondBackoff < 80*time.Millisecond || secondBackoff > 250*time.Millisecond {
+		t.Errorf("second backoff expected ~100ms, got %v", secondBackoff)
+	}
+}
+
+func TestWithRetriesContext_SingleAttempt(t *testing.T) {
+	attempts := 0
+	originalErr := errors.New("single attempt error")
+	err := WithRetriesContext(context.Background(), 1, 10*time.Millisecond, func() error {
+		attempts++
+		return originalErr
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt, got %d", attempts)
+	}
+	if !errors.Is(err, originalErr) {
+		t.Errorf("expected wrapped error to contain original error")
+	}
+}
+
+func TestWithRetriesContext_AlreadyCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	attempts := 0
+	err := WithRetriesContext(ctx, 3, 10*time.Millisecond, func() error {
+		attempts++
+		return errors.New("should not retry")
+	})
+
+	// The first attempt runs (context is checked during backoff, not before fn call)
+	// But after the first failure, the backoff wait sees the cancelled context
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt with already-cancelled context, got %d", attempts)
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

feat

### What this PR does / Why we need it?

Adds internal retry logic (3 attempts, exponential backoff) to SFTP credential fetching and file upload in the mustgather investigation, so transient failures are handled locally without re-running the expensive must-gather.

If local retries are exhausted, `InfrastructureError` wrapping is preserved as a fallback for the controller-level retry.

Also adds a reusable `WithRetriesContext()` utility to `pkg/utils` and removes the unused `WithRetries`/`WithRetriesConfigurable` functions.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [x] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
