### PR TITLE
make konflux build source images for e2e

### DIFF
--- a/.tekton/configuration-anomaly-detection-e2e-pull-request.yaml
+++ b/.tekton/configuration-anomaly-detection-e2e-pull-request.yaml
@@ -75,7 +75,7 @@ spec:
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/configuration-anomaly-detection-e2e-push.yaml
+++ b/.tekton/configuration-anomaly-detection-e2e-push.yaml
@@ -72,7 +72,7 @@ spec:
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string


### PR DESCRIPTION
### What type of PR is this?
builds fail without src images 

this is defined in konflux config but the initial pull request seems to ignore that setting, same PR was done for the other image https://github.com/openshift/configuration-anomaly-detection/pull/739

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
