### PR TITLE
Send out a Service Log if the cluster owner is banned for UpgradeConfigSyncFailureOver4HrSRE alerts

### DIFF
--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/README.md
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/README.md
@@ -4,9 +4,12 @@ Investigates the UpgradeConfigSyncFailureOver4HrSRE alert by validating cluster 
 
 ## What it checks
 
-Uses `pkg/pullsecret` to validate:
-1. **Email**: `cloud.openshift.com` email in cluster pull secret matches OCM account email
-2. **Registry credentials**: Per-registry email and token match OCM credentials
+- Uses `pkg/ocm` to check if the cluster owner is banned:
+  - if the owner is banned due to export control compliance, the incident is escalated for SREs to follow up ([SOP](https://github.com/openshift/ops-sop/blob/master/v4/alerts/UpgradeConfigSyncFailureOver4HrSRE.md)).
+  - if the owner is banned for any other reason, a Service Log is sent out.
+- Uses `pkg/pullsecret` to validate:
+  1. **Email**: `cloud.openshift.com` email in cluster pull secret matches OCM account email
+  2. **Registry credentials**: Per-registry email and token match OCM credentials
 
 ## Manual Integration Test
 

--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
@@ -2,6 +2,8 @@
 package upgradeconfigsyncfailureover4hr
 
 import (
+	"errors"
+
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
@@ -22,20 +24,61 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	notes := notewriter.New("UpgradeConfigSyncFailureOver4Hr", logging.RawLogger)
 
 	logging.Infof("Checking if user is Banned.")
-	userBannedStatus, userBannedNotes, err := ocm.CheckIfUserBanned(r.OcmClient, r.Cluster)
-	if err != nil {
+	userBannedErr := ocm.UserBannedError{}
+	err = ocm.CheckIfUserBanned(r.OcmClient, r.Cluster)
+
+	switch {
+	case errors.As(err, &userBannedErr) && userBannedErr.Code == "export_control_compliance":
+		// User is banned due to Export Control Compliance; escalate to SRE
+		notes.AppendWarning("%v", err)
+		result.Actions = append(
+			result.Actions,
+			executor.NoteAndReportFrom(notes, r.Cluster.ID(), c.Name())...,
+		)
+
+		result.Actions = append(
+			result.Actions,
+			executor.Escalate("Export Control Compliance ban detected, please refer to the SOP."),
+		)
+
+		return result, nil
+	case errors.As(err, &userBannedErr):
+		// User is banned, but not due to Export Control Compliance; Send a SL
+
+		sl := ocm.NewOCMBannedUserServiceLog()
+
+		notes.AppendWarning("%v", err)
+		notes.AppendWarning("Sending out Service Log (%s)", sl.Summary)
+		result.Actions = append(
+			result.Actions,
+			executor.NoteAndReportFrom(notes, r.Cluster.ID(), c.Name())...,
+		)
+
+		result.Actions = append(
+			result.Actions,
+			executor.NewServiceLogAction(sl.Severity, sl.Summary).
+				WithDescription(sl.Description).
+				WithServiceName(sl.ServiceName).
+				Build(),
+		)
+		return result, nil
+	case err != nil:
+		// Unhandled error; escalate to SRE
 		notes.AppendWarning("encountered an issue when checking if the cluster owner is banned: %s\nPlease investigate.", err)
 		result.Actions = append(
-			executor.NoteAndReportFrom(notes, r.Cluster.ID(), c.Name()),
+			result.Actions,
+			executor.NoteAndReportFrom(notes, r.Cluster.ID(), c.Name())...,
+		)
+
+		result.Actions = append(
+			result.Actions,
 			executor.Escalate("Failed to check if user is banned"),
 		)
 		return result, nil
 	}
-	if userBannedStatus {
-		notes.AppendWarning("%s", userBannedNotes)
-	} else {
-		notes.AppendSuccess("User is not banned.")
-	}
+
+	notes.AppendSuccess("User is not banned.")
+
 	user, err := ocm.GetCreatorFromCluster(r.OcmClient.GetConnection(), r.Cluster)
 	logging.Infof("User ID is: %v", user.ID())
 	if err != nil {

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -35,6 +35,12 @@ type ServiceLog struct {
 	InternalOnly bool
 }
 
+// UserBanedError contains the reason for a user's ban
+type UserBannedError struct {
+	Code        string
+	Description string
+}
+
 // Client is the interface exposing OCM related functions
 type Client interface {
 	GetClusterMachinePools(internalClusterID string) ([]*cmv1.MachinePool, error)
@@ -331,18 +337,21 @@ func (c *SdkClient) GetClusterHypershiftConfig(cluster *cmv1.Cluster) (*cmv1.Hyp
 	return resp.Body(), nil
 }
 
-func CheckIfUserBanned(ocmClient Client, cluster *cmv1.Cluster) (bool, string, error) {
+func CheckIfUserBanned(ocmClient Client, cluster *cmv1.Cluster) error {
 	user, err := GetCreatorFromCluster(ocmClient.GetConnection(), cluster)
 	if err != nil {
-		return false, "encountered an issue when checking if the cluster owner is banned. Please investigate.", err
+		return fmt.Errorf("while checking if the cluster owner is banned: %w", err)
 	}
 
 	if user.Banned() {
-		noteMessage := fmt.Sprintf("User is banned %s. Ban description %s.\n Please open a proactive case, so that MCS can resolve the ban or organize a ownership transfer.", user.BanCode(), user.BanDescription())
-		logging.Warnf(noteMessage)
-		return true, noteMessage, nil
+		return UserBannedError{
+			Code:        user.BanCode(),
+			Description: user.BanDescription(),
+		}
 	}
-	return false, "User is not banned.", nil
+
+	// User is not banned
+	return nil
 }
 
 const (
@@ -439,4 +448,18 @@ func (c *SdkClient) GetDynatraceURL(cluster *cmv1.Cluster) (string, error) {
 	}
 
 	return "", errors.New("dynatrace tenant label not found in subscription")
+}
+
+func (e UserBannedError) Error() string {
+	return fmt.Sprintf("user is banned (%s): %s", e.Code, e.Description)
+}
+
+func NewOCMBannedUserServiceLog() ServiceLog {
+	return ServiceLog{
+		Severity:     "Critical",
+		Summary:      "Action required: Arrange new cluster owner",
+		Description:  "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please raise a support case with Red Hat to nominate a new owner for the cluster in https://console.redhat.com/openshift/.",
+		InternalOnly: false,
+		ServiceName:  "SREManualAction",
+	}
 }


### PR DESCRIPTION
### What type of PR is this?

Change to existing Investigation

### What this PR does / Why we need it?

This PR addresses [SREP-1129](https://redhat.atlassian.net/browse/SREP-1129): the investigation for alert `UpgradeConfigSyncFailureOver4HrSRE` will send out a service log if:

- the cluster owner is banned
- the ban is not due to export control compliance

### Special notes for your reviewer

Until [ACM !5183](https://gitlab.cee.redhat.com/service/uhc-account-manager/-/merge_requests/5183) is merged there is an error with the pull secret validation path. This is not relevant to the changes of this PR.

### Test Coverage

There are currently no tests for this investigation. As the network validation path as it is reaches out to the AWS API the investigation can't be unit-tested as a whole (current mocks won't do). Tests should be more easily added once [SREP-4342](https://redhat.atlassian.net/browse/SREP-4342) is implemented.

I have tested all four paths (ban due to export control compliance, generic ban, generic error, user is not banned) locally by hard-coding the ban response from OCM.

#### Test coverage checks
- [ ] Added tests
- [x] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR


[SREP-1129]: https://redhat.atlassian.net/browse/SREP-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SREP-4342]: https://redhat.atlassian.net/browse/SREP-4342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ