### PR TITLE
Add etcd snapshot analysis by resource type

### DIFF
--- a/pkg/investigations/etcddatabasequotalowspace/analysis.go
+++ b/pkg/investigations/etcddatabasequotalowspace/analysis.go
@@ -33,6 +33,7 @@ type AnalysisResult struct {
 	TopNamespaces    []NamespaceSize
 	LargestResources []ResourceSize
 	EventSizesByNS   []NamespaceSize
+	TopResourceTypes []ResourceTypeSize
 }
 
 type NamespaceSize struct {
@@ -45,6 +46,11 @@ type ResourceSize struct {
 	Name         string
 	SizeMB       float64
 	ResourceType string
+}
+
+type ResourceTypeSize struct {
+	ResourceType string
+	SizeMB       float64
 }
 
 // createAnalysisJob creates a Kubernetes Job to analyze the etcd snapshot
@@ -236,6 +242,7 @@ func parseAnalysisOutput(output string) (*AnalysisResult, error) {
 		TopNamespaces:    make([]NamespaceSize, 0),
 		LargestResources: make([]ResourceSize, 0),
 		EventSizesByNS:   make([]NamespaceSize, 0),
+		TopResourceTypes: make([]ResourceTypeSize, 0),
 	}
 
 	lines := strings.Split(output, "\n")
@@ -267,6 +274,12 @@ func parseAnalysisOutput(output string) (*AnalysisResult, error) {
 			}
 			currentSection = 3
 			sectionLines = append(sectionLines[:0], line)
+		case "resourceType,total_size_megabytes":
+			if len(sectionLines) > 0 && currentSection > 0 {
+				processSection(result, currentSection, strings.Join(sectionLines, "\n"))
+			}
+			currentSection = 4
+			sectionLines = append(sectionLines[:0], line)
 		default:
 			sectionLines = append(sectionLines, line)
 		}
@@ -288,6 +301,8 @@ func processSection(result *AnalysisResult, sectionType int, csvData string) {
 		result.LargestResources = parseResourceSizes(csvData)
 	case 3:
 		result.EventSizesByNS = parseNamespaceSizes(csvData)
+	case 4:
+		result.TopResourceTypes = parseResourceTypeSizes(csvData)
 	}
 }
 
@@ -375,6 +390,47 @@ func parseResourceSizes(csvData string) []ResourceSize {
 	return results
 }
 
+// parseResourceTypeSizes parses CSV with resourceType,total_size_megabytes format
+func parseResourceTypeSizes(csvData string) []ResourceTypeSize {
+	results := make([]ResourceTypeSize, 0)
+
+	reader := csv.NewReader(strings.NewReader(csvData))
+
+	_, err := reader.Read()
+	if err != nil {
+		logging.Warnf("failed to read CSV header: %v", err)
+		return results
+	}
+
+	for {
+		record, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			logging.Warnf("failed to read CSV record: %v", err)
+			continue
+		}
+
+		if len(record) < 2 {
+			continue
+		}
+
+		sizeMB, err := strconv.ParseFloat(record[1], 64)
+		if err != nil {
+			logging.Warnf("failed to parse size: %v", err)
+			continue
+		}
+
+		results = append(results, ResourceTypeSize{
+			ResourceType: record[0],
+			SizeMB:       sizeMB,
+		})
+	}
+
+	return results
+}
+
 // formatAnalysisResults formats the analysis results into human-readable text
 func formatAnalysisResults(result *AnalysisResult) string {
 	var builder strings.Builder
@@ -406,6 +462,15 @@ func formatAnalysisResults(result *AnalysisResult) string {
 		builder.WriteString("================================\n")
 		for i, ns := range result.EventSizesByNS {
 			builder.WriteString(fmt.Sprintf("%d. %s: %.2f MB\n", i+1, ns.Namespace, ns.SizeMB))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(result.TopResourceTypes) > 0 {
+		builder.WriteString("Top Space Consumers by Resource Type:\n")
+		builder.WriteString("================================\n")
+		for i, rt := range result.TopResourceTypes {
+			builder.WriteString(fmt.Sprintf("%d. %s: %.2f MB\n", i+1, rt.ResourceType, rt.SizeMB))
 		}
 		builder.WriteString("\n")
 	}

--- a/pkg/investigations/etcddatabasequotalowspace/analysis_test.go
+++ b/pkg/investigations/etcddatabasequotalowspace/analysis_test.go
@@ -49,6 +49,23 @@ default,app-config,8.75,configmap`
 	assert.Equal(t, "configmap", result[2].ResourceType)
 }
 
+func TestParseResourceTypeSizes(t *testing.T) {
+	csvData := `resourceType,total_size_megabytes
+configmaps,10.86
+secrets,8.22
+pods,3.62`
+
+	result := parseResourceTypeSizes(csvData)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, "configmaps", result[0].ResourceType)
+	assert.Equal(t, 10.86, result[0].SizeMB)
+	assert.Equal(t, "secrets", result[1].ResourceType)
+	assert.Equal(t, 8.22, result[1].SizeMB)
+	assert.Equal(t, "pods", result[2].ResourceType)
+	assert.Equal(t, 3.62, result[2].SizeMB)
+}
+
 func TestParseAnalysisOutput(t *testing.T) {
 	output := `namespace,total_size_megabytes
 openshift-monitoring,45.23
@@ -58,7 +75,10 @@ openshift-monitoring,prometheus-config,15.23,configmap
 kube-system,cluster-info,10.50,secret
 namespace,total_event_size_megabytes
 openshift-monitoring,5.00
-default,2.50`
+default,2.50
+resourceType,total_size_megabytes
+configmaps,10.86
+secrets,8.22`
 
 	result, err := parseAnalysisOutput(output)
 
@@ -76,6 +96,12 @@ default,2.50`
 	assert.Len(t, result.EventSizesByNS, 2)
 	assert.Equal(t, "openshift-monitoring", result.EventSizesByNS[0].Namespace)
 	assert.Equal(t, 5.00, result.EventSizesByNS[0].SizeMB)
+
+	assert.Len(t, result.TopResourceTypes, 2)
+	assert.Equal(t, "configmaps", result.TopResourceTypes[0].ResourceType)
+	assert.Equal(t, 10.86, result.TopResourceTypes[0].SizeMB)
+	assert.Equal(t, "secrets", result.TopResourceTypes[1].ResourceType)
+	assert.Equal(t, 8.22, result.TopResourceTypes[1].SizeMB)
 }
 
 func TestFormatAnalysisResults(t *testing.T) {
@@ -92,6 +118,10 @@ func TestFormatAnalysisResults(t *testing.T) {
 			{Namespace: "openshift-monitoring", SizeMB: 5.00},
 			{Namespace: "default", SizeMB: 2.50},
 		},
+		TopResourceTypes: []ResourceTypeSize{
+			{ResourceType: "configmaps", SizeMB: 10.86},
+			{ResourceType: "secrets", SizeMB: 8.22},
+		},
 	}
 
 	formatted := formatAnalysisResults(result)
@@ -105,4 +135,7 @@ func TestFormatAnalysisResults(t *testing.T) {
 	assert.Contains(t, formatted, "cluster-info: 10.50 MB (secret)")
 	assert.Contains(t, formatted, "Event Storage by Namespace")
 	assert.Contains(t, formatted, "openshift-monitoring: 5.00 MB")
+	assert.Contains(t, formatted, "Top Space Consumers by Resource Type")
+	assert.Contains(t, formatted, "configmaps: 10.86 MB")
+	assert.Contains(t, formatted, "secrets: 8.22 MB")
 }


### PR DESCRIPTION
## Summary
- Add parsing and display of a new octosql query that breaks down etcd space consumption by resource type (configmaps, secrets, pods, etc.)
- New `ResourceTypeSize` struct and `TopResourceTypes` field in `AnalysisResult`
- Detects the `resourceType,total_size_megabytes` CSV header and renders a "Top Space Consumers by Resource Type" section

## Test plan
- [x] Unit tests pass for `parseResourceTypeSizes`, `parseAnalysisOutput`, and `formatAnalysisResults`
- [ ] Verify end-to-end with a real etcd snapshot producing the new query output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced etcd database quota analysis to identify and display top space consumers grouped by resource type.

* **Tests**
  * Added comprehensive tests for resource type parsing and space consumption analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->