### PR TITLE
renovate should not update major versions for indirect dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,15 @@
       "description": "Go module major updates - require manual review",
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["major"],
+      "matchDepTypes": ["!indirect"],
       "addLabels": ["area/dependency", "ok-to-test"]
+    },
+    {
+      "description": "Disable major updates for indirect Go dependencies - they update when their parent dependency updates",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / Why we need it?
breaking changes in indirect deps need to be handled by the direct dependency first 
see https://github.com/openshift/configuration-anomaly-detection/pull/789

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to refine how Go dependency updates are processed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->