### PR TITLE
Escalate to primary if cluster owner is banned

### DIFF
--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
@@ -61,6 +61,12 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 				WithServiceName(sl.ServiceName).
 				Build(),
 		)
+
+		result.Actions = append(
+			result.Actions,
+			executor.Escalate("Banned OCM user, please open a proactive ticket."),
+		)
+
 		return result, nil
 	case err != nil:
 		// Unhandled error; escalate to SRE


### PR DESCRIPTION
### What type of PR is this?

Minor change

### What this PR does / Why we need it?

As per our [SOP](https://github.com/openshift/ops-sop/blob/master/v4/alerts/UpgradeConfigSyncFailureOver4HrSRE.md#try-this-first), a proactive case should be opened if a user is banned regardless of reason; This PR updates the generic banned user path to escalate to SRE to do that. 

### Special notes for your reviewer

### Test Coverage

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [] This PR may not need unit tests

### Pre-checks (if applicable)
- [] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced investigation workflow to automatically escalate banned user cases (excluding export compliance instances) by creating proactive support tickets for faster resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->