### PR TITLE
SREP-1129 - OCMAgentResponseFailureServiceLogsSRE Investigation

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -593,7 +593,7 @@ func (c *investigationRunner) populateFilterContextFromOCM(filterCtx *types.Filt
 
 	// Owner ID and email require subscription + account lookups — only call if a filter needs them.
 	if slices.Contains(requiredKeys, config.FieldOwnerID) || slices.Contains(requiredKeys, config.FieldOwnerEmail) {
-		creator, err := ocm.GetCreatorFromCluster(c.ocmClient.GetConnection(), cluster)
+		creator, err := c.ocmClient.GetCreatorFromCluster(cluster)
 		if err != nil {
 			return fmt.Errorf("could not populate filter context owner fields: %w", err)
 		}

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -25,6 +25,7 @@ var shortNameToInvestigation = map[string]string{
 	"insightsoperatordown":     "insightsoperatordown",
 	"machine-health-check":     "machinehealthcheckunterminatedshortcircuitsre",
 	"must-gather":              "mustgather",
+	"ocmagentresponsefailure":  "ocmagentresponsefailure",
 	"restart-controlplane":     "restartcontrolplane",
 	"upgrade-config":           "upgradeconfigsyncfailureover4hr",
 	"describe-nodes":           "describenodes",

--- a/pkg/investigations/insightsoperatordown/insightsoperatordown.go
+++ b/pkg/investigations/insightsoperatordown/insightsoperatordown.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/networkverifier"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
-	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -26,7 +25,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 	notes := notewriter.New(r.Name, logging.RawLogger)
 
-	user, err := ocm.GetCreatorFromCluster(r.OcmClient.GetConnection(), r.Cluster)
+	user, err := r.OcmClient.GetCreatorFromCluster(r.Cluster)
 	if err != nil {
 		notes.AppendWarning("encountered an issue when checking if the cluster owner is banned: %s", err)
 		result.Actions = append(

--- a/pkg/investigations/ocmagentresponsefailure/README.md
+++ b/pkg/investigations/ocmagentresponsefailure/README.md
@@ -1,0 +1,16 @@
+# ocmagentresponsefailure Investigation
+
+Investigates the OCMAgentResponseFailureServiceLogsSRE alert; as part of this investigation, the following checks are run:
+
+1. Network egress verifier
+1. OCM banned user validation
+1. Pull secret validation
+
+Once the initial informing phase tests are over, a Service Log will be sent out if the cluster owner is banned, with the only exception being if the reason of the ban is due to Export Control Compliance.
+In any other case the investigation is escalated to SRE for further analysis, please refer to the [SOP](https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md) for this alert for further information.
+
+
+## Testing
+
+Refer to the [testing README](./testing/README.md) for instructions on how to test this investigation.
+

--- a/pkg/investigations/ocmagentresponsefailure/metadata.yaml
+++ b/pkg/investigations/ocmagentresponsefailure/metadata.yaml
@@ -1,0 +1,15 @@
+name: ocmagentresponsefailure
+rbac:
+  roles:
+    - namespace: "openshift-config"
+      rules:
+        - verbs:
+            - "get"
+          apiGroups:
+            - ""
+          resources:
+            - "secrets"
+          resourceNames:
+            - "pull-secret"
+  clusterRoleRules: []
+customerDataAccess: false

--- a/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
+++ b/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
@@ -4,6 +4,8 @@ package ocmagentresponsefailure
 
 import (
 	"errors"
+	"os"
+	"strconv"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
@@ -104,6 +106,7 @@ func (i *Investigation) AlertTitle() string {
 // checkUserBanStatus checks if the cluster owner is banned.
 // It returns a set of actions, and a boolean indicating whether the investigation should halt
 func checkUserBanStatus(r *investigation.Resources) (checkResult, error) {
+	experimentalEnabled, _ := strconv.ParseBool(os.Getenv("CAD_EXPERIMENTAL_ENABLED"))
 	userBannedErr := ocm.UserBannedError{}
 	err := r.OcmClient.CheckIfUserBanned(r.Cluster)
 	actions := []types.Action{}
@@ -130,14 +133,17 @@ func checkUserBanStatus(r *investigation.Resources) (checkResult, error) {
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), r.Name)...,
 		)
 
-		// TODO: Uncomment once informing phase tests are concluded
-		/*
+		// Remove this check once informing phase tests are concluded
+		if experimentalEnabled {
 			sl := ocm.NewOCMBannedUserServiceLog()
-			executor.NewServiceLogAction(sl.Severity, sl.Summary).
-				WithDescription(sl.Description).
-				WithServiceName(sl.ServiceName).
-				Build(),
-		*/
+			actions = append(
+				actions,
+				executor.NewServiceLogAction(sl.Severity, sl.Summary).
+					WithDescription(sl.Description).
+					WithServiceName(sl.ServiceName).
+					Build(),
+			)
+		}
 
 		actions = append(
 			actions,

--- a/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
+++ b/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
@@ -130,7 +130,7 @@ func checkUserBanStatus(r *investigation.Resources) (checkResult, error) {
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), r.Name)...,
 		)
 
-		// Uncomment once informing phase tests are concluded
+		// TODO: Uncomment once informing phase tests are concluded
 		/*
 			sl := ocm.NewOCMBannedUserServiceLog()
 			executor.NewServiceLogAction(sl.Severity, sl.Summary).

--- a/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
+++ b/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
@@ -1,0 +1,247 @@
+// Package ocmagentresponsefailure implements the investigation logic
+// for the "OCMAgentResponseFailureServiceLogsSRE" alert.
+package ocmagentresponsefailure
+
+import (
+	"errors"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/networkverifier"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	"github.com/openshift/configuration-anomaly-detection/pkg/pullsecret"
+	"github.com/openshift/configuration-anomaly-detection/pkg/types"
+)
+
+type Investigation struct{}
+
+type check func(*investigation.Resources) (checkResult, error)
+
+// checkResult is returned by individual checks. It contains the set of actions
+// as determined by the check, as well as a boolean indicating whether the
+// investigation should stop.
+type checkResult struct {
+	actions []types.Action
+	stop    bool
+}
+
+func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
+	investigationResult := investigation.InvestigationResult{}
+	r, err := rb.WithNotes().WithAwsClient().WithK8sClient().WithClusterDeployment().Build()
+	if err != nil {
+		if msg, ok := investigation.ClusterAccessErrorMessage(err); ok {
+			investigationResult.Actions = []types.Action{
+				executor.Note(msg),
+				executor.Escalate(msg),
+			}
+			return investigationResult, nil
+		}
+		return investigationResult, investigation.WrapInfrastructure(err, "Resource build error")
+	}
+
+	if r.IsHCP {
+		msg := "HCP detected, please manually investigate."
+		investigationResult.Actions = []types.Action{
+			executor.Note(msg),
+			executor.Escalate(msg),
+		}
+
+		return investigationResult, nil
+	}
+
+	checks := []check{
+		validateEgress,
+		checkUserBanStatus,
+		validatePullSecret,
+	}
+
+	// Run all checks and merge their resulting actions together into the investigation result.
+	// Continue until all checks are run or a check signals the investigation should stop.
+	for _, c := range checks {
+		result, err := c(r)
+		if err != nil {
+			return investigationResult, err
+		}
+
+		investigationResult.Actions = append(investigationResult.Actions, result.actions...)
+
+		if result.stop {
+			return investigationResult, nil
+		}
+	}
+
+	investigationResult.Actions = append(
+		investigationResult.Actions,
+		executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name())...,
+	)
+
+	investigationResult.Actions = append(
+		investigationResult.Actions,
+		executor.Escalate("OCMAgentResponseFailureServiceLogsSRE investigation complete"),
+	)
+
+	return investigationResult, nil
+}
+
+func (i *Investigation) Name() string {
+	return "ocmagentresponsefailure"
+}
+
+func (i *Investigation) Description() string {
+	return "Investigates the OCMAgentResponseFailureServiceLogsSRE alert"
+}
+
+func (i *Investigation) IsExperimental() bool {
+	// TODO: Update to false when graduating to production.
+	return true
+}
+
+func (i *Investigation) AlertTitle() string {
+	return "OCMAgentResponseFailureServiceLogsSRE"
+}
+
+// checkUserBanStatus checks if the cluster owner is banned.
+// It returns a set of actions, and a boolean indicating whether the investigation should halt
+func checkUserBanStatus(r *investigation.Resources) (checkResult, error) {
+	userBannedErr := ocm.UserBannedError{}
+	err := r.OcmClient.CheckIfUserBanned(r.Cluster)
+	actions := []types.Action{}
+
+	switch {
+	case errors.As(err, &userBannedErr) && userBannedErr.Code == "export_control_compliance":
+		// User is banned due to Export Control Compliance; escalate to SRE
+		r.Notes.AppendWarning("%v", err)
+		actions = append(
+			actions,
+			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), r.Name)...,
+		)
+		actions = append(
+			actions,
+			executor.Escalate("Export Control Compliance ban detected, please refer to the SOP."),
+		)
+		return checkResult{actions: actions, stop: true}, nil
+	case errors.As(err, &userBannedErr):
+		// User is banned, but not due to Export Control Compliance; Send a SL
+
+		r.Notes.AppendWarning("%v", err)
+		actions = append(
+			actions,
+			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), r.Name)...,
+		)
+
+		// Uncomment once informing phase tests are concluded
+		/*
+			sl := ocm.NewOCMBannedUserServiceLog()
+			executor.NewServiceLogAction(sl.Severity, sl.Summary).
+				WithDescription(sl.Description).
+				WithServiceName(sl.ServiceName).
+				Build(),
+		*/
+
+		actions = append(
+			actions,
+			executor.Escalate("User is banned, please refer to the SOP."),
+		)
+		return checkResult{actions: actions, stop: true}, nil
+	case err != nil:
+		// Unhandled error; escalate to SRE
+		r.Notes.AppendWarning("encountered an issue when checking if the cluster owner is banned: %s\nPlease investigate.", err)
+		actions = append(
+			actions,
+			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), r.Name)...,
+		)
+		actions = append(
+			actions,
+			executor.Escalate("Failed to check if user is banned"),
+		)
+		return checkResult{actions: actions, stop: true}, nil
+	}
+
+	r.Notes.AppendSuccess("User is not banned.")
+
+	return checkResult{actions: actions, stop: false}, nil
+}
+
+// validateEgress checks the cluster can reach the required endpoints.
+// It returns a set of actions, and a boolean indicating whether the investigation should halt
+func validateEgress(r *investigation.Resources) (checkResult, error) {
+	actions := []types.Action{}
+	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
+	if err != nil {
+		logging.Errorf("Network verifier ran into an error: %s", err.Error())
+		r.Notes.AppendWarning("NetworkVerifier failed to run:\n %s", err.Error())
+		return checkResult{actions: actions, stop: false}, nil
+	}
+
+	switch verifierResult {
+	case networkverifier.Failure:
+		// Once the informing phase tests are over, this path will send out a SL as per SOP.
+		r.Notes.AppendWarning("Network verifier reported failure: %s", failureReason)
+		actions = append(
+			actions,
+			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), r.Name)...,
+		)
+		actions = append(
+			actions,
+			executor.Escalate("Egress network verifier failed. Please investigate."),
+		)
+		return checkResult{actions: actions, stop: true}, nil
+	case networkverifier.Success:
+		r.Notes.AppendSuccess("Network verifier passed")
+		logging.Info("Network verifier passed.")
+	}
+
+	return checkResult{actions: actions, stop: false}, nil
+}
+
+// validatePullSecret checks the cluster pull secret is valid.
+// It returns a set of actions, and a boolean indicating whether the investigation should halt
+func validatePullSecret(r *investigation.Resources) (checkResult, error) {
+	actions := []types.Action{}
+	user, err := r.OcmClient.GetCreatorFromCluster(r.Cluster)
+	if err != nil {
+		r.Notes.AppendWarning("Failed getting cluster creator from ocm: %s", err)
+		actions = append(
+			actions,
+			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), r.Name)...,
+		)
+		actions = append(
+			actions,
+			executor.Escalate("Failed to get cluster creator from OCM"),
+		)
+		return checkResult{actions: actions, stop: true}, nil
+	}
+
+	logging.Infof("User ID is: %v", user.ID())
+
+	// Pullsecret validation done via pullsecret package
+	ocmEmail := user.Email()
+	emailValidation := pullsecret.ValidateEmail(r.K8sClient, ocmEmail)
+
+	for _, warning := range emailValidation.Warnings {
+		r.Notes.AppendWarning("%s", warning)
+	}
+
+	if emailValidation.IsValid && len(emailValidation.Warnings) == 0 {
+		r.Notes.AppendSuccess("Pull Secret matches on cluster and in OCM. Please continue investigation.")
+	}
+
+	// Registry credentials validation
+	registryValidation, registryResults := pullsecret.ValidateRegistryCredentials(r.K8sClient, r.OcmClient.GetConnection(), user.ID(), ocmEmail)
+
+	// INFO: per-registry validation results at debug level for troubleshooting
+	for _, regResult := range registryResults {
+		if regResult.Error != nil {
+			logging.Debugf("Registry '%s': error=%v", regResult.Registry, regResult.Error)
+		} else {
+			logging.Debugf("Registry '%s': emailMatch=%v, tokenMatch=%v", regResult.Registry, regResult.EmailMatch, regResult.TokenMatch)
+		}
+	}
+
+	for _, warning := range registryValidation.Warnings {
+		r.Notes.AppendWarning("%s", warning)
+	}
+
+	return checkResult{actions: actions, stop: false}, nil
+}

--- a/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure_test.go
+++ b/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure_test.go
@@ -1,6 +1,7 @@
 package ocmagentresponsefailure
 
 import (
+	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -29,11 +30,12 @@ type testMocks struct {
 
 func Test_checkUserBanStatus(t *testing.T) {
 	tests := []struct {
-		name       string
-		want       investigation.InvestigationResult
-		wantErr    bool
-		cluster    func() *cmv1.Cluster
-		setupMocks func(*testMocks)
+		name                string
+		want                investigation.InvestigationResult
+		wantErr             bool
+		cluster             func() *cmv1.Cluster
+		setupMocks          func(*testMocks)
+		experimentalEnabled bool
 	}{
 		{
 			// this will eventually send out a Service Log
@@ -53,6 +55,26 @@ func Test_checkUserBanStatus(t *testing.T) {
 						Description: "Some reason",
 					})
 			},
+		},
+		{
+			name: "banned user experimental mode",
+			want: investigation.InvestigationResult{
+				Actions: []types.Action{
+					&executor.BackplaneReportAction{},
+					&executor.PagerDutyNoteAction{},
+					&executor.ServiceLogAction{},
+					&executor.EscalateIncidentAction{},
+				},
+			},
+			setupMocks: func(m *testMocks) {
+				m.ocmClient.EXPECT().
+					CheckIfUserBanned(m.cluster).
+					Return(ocm.UserBannedError{
+						Code:        "some_reason",
+						Description: "Some reason",
+					})
+			},
+			experimentalEnabled: true,
 		},
 		{
 			name: "export control compliance",
@@ -114,6 +136,10 @@ func Test_checkUserBanStatus(t *testing.T) {
 				PdClient:  m.pdClient,
 				AwsClient: m.awsClient,
 				Notes:     notewriter.New(tt.name, logging.RawLogger),
+			}
+
+			if tt.experimentalEnabled {
+				os.Setenv("CAD_EXPERIMENTAL_ENABLED", "true")
 			}
 
 			got, err := checkUserBanStatus(resources)

--- a/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure_test.go
+++ b/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure_test.go
@@ -1,0 +1,156 @@
+package ocmagentresponsefailure
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	awsmock "github.com/openshift/configuration-anomaly-detection/pkg/aws/mock"
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	ocmmock "github.com/openshift/configuration-anomaly-detection/pkg/ocm/mock"
+	pdmock "github.com/openshift/configuration-anomaly-detection/pkg/pagerduty/mock"
+	"github.com/openshift/configuration-anomaly-detection/pkg/types"
+	"go.uber.org/mock/gomock"
+)
+
+type testMocks struct {
+	ctrl      *gomock.Controller
+	ocmClient *ocmmock.MockClient
+	awsClient *awsmock.MockClient
+	pdClient  *pdmock.MockClient
+	cluster   *cmv1.Cluster
+}
+
+func Test_checkUserBanStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		want       investigation.InvestigationResult
+		wantErr    bool
+		cluster    func() *cmv1.Cluster
+		setupMocks func(*testMocks)
+	}{
+		{
+			// this will eventually send out a Service Log
+			name: "banned user",
+			want: investigation.InvestigationResult{
+				Actions: []types.Action{
+					&executor.BackplaneReportAction{},
+					&executor.PagerDutyNoteAction{},
+					&executor.EscalateIncidentAction{},
+				},
+			},
+			setupMocks: func(m *testMocks) {
+				m.ocmClient.EXPECT().
+					CheckIfUserBanned(m.cluster).
+					Return(ocm.UserBannedError{
+						Code:        "some_reason",
+						Description: "Some reason",
+					})
+			},
+		},
+		{
+			name: "export control compliance",
+			want: investigation.InvestigationResult{
+				Actions: []types.Action{
+					&executor.BackplaneReportAction{},
+					&executor.PagerDutyNoteAction{},
+					&executor.EscalateIncidentAction{},
+				},
+			},
+			setupMocks: func(m *testMocks) {
+				m.ocmClient.EXPECT().
+					CheckIfUserBanned(m.cluster).
+					Return(ocm.UserBannedError{
+						Code:        "export_control_compliance",
+						Description: "Export Control Compliance",
+					})
+			},
+		},
+		{
+			name: "user is not banned",
+			want: investigation.InvestigationResult{
+				Actions: []types.Action{},
+			},
+			setupMocks: func(m *testMocks) {
+				m.ocmClient.EXPECT().
+					CheckIfUserBanned(m.cluster).
+					Return(nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Create the mocks struct
+			m := &testMocks{
+				ctrl:      ctrl,
+				ocmClient: ocmmock.NewMockClient(ctrl),
+				pdClient:  pdmock.NewMockClient(ctrl),
+				awsClient: awsmock.NewMockClient(ctrl),
+				cluster:   newTestCluster(),
+			}
+
+			// Override cluster if test provides custom one
+			if tt.cluster != nil {
+				m.cluster = tt.cluster()
+			}
+
+			// Let test configure its specific mocks
+			tt.setupMocks(m)
+
+			// Build resources
+			resources := &investigation.Resources{
+				Cluster:   m.cluster,
+				OcmClient: m.ocmClient,
+				PdClient:  m.pdClient,
+				AwsClient: m.awsClient,
+				Notes:     notewriter.New(tt.name, logging.RawLogger),
+			}
+
+			got, err := checkUserBanStatus(resources)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wanted error = %v, got %v", tt.wantErr, err)
+			}
+
+			assertActionsEqual(t, got.actions, tt.want.Actions)
+		})
+	}
+}
+
+func newTestCluster() *cmv1.Cluster {
+	cluster, _ := cmv1.NewCluster().
+		ID("test-cluster").
+		InfraID("test-infra-id").
+		Build()
+	return cluster
+}
+
+// assertActionsEqual validates the number of expected vs. got actions is equal
+// as well as that their types match. Action fields are not validated to keep
+// this check simple and decoupled from any specific action type.
+func assertActionsEqual(t *testing.T, a1, a2 []types.Action) {
+	t.Helper()
+
+	if !slices.EqualFunc(a1, a2, func(a1, a2 types.Action) bool {
+		return reflect.TypeOf(a1) == reflect.TypeOf(a2)
+	}) {
+		fmtTypes := func(actions []types.Action) string {
+			s := make([]string, len(actions))
+			for i, a := range actions {
+				s[i] = reflect.TypeOf(a).String()
+			}
+			return "[" + strings.Join(s, ", ") + "]"
+		}
+		t.Errorf("action types mismatch:\n  %s\ndoes not equal\n  %s", fmtTypes(a1), fmtTypes(a2))
+	}
+}

--- a/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure_test.go
+++ b/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -138,9 +139,15 @@ func Test_checkUserBanStatus(t *testing.T) {
 				Notes:     notewriter.New(tt.name, logging.RawLogger),
 			}
 
-			if tt.experimentalEnabled {
-				os.Setenv("CAD_EXPERIMENTAL_ENABLED", "true")
+			if err := os.Setenv("CAD_EXPERIMENTAL_ENABLED", strconv.FormatBool(tt.experimentalEnabled)); err != nil {
+				t.Fatalf("set CAD_EXPERIMENTAL_ENABLED: %v", err)
 			}
+
+			t.Cleanup(func() {
+				if err := os.Unsetenv("CAD_EXPERIMENTAL_ENABLED"); err != nil {
+					t.Errorf("unset CAD_EXPERIMENTAL_ENABLED: %v", err)
+				}
+			})
 
 			got, err := checkUserBanStatus(resources)
 

--- a/pkg/investigations/ocmagentresponsefailure/testing/README.md
+++ b/pkg/investigations/ocmagentresponsefailure/testing/README.md
@@ -1,0 +1,122 @@
+# Testing the OCMAgentResponseFailureServiceLogsSRE investigation
+
+This document describes how to test the OCMAgentResponseFailureServiceLogsSRE investigation end-to-end in a local environment.
+
+## Overview
+
+This investigation:
+1. verifies if the cluster is classic ROSA (HCP is not supported)
+1. runs the network verifier
+1. checks if the cluster owner is banned
+1. validate the cluster pull secret
+
+> [!NOTE]
+>While unit tests use a mocked OCM client to test the user ban validation logic, for integration tests in staging I've tested by returning a hard-coded error.
+
+## Prerequisites
+
+### Environment Requirements
+- **Cluster**: ROSA classic cluster (HCP clusters are not supported)
+- **Access**: Cluster must be accessible via backplane/OCM
+- **Environment Variables**: Set up via `source test/set_stage_env.sh`
+- **Local Backplane API**: Start local backplane instance:
+  ```bash
+  OCM_BACKPLANE_REPO_PATH=<PATH/TO/BACKPLANE>/backplane-api ./test/launch_local_env.sh
+  ```
+
+### Build the Binary
+```bash
+make build
+```
+
+## Unit testing
+
+> [!NOTE]
+>Only part of the investigation is covered by unit tests: at the time of writing some checks reach out to the AWS API even when using mocked clients.
+
+To run unit tests:
+
+```
+$ make test
+```
+
+
+## Manual Testing
+
+### Step 1: Create or Identify a ROSA Classic Cluster
+
+You need an actual ROSA classic cluster. Note the cluster ID for the next steps.
+
+### Step 2: Generate Test Incident Payload
+
+Create a PagerDuty incident payload that triggers the `OCMAgentResponseFailureServiceLogsSRE` alert:
+
+```bash
+./test/generate_incident.sh OCMAgentResponseFailureServiceLogsSRE $CLUSTER_ID
+```
+
+This creates a `payload` file in the current directory and a PagerDuty incident which can be checked for CAD output.
+
+### Step 3: Set Up Environment
+
+```bash
+# Export environment variables from vault
+source test/set_stage_env.sh
+```
+
+### Step 4: Run the Investigation
+
+```bash
+BACKPLANE_URL=https://localhost:8443 \
+HTTP_PROXY=http://127.0.0.1:8888 \
+HTTPS_PROXY=http://127.0.0.1:8888 \
+BACKPLANE_PROXY=http://127.0.0.1:8888 \
+./bin/cadctl investigate --payload-path ./payload --log-level debug
+```
+
+### Step 5: Verify Results
+
+The investigation should:
+
+1. **Validate network egress** - Check logs for:
+   ```
+   Running Network Verifier with security group [...]
+   ```
+   i. if the network verifier reports a failure, the incident should be escalated:
+
+   ```
+   {"level":"info","timestamp":"2026-04-14T15:14:13+02:00","caller":"notewriter/notewriter.go:38","msg":"⚠️ Network verifier reported failure: https://observatorium-mst.api.openshift.com:443 (Failed to connect to observatorium-mst.api.openshift.com port 443: Connection timed out)\n","cluster_id":"","pipeline_name":""}
+   {"level":"info","timestamp":"2026-04-14T15:14:16+02:00","caller":"executor/actions.go:211","msg":"Escalating incident: Egress network verifier failed. Please investigate.","cluster_id":"","pipeline_name":""}
+   ```
+
+   ii. if the network verifier runs successfully, the next check is performed:
+
+   ```
+   {"level":"info","timestamp":"2026-04-14T16:17:41+02:00","caller":"logging/logging.go:42","msg":"Network verifier passed.","cluster_id":"","pipeline_name":""}
+   ```
+
+2. **Check if the cluster owner is banned in OCM** - Check logs for:
+
+   ```
+   {"level":"info","timestamp":"2026-04-14T16:17:42+02:00","caller":"notewriter/notewriter.go:38","msg":"✅ User is not banned.\n","cluster_id":"","pipeline_name":""}
+   ```
+    or:
+
+    ```
+    {"level":"info","timestamp":"2026-04-14T16:28:29+02:00","caller":"notewriter/notewriter.go:38","msg":"⚠️ user is banned (export_control_compliance): Export control compliance\n","cluster_id":"","pipeline_name":""}
+    ```
+
+    i. If the user is banned due to export control compliance, the investigation is stopped and the incident is escalated
+    ii. If the user is banned due for any other reason the incident is escalated, but a service log will be sent once the informing phase tests are over
+
+3. **Validate the pull secret validity**:
+
+    > [!NOTE]
+    >Until [ACM !5183](https://gitlab.cee.redhat.com/service/uhc-account-manager/-/merge_requests/5183) is rolled out this fails due to a lack of permissions for CAD's service account.
+
+5. **Post to PagerDuty and escalate for further investigation by SRE** - Verify a note was added to the incident with:
+
+   ```
+   🤖 CAD created a cluster report, access it with the following command:
+    osdctl cluster reports get --cluster-id <cluster_id> --report-id <report_id>
+   ```

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/mustgather"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/ocmagentresponsefailure"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/restartcontrolplane"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/upgradeconfigsyncfailureover4hr"
 )
@@ -28,6 +29,7 @@ var availableInvestigations = []investigation.Investigation{
 	&insightsoperatordown.Investigation{},
 	&upgradeconfigsyncfailureover4hr.Investigation{},
 	&machinehealthcheckunterminatedshortcircuitsre.Investigation{},
+	&ocmagentresponsefailure.Investigation{},
 	&restartcontrolplane.Investigation{},
 	&cannotretrieveupdatessre.Investigation{},
 	&mustgather.Investigation{},

--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
@@ -25,7 +25,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	logging.Infof("Checking if user is Banned.")
 	userBannedErr := ocm.UserBannedError{}
-	err = ocm.CheckIfUserBanned(r.OcmClient, r.Cluster)
+	err = r.OcmClient.CheckIfUserBanned(r.Cluster)
 
 	switch {
 	case errors.As(err, &userBannedErr) && userBannedErr.Code == "export_control_compliance":
@@ -85,8 +85,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	notes.AppendSuccess("User is not banned.")
 
-	user, err := ocm.GetCreatorFromCluster(r.OcmClient.GetConnection(), r.Cluster)
-	logging.Infof("User ID is: %v", user.ID())
+	user, err := r.OcmClient.GetCreatorFromCluster(r.Cluster)
 	if err != nil {
 		notes.AppendWarning("Failed getting cluster creator from ocm: %s", err)
 		result.Actions = append(
@@ -95,6 +94,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		)
 		return result, nil
 	}
+	logging.Infof("User ID is: %v", user.ID())
 
 	r, err = rb.WithK8sClient().Build()
 	if err != nil {

--- a/pkg/networkverifier/networkverifier.go
+++ b/pkg/networkverifier/networkverifier.go
@@ -31,6 +31,10 @@ const (
 
 // InitializeValidateEgressInput computes the input to pass to the network verifier tool
 func InitializeValidateEgressInput(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsClient aws.Client) (*verifier.ValidateEgressInput, error) {
+	if clusterDeployment == nil {
+		return nil, fmt.Errorf("nil clusterDeployment")
+	}
+
 	infraID := clusterDeployment.Spec.ClusterMetadata.InfraID
 	securityGroupID, err := awsClient.GetSecurityGroupID(infraID)
 	if err != nil {

--- a/pkg/ocm/mock/ocmmock.go
+++ b/pkg/ocm/mock/ocmmock.go
@@ -13,8 +13,9 @@ import (
 	reflect "reflect"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	v10 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
+	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	v10 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	v11 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	ocm "github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -44,7 +45,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AwsClassicJumpRoleCompatible mocks base method.
-func (m *MockClient) AwsClassicJumpRoleCompatible(cluster *v1.Cluster) (bool, error) {
+func (m *MockClient) AwsClassicJumpRoleCompatible(cluster *v10.Cluster) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AwsClassicJumpRoleCompatible", cluster)
 	ret0, _ := ret[0].(bool)
@@ -58,11 +59,25 @@ func (mr *MockClientMockRecorder) AwsClassicJumpRoleCompatible(cluster any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwsClassicJumpRoleCompatible", reflect.TypeOf((*MockClient)(nil).AwsClassicJumpRoleCompatible), cluster)
 }
 
+// CheckIfUserBanned mocks base method.
+func (m *MockClient) CheckIfUserBanned(cluster *v10.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckIfUserBanned", cluster)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckIfUserBanned indicates an expected call of CheckIfUserBanned.
+func (mr *MockClientMockRecorder) CheckIfUserBanned(cluster any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckIfUserBanned", reflect.TypeOf((*MockClient)(nil).CheckIfUserBanned), cluster)
+}
+
 // GetClusterHypershiftConfig mocks base method.
-func (m *MockClient) GetClusterHypershiftConfig(cluster *v1.Cluster) (*v1.HypershiftConfig, error) {
+func (m *MockClient) GetClusterHypershiftConfig(cluster *v10.Cluster) (*v10.HypershiftConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterHypershiftConfig", cluster)
-	ret0, _ := ret[0].(*v1.HypershiftConfig)
+	ret0, _ := ret[0].(*v10.HypershiftConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -74,10 +89,10 @@ func (mr *MockClientMockRecorder) GetClusterHypershiftConfig(cluster any) *gomoc
 }
 
 // GetClusterInfo mocks base method.
-func (m *MockClient) GetClusterInfo(identifier string) (*v1.Cluster, error) {
+func (m *MockClient) GetClusterInfo(identifier string) (*v10.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterInfo", identifier)
-	ret0, _ := ret[0].(*v1.Cluster)
+	ret0, _ := ret[0].(*v10.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -89,10 +104,10 @@ func (mr *MockClientMockRecorder) GetClusterInfo(identifier any) *gomock.Call {
 }
 
 // GetClusterMachinePools mocks base method.
-func (m *MockClient) GetClusterMachinePools(internalClusterID string) ([]*v1.MachinePool, error) {
+func (m *MockClient) GetClusterMachinePools(internalClusterID string) ([]*v10.MachinePool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterMachinePools", internalClusterID)
-	ret0, _ := ret[0].([]*v1.MachinePool)
+	ret0, _ := ret[0].([]*v10.MachinePool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -117,8 +132,23 @@ func (mr *MockClientMockRecorder) GetConnection() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnection", reflect.TypeOf((*MockClient)(nil).GetConnection))
 }
 
+// GetCreatorFromCluster mocks base method.
+func (m *MockClient) GetCreatorFromCluster(cluster *v10.Cluster) (*v1.Account, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCreatorFromCluster", cluster)
+	ret0, _ := ret[0].(*v1.Account)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCreatorFromCluster indicates an expected call of GetCreatorFromCluster.
+func (mr *MockClientMockRecorder) GetCreatorFromCluster(cluster any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCreatorFromCluster", reflect.TypeOf((*MockClient)(nil).GetCreatorFromCluster), cluster)
+}
+
 // GetDynatraceURL mocks base method.
-func (m *MockClient) GetDynatraceURL(cluster *v1.Cluster) (string, error) {
+func (m *MockClient) GetDynatraceURL(cluster *v10.Cluster) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDynatraceURL", cluster)
 	ret0, _ := ret[0].(string)
@@ -148,10 +178,10 @@ func (mr *MockClientMockRecorder) GetOrganizationID(clusterID any) *gomock.Call 
 }
 
 // GetServiceLog mocks base method.
-func (m *MockClient) GetServiceLog(cluster *v1.Cluster, filter string) (*v10.ClusterLogsUUIDListResponse, error) {
+func (m *MockClient) GetServiceLog(cluster *v10.Cluster, filter string) (*v11.ClusterLogsUUIDListResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceLog", cluster, filter)
-	ret0, _ := ret[0].(*v10.ClusterLogsUUIDListResponse)
+	ret0, _ := ret[0].(*v11.ClusterLogsUUIDListResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -178,7 +208,7 @@ func (mr *MockClientMockRecorder) GetSupportRoleARN(internalClusterID any) *gomo
 }
 
 // IsAccessProtected mocks base method.
-func (m *MockClient) IsAccessProtected(cluster *v1.Cluster) (bool, error) {
+func (m *MockClient) IsAccessProtected(cluster *v10.Cluster) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAccessProtected", cluster)
 	ret0, _ := ret[0].(bool)
@@ -208,7 +238,7 @@ func (mr *MockClientMockRecorder) IsManagingCluster(clusterID any) *gomock.Call 
 }
 
 // PostLimitedSupportReason mocks base method.
-func (m *MockClient) PostLimitedSupportReason(cluster *v1.Cluster, limitedSupportReason *ocm.LimitedSupportReason) error {
+func (m *MockClient) PostLimitedSupportReason(cluster *v10.Cluster, limitedSupportReason *ocm.LimitedSupportReason) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostLimitedSupportReason", cluster, limitedSupportReason)
 	ret0, _ := ret[0].(error)
@@ -222,7 +252,7 @@ func (mr *MockClientMockRecorder) PostLimitedSupportReason(cluster, limitedSuppo
 }
 
 // PostServiceLog mocks base method.
-func (m *MockClient) PostServiceLog(cluster *v1.Cluster, sl *ocm.ServiceLog) error {
+func (m *MockClient) PostServiceLog(cluster *v10.Cluster, sl *ocm.ServiceLog) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostServiceLog", cluster, sl)
 	ret0, _ := ret[0].(error)

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -56,6 +56,8 @@ type Client interface {
 	GetClusterInfo(identifier string) (*cmv1.Cluster, error)
 	IsManagingCluster(clusterID string) (bool, error)
 	GetDynatraceURL(cluster *cmv1.Cluster) (string, error)
+	CheckIfUserBanned(cluster *cmv1.Cluster) error
+	GetCreatorFromCluster(cluster *cmv1.Cluster) (*amv1.Account, error)
 }
 
 // SdkClient is the ocm client with which we can run the commands
@@ -337,8 +339,8 @@ func (c *SdkClient) GetClusterHypershiftConfig(cluster *cmv1.Cluster) (*cmv1.Hyp
 	return resp.Body(), nil
 }
 
-func CheckIfUserBanned(ocmClient Client, cluster *cmv1.Cluster) error {
-	user, err := GetCreatorFromCluster(ocmClient.GetConnection(), cluster)
+func (c *SdkClient) CheckIfUserBanned(cluster *cmv1.Cluster) error {
+	user, err := c.GetCreatorFromCluster(cluster)
 	if err != nil {
 		return fmt.Errorf("while checking if the cluster owner is banned: %w", err)
 	}
@@ -383,13 +385,13 @@ func (c *SdkClient) IsManagingCluster(clusterID string) (bool, error) {
 	return false, nil
 }
 
-func GetCreatorFromCluster(ocmConn *sdk.Connection, cluster *cmv1.Cluster) (*amv1.Account, error) {
+func (c *SdkClient) GetCreatorFromCluster(cluster *cmv1.Cluster) (*amv1.Account, error) {
 	logging.Debugf("Getting subscription from cluster: %s", cluster.ID())
 	cmv1Subscription, ok := cluster.GetSubscription()
 	if !ok {
 		return nil, fmt.Errorf("failed to get subscription from cluster: %s", cluster.ID())
 	}
-	subscriptionResponse, err := ocmConn.AccountsMgmt().V1().Subscriptions().Subscription(cmv1Subscription.ID()).Get().Send()
+	subscriptionResponse, err := c.conn.AccountsMgmt().V1().Subscriptions().Subscription(cmv1Subscription.ID()).Get().Send()
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +405,7 @@ func GetCreatorFromCluster(ocmConn *sdk.Connection, cluster *cmv1.Cluster) (*amv
 		return nil, fmt.Errorf("expecting status 'Active' found %v", status)
 	}
 
-	accountResponse, err := ocmConn.AccountsMgmt().V1().Accounts().Account(subscription.Creator().ID()).Get().Send()
+	accountResponse, err := c.conn.AccountsMgmt().V1().Accounts().Account(subscription.Creator().ID()).Get().Send()
 	if err != nil {
 		return nil, err
 	}

--- a/test/generate_incident.sh
+++ b/test/generate_incident.sh
@@ -14,6 +14,7 @@ declare -A alert_mapping=(
     ["UpgradeConfigSyncFailureOver4HrSRE"]="UpgradeConfigSyncFailureOver4HrSRE Critical (1)"
     ["etcdDatabaseQuotaLowSpace"]="etcdDatabaseQuotaLowSpace CRITICAL (1)"
     ["console-errorbudgetburn"]="console-errorbudgetburn Critical (1)"
+    ["OCMAgentResponseFailureServiceLogsSRE"]="OCMAgentResponseFailureServiceLogsSRE CRITICAL (1)"
 )
 
 # Function to print help message


### PR DESCRIPTION
### What type of PR is this?

New investigation

### What this PR does / Why we need it?

This PR addresses [SREP-1129](https://redhat.atlassian.net/browse/SREP-1129) by adding a new investigation for the [OCMAgentResponseFailureServiceLogsSRE](https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md) alert.

The investigation runs a few checks, then escalate to SRE for following up with the SOP:

1. Network verifier
2. OCM user ban status
3. Pull secret validation

### Special notes for your reviewer

This investigation does not cover 100% of the [SOP](https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md) and some checks are left to the SRE to perform:

- if a cluster is HCP the investigation escalates to SRE as ocm-agent runs on on the RHOBS cluster
- templating failures from the SOP are not checked
- ownership transfers are not checked

### Test Coverage

Only part of the investigation is covered by unit tests: at the time of writing some checks reach out to their respective APIs so can't be easily unit-tested with mocks:

- the network verifier calls out to AWS
- the pull secret check calls out to OCM

Instructions for local testing with a staging cluster are provided in testing/README.md. Additionally, the following tests have been performed locally, targeting a cluster in the staging environment:

- **happy path**: a report is saved and the incident is escalated to primary
- **blocked egress**:  tested by adding NACL rules to block egress traffic to RHOBS: a report is saved and the incident is escalated to primary.
- **banned OCM user**: tested by hard-coding the ban check result: a report is saved and the incident is escalated to primary. As per the investigation promotion guidelines, sending out the SL has been gated behind the experimental flag to temporarily avoid performing write actions.
- **invalid pull secret**:  tested by updating the pull secret for quay.io with an email that doesn't match what's in OCM: a report is saved and the incident is escalated to primary.


#### Test coverage checks
- [x] Added tests 
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR


[SREP-1129]: https://redhat.atlassian.net/browse/SREP-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new investigation for OCM Agent Response Failures (egress check, owner ban check, pull-secret validation) and a short-name for manual lookup.

* **Bug Fixes**
  * Prevented a nil-pointer issue in network egress validation.

* **Refactor**
  * Reworked OCM client call paths for creator/ban lookups and registered the new investigation.

* **Documentation**
  * Added investigation README and a local end-to-end testing guide.

* **Tests**
  * Added unit tests covering ban-check logic and related flows.

* **Chores**
  * Added component metadata and updated test incident mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->