### PR TITLE
SREP-3858: Reimplement cluster-health-check managed script as a CAD action

### DIFF
--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -26,6 +26,7 @@ var shortNameToInvestigation = map[string]string{
 	"restart-controlplane":     "restartcontrolplane",
 	"upgrade-config":           "upgradeconfigsyncfailureover4hr",
 	"describe-nodes":           "describenodes",
+	"cluster-health-check":     "clusterhealthcheck",
 }
 
 type ManualController struct {

--- a/pkg/investigations/clusterhealthcheck/README.md
+++ b/pkg/investigations/clusterhealthcheck/README.md
@@ -1,0 +1,26 @@
+# clusterhealthcheck Investigation
+
+Runs comprehensive health checks against a cluster, replicating the functionality of the [managed-scripts health/cluster-health-check](https://github.com/openshift/managed-scripts/tree/main/scripts/health/cluster-health-check).
+
+## Checks
+
+- **Cluster Operators** — reports degraded, unavailable, or progressing operators.
+- **API Server Health** — checks `/healthz`, `/livez`, `/readyz` endpoints and per-pod readiness in `openshift-apiserver` and `openshift-kube-apiserver`.
+- **ETCD Status** — execs `etcdctl endpoint health --cluster` in an etcd pod to verify cluster health via a linearizable read. Skipped on HCP.
+- **MachineConfigPools** — reports degraded or updating MCPs. Skipped on HCP.
+- **Pending CSRs** — lists pending certificate signing requests.
+- **Node Status** — reports not-ready, unschedulable, or condition-flagged nodes and taints.
+- **Capacity** — reports per-node CPU/memory pre-allocation and live utilization via the metrics API.
+- **Firing Alerts** — queries Alertmanager (via pod exec) for active firing alerts.
+- **Cluster Version** — reports current version, update conditions, and EOL status by querying the OpenShift upgrade graph API.
+- **Failing Pods** — reports failed, crash-looping, or high-restart pods.
+- **Restrictive PDBs** — reports PodDisruptionBudgets blocking voluntary disruptions (`MaxUnavailable=0`, `MaxUnavailable=0%`, `MinAvailable=100%`, or `MinAvailable >= ExpectedPods`).
+- **Events** — reports non-normal cluster events.
+
+## Deviations from the managed-script
+
+This implementation closely follows the original but has a few notable differences:
+
+- **ETCD**: Uses `etcdctl endpoint health --cluster` (linearizable/consensus-verified) instead of curling the `etcd-readyz` sidecar (serializable/local-only). Stronger check, but reports at the cluster level rather than per-pod.
+- **Alerts**: Uses pod exec + Alertmanager v2 API instead of route + OAuth + v1 API. Same data, different access path.
+- **PDB**: Checks more conditions than the original (also covers `MinAvailable` and gates on `DisruptionsAllowed`).

--- a/pkg/investigations/clusterhealthcheck/clusterhealthcheck.go
+++ b/pkg/investigations/clusterhealthcheck/clusterhealthcheck.go
@@ -1,0 +1,1168 @@
+// Package clusterhealthcheck implements a CAD investigation that runs
+// comprehensive health checks against an OpenShift cluster, replicating the
+// functionality of the managed-scripts health/cluster-health-check action.
+package clusterhealthcheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/types"
+
+	certsv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type alertsFetcher interface {
+	fetchFiringAlerts(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config) ([]firingAlert, error)
+}
+
+type etcdHealthChecker interface {
+	checkEtcdHealth(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config, namespace string) (string, error)
+}
+
+type apiHealthChecker interface {
+	checkHealth(ctx context.Context, restConfig *rest.Config) (apiHealthResult, error)
+}
+
+type eolChecker interface {
+	checkEOL(ctx context.Context, channel string, currentMinor int) (latestMinor int, err error)
+}
+
+type apiHealthResult struct {
+	healthz string
+	livez   string
+	readyz  string
+}
+
+type firingAlert struct {
+	Name     string
+	Severity string
+	State    string
+	Summary  string
+}
+
+type Investigation struct {
+	alertsFetcher    alertsFetcher
+	etcdChecker      etcdHealthChecker
+	apiHealthChecker apiHealthChecker
+	eolChecker       eolChecker
+}
+
+func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
+	ctx := context.Background()
+	result := investigation.InvestigationResult{}
+
+	r, err := rb.WithCluster().WithK8sClient().Build()
+	if err != nil {
+		if msg, ok := investigation.ClusterAccessErrorMessage(err); ok {
+			logging.Warnf("Cluster access error for cluster-health-check: %v", err)
+			result.Actions = []types.Action{
+				executor.Note(msg),
+			}
+			return result, nil
+		}
+		return result, investigation.WrapInfrastructure(err, "failed to build resources for cluster-health-check")
+	}
+
+	notes := notewriter.New(i.Name(), logging.RawLogger)
+
+	if r.IsHCP {
+		notes.AppendWarning("This is an HCP cluster - some checks may differ (control plane runs on management cluster)")
+	}
+
+	// run all 12 health checks, collecting results.
+	i.checkClusterOperators(ctx, r.K8sClient, notes)
+	i.checkAPIServerHealth(ctx, r, notes)
+	i.checkEtcdStatus(ctx, r, notes)
+	i.checkMachineConfigPools(ctx, r.K8sClient, r.IsHCP, notes)
+	i.checkPendingCSRs(ctx, r.K8sClient, notes)
+	i.checkNodeStatus(ctx, r.K8sClient, notes)
+	i.checkCapacity(ctx, r, notes)
+	i.checkFiringAlerts(ctx, r, notes)
+	i.checkClusterVersion(ctx, r.K8sClient, notes)
+	i.checkFailingPods(ctx, r.K8sClient, notes)
+	i.checkRestrictivePDBs(ctx, r.K8sClient, notes)
+	i.checkNonNormalEvents(ctx, r.K8sClient, notes)
+
+	result.Actions = executor.NoteAndReportFrom(notes, r.Cluster.ID(), i.Name())
+	return result, nil
+}
+
+// checkClusterOperators lists all ClusterOperators and reports any that are degraded, unavailable, or progressing.
+func (i *Investigation) checkClusterOperators(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	coList := &configv1.ClusterOperatorList{}
+	if err := k8sClient.List(ctx, coList); err != nil {
+		notes.AppendWarning("Cluster Operators: failed to list - %v", err)
+		return
+	}
+
+	if len(coList.Items) == 0 {
+		notes.AppendWarning("Cluster Operators: none found")
+		return
+	}
+
+	var degraded, unavailable, progressing []string
+
+	for _, co := range coList.Items {
+		for _, cond := range co.Status.Conditions {
+			switch {
+			case cond.Type == configv1.OperatorDegraded && cond.Status == configv1.ConditionTrue:
+				degraded = append(degraded, fmt.Sprintf("%s (reason: %s)", co.Name, cond.Reason))
+			case cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionFalse:
+				unavailable = append(unavailable, fmt.Sprintf("%s (reason: %s)", co.Name, cond.Reason))
+			case cond.Type == configv1.OperatorProgressing && cond.Status == configv1.ConditionTrue:
+				progressing = append(progressing, fmt.Sprintf("%s (reason: %s)", co.Name, cond.Reason))
+			}
+		}
+	}
+
+	if len(degraded) == 0 && len(unavailable) == 0 && len(progressing) == 0 {
+		notes.AppendSuccess("Cluster Operators: all %d operators are healthy", len(coList.Items))
+	} else {
+		if len(unavailable) > 0 {
+			notes.AppendWarning("Cluster Operators: %d unavailable - %s", len(unavailable), strings.Join(unavailable, ", "))
+		}
+		if len(degraded) > 0 {
+			notes.AppendWarning("Cluster Operators: %d degraded - %s", len(degraded), strings.Join(degraded, ", "))
+		}
+		if len(progressing) > 0 {
+			notes.AppendWarning("Cluster Operators: %d progressing - %s", len(progressing), strings.Join(progressing, ", "))
+		}
+	}
+}
+
+// checkAPIServerHealth queries the API server /healthz, /livez, and /readyz endpoints,
+// and checks per-pod readiness for both openshift-apiserver and openshift-kube-apiserver.
+func (i *Investigation) checkAPIServerHealth(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
+	restConfig, err := getRestConfig(r)
+	if err != nil {
+		notes.AppendWarning("API Server Health: unable to get REST config - %v", err)
+		return
+	}
+
+	checker := i.apiHealthChecker
+	if checker == nil {
+		checker = &defaultAPIHealthChecker{}
+	}
+
+	healthResult, err := checker.checkHealth(ctx, restConfig)
+	if err != nil {
+		notes.AppendWarning("API Server Health: check failed - %v", err)
+		return
+	}
+
+	allOk := healthResult.healthz == "ok" && healthResult.livez == "ok" && healthResult.readyz == "ok"
+	if allOk {
+		notes.AppendSuccess("API Server Health: all endpoints healthy (healthz=ok, livez=ok, readyz=ok)")
+	} else {
+		notes.AppendWarning("API Server Health: healthz=%s, livez=%s, readyz=%s", healthResult.healthz, healthResult.livez, healthResult.readyz)
+	}
+
+	i.checkAPIServerPods(ctx, r.K8sClient, r.IsHCP, notes)
+}
+
+func (i *Investigation) checkAPIServerPods(ctx context.Context, k8sClient k8sclient.Client, isHCP bool, notes *notewriter.NoteWriter) {
+	if isHCP {
+		notes.AppendWarning("API Server Pods: skipped - control plane runs on the management cluster for HCP clusters")
+		return
+	}
+	type apiServerCheck struct {
+		namespace string
+		label     string
+		name      string
+	}
+
+	checks := []apiServerCheck{
+		{namespace: "openshift-apiserver", label: "app=openshift-apiserver-a", name: "OpenShift API Server"},
+		{namespace: "openshift-kube-apiserver", label: "app=openshift-kube-apiserver", name: "Kube API Server"},
+	}
+
+	for _, check := range checks {
+		podList := &corev1.PodList{}
+		if err := k8sClient.List(ctx, podList, client.InNamespace(check.namespace), client.MatchingLabels(parseLabelSelector(check.label))); err != nil {
+			notes.AppendWarning("%s Pods: failed to list - %v", check.name, err)
+			continue
+		}
+
+		if len(podList.Items) == 0 {
+			notes.AppendWarning("%s Pods: no pods found in %s", check.name, check.namespace)
+			continue
+		}
+
+		var notReady []string
+		for _, pod := range podList.Items {
+			ready := false
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					ready = true
+					break
+				}
+			}
+			if !ready {
+				reason := string(pod.Status.Phase)
+				for _, cond := range pod.Status.Conditions {
+					if cond.Type == corev1.PodReady && cond.Reason != "" {
+						reason = cond.Reason
+						break
+					}
+				}
+				notReady = append(notReady, fmt.Sprintf("%s (%s)", pod.Name, reason))
+			}
+		}
+
+		if len(notReady) == 0 {
+			notes.AppendSuccess("%s Pods: all %d pods are Ready", check.name, len(podList.Items))
+		} else {
+			notes.AppendWarning("%s Pods: %d/%d not ready - %s", check.name, len(notReady), len(podList.Items), strings.Join(notReady, ", "))
+		}
+	}
+}
+
+// parseLabelSelector converts a "key=value" string to a map for client.MatchingLabels.
+func parseLabelSelector(selector string) map[string]string {
+	labels := map[string]string{}
+	parts := strings.SplitN(selector, "=", 2)
+	if len(parts) == 2 {
+		labels[parts[0]] = parts[1]
+	}
+	return labels
+}
+
+type defaultAPIHealthChecker struct{}
+
+func (d *defaultAPIHealthChecker) checkHealth(ctx context.Context, restConfig *rest.Config) (apiHealthResult, error) {
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return apiHealthResult{}, fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	result := apiHealthResult{}
+
+	body, err := clientset.Discovery().RESTClient().Get().AbsPath("/healthz").DoRaw(ctx)
+	if err != nil {
+		result.healthz = fmt.Sprintf("error: %v", err)
+	} else {
+		result.healthz = string(body)
+	}
+
+	body, err = clientset.Discovery().RESTClient().Get().AbsPath("/livez").DoRaw(ctx)
+	if err != nil {
+		result.livez = fmt.Sprintf("error: %v", err)
+	} else {
+		result.livez = string(body)
+	}
+
+	body, err = clientset.Discovery().RESTClient().Get().AbsPath("/readyz").DoRaw(ctx)
+	if err != nil {
+		result.readyz = fmt.Sprintf("error: %v", err)
+	} else {
+		result.readyz = string(body)
+	}
+
+	return result, nil
+}
+
+// checkEtcdStatus execs etcdctl in an etcd pod to verify cluster health. Skipped on HCP clusters.
+func (i *Investigation) checkEtcdStatus(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
+	if r.IsHCP {
+		notes.AppendWarning("ETCD Status: skipped - etcd runs on the management cluster for HCP clusters")
+		return
+	}
+
+	checker := i.etcdChecker
+	if checker == nil {
+		checker = &defaultEtcdHealthChecker{}
+	}
+
+	restConfig, err := getRestConfig(r)
+	if err != nil {
+		notes.AppendWarning("ETCD Status: unable to get REST config - %v", err)
+		return
+	}
+
+	output, err := checker.checkEtcdHealth(ctx, r.K8sClient, restConfig, "openshift-etcd")
+	if err != nil {
+		if output != "" {
+			notes.AppendWarning("ETCD Status:\n%s", output)
+		} else {
+			notes.AppendWarning("ETCD Status: check failed - %v", err)
+		}
+		return
+	}
+
+	notes.AppendSuccess("ETCD Status:\n%s", output)
+}
+
+type defaultEtcdHealthChecker struct{}
+
+func (d *defaultEtcdHealthChecker) checkEtcdHealth(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config, namespace string) (string, error) {
+	podList := &corev1.PodList{}
+	err := k8sClient.List(ctx, podList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{"app": "etcd"},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to list etcd pods: %w", err)
+	}
+
+	if len(podList.Items) == 0 {
+		err = k8sClient.List(ctx, podList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{"k8s-app": "etcd"},
+		)
+		if err != nil {
+			return "", fmt.Errorf("failed to list etcd pods: %w", err)
+		}
+	}
+
+	if len(podList.Items) == 0 {
+		return "", fmt.Errorf("no etcd pods found in namespace %s", namespace)
+	}
+
+	var etcdPod *corev1.Pod
+	for idx := range podList.Items {
+		if podList.Items[idx].Status.Phase == corev1.PodRunning {
+			etcdPod = &podList.Items[idx]
+			break
+		}
+	}
+
+	if etcdPod == nil {
+		return "", fmt.Errorf("no running etcd pods found in namespace %s", namespace)
+	}
+
+	containerName := "etcd"
+	for _, c := range etcdPod.Spec.Containers {
+		if c.Name == "etcdctl" || c.Name == "etcd" {
+			containerName = c.Name
+			break
+		}
+	}
+
+	output, err := k8sclient.ExecInPod(ctx, restConfig, etcdPod, containerName, []string{
+		"etcdctl", "endpoint", "health", "--cluster",
+	})
+	if err != nil {
+		return strings.TrimSpace(output), fmt.Errorf("failed to exec etcdctl health check: %w", err)
+	}
+
+	return strings.TrimSpace(output), nil
+}
+
+// checkMachineConfigPools lists MCPs and reports any that are degraded or updating. Skipped on HCP clusters.
+func (i *Investigation) checkMachineConfigPools(ctx context.Context, k8sClient k8sclient.Client, isHCP bool, notes *notewriter.NoteWriter) {
+	if isHCP {
+		notes.AppendWarning("MachineConfigPools: skipped - MCPs are not used on HCP clusters")
+		return
+	}
+
+	mcpList := &mcfgv1.MachineConfigPoolList{}
+	if err := k8sClient.List(ctx, mcpList); err != nil {
+		notes.AppendWarning("MachineConfigPools: failed to list - %v", err)
+		return
+	}
+
+	if len(mcpList.Items) == 0 {
+		notes.AppendWarning("MachineConfigPools: none found")
+		return
+	}
+
+	var degraded, updating []string
+
+	for _, mcp := range mcpList.Items {
+		for _, cond := range mcp.Status.Conditions {
+			switch {
+			case cond.Type == mcfgv1.MachineConfigPoolDegraded && cond.Status == corev1.ConditionTrue:
+				degraded = append(degraded, fmt.Sprintf("%s (reason: %s, message: %s)", mcp.Name, cond.Reason, cond.Message))
+			case cond.Type == mcfgv1.MachineConfigPoolUpdating && cond.Status == corev1.ConditionTrue:
+				updating = append(updating, fmt.Sprintf("%s (%d/%d updated)", mcp.Name, mcp.Status.UpdatedMachineCount, mcp.Status.MachineCount))
+			}
+		}
+	}
+
+	if len(degraded) == 0 && len(updating) == 0 {
+		notes.AppendSuccess("MachineConfigPools: all %d pools are healthy", len(mcpList.Items))
+	} else {
+		if len(degraded) > 0 {
+			notes.AppendWarning("MachineConfigPools: %d degraded - %s", len(degraded), strings.Join(degraded, "; "))
+		}
+		if len(updating) > 0 {
+			notes.AppendWarning("MachineConfigPools: %d updating - %s", len(updating), strings.Join(updating, "; "))
+		}
+	}
+}
+
+// checkPendingCSRs lists CertificateSigningRequests and reports any that are neither approved nor denied.
+func (i *Investigation) checkPendingCSRs(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	csrList := &certsv1.CertificateSigningRequestList{}
+	if err := k8sClient.List(ctx, csrList); err != nil {
+		notes.AppendWarning("Pending CSRs: failed to list - %v", err)
+		return
+	}
+
+	var pending []string
+	for _, csr := range csrList.Items {
+		approved := false
+		denied := false
+		for _, cond := range csr.Status.Conditions {
+			if cond.Type == certsv1.CertificateApproved {
+				approved = true
+			}
+			if cond.Type == certsv1.CertificateDenied {
+				denied = true
+			}
+		}
+		if !approved && !denied {
+			age := time.Since(csr.CreationTimestamp.Time).Truncate(time.Second)
+			pending = append(pending, fmt.Sprintf("%s (requester: %s, age: %s)", csr.Name, csr.Spec.Username, age))
+		}
+	}
+
+	if len(pending) == 0 {
+		notes.AppendSuccess("Pending CSRs: none")
+	} else {
+		notes.AppendWarning("Pending CSRs: %d pending - %s", len(pending), strings.Join(pending, "; "))
+	}
+}
+
+// checkNodeStatus reports nodes that are not ready, unschedulable, under pressure, or tainted.
+func (i *Investigation) checkNodeStatus(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	nodeList := &corev1.NodeList{}
+	if err := k8sClient.List(ctx, nodeList); err != nil {
+		notes.AppendWarning("Nodes: failed to list - %v", err)
+		return
+	}
+
+	if len(nodeList.Items) == 0 {
+		notes.AppendWarning("Nodes: none found")
+		return
+	}
+
+	var notReady, schedulingDisabled, tainted []string
+	var conditionIssues []string
+
+	for _, node := range nodeList.Items {
+		for _, cond := range node.Status.Conditions {
+			switch cond.Type {
+			case corev1.NodeReady:
+				if cond.Status != corev1.ConditionTrue {
+					notReady = append(notReady, fmt.Sprintf("%s (status: %s, reason: %s)", node.Name, cond.Status, cond.Reason))
+				}
+			case corev1.NodeMemoryPressure:
+				if cond.Status == corev1.ConditionTrue {
+					conditionIssues = append(conditionIssues, fmt.Sprintf("%s: MemoryPressure", node.Name))
+				}
+			case corev1.NodeDiskPressure:
+				if cond.Status == corev1.ConditionTrue {
+					conditionIssues = append(conditionIssues, fmt.Sprintf("%s: DiskPressure", node.Name))
+				}
+			case corev1.NodePIDPressure:
+				if cond.Status == corev1.ConditionTrue {
+					conditionIssues = append(conditionIssues, fmt.Sprintf("%s: PIDPressure", node.Name))
+				}
+			}
+		}
+
+		if node.Spec.Unschedulable {
+			schedulingDisabled = append(schedulingDisabled, node.Name)
+		}
+
+		for _, taint := range node.Spec.Taints {
+			tainted = append(tainted, fmt.Sprintf("%s: %s: %s", node.Name, taint.Key, taint.Effect))
+		}
+	}
+
+	if len(notReady) == 0 && len(schedulingDisabled) == 0 && len(conditionIssues) == 0 {
+		notes.AppendSuccess("Nodes: all %d nodes are Ready and healthy", len(nodeList.Items))
+	} else {
+		if len(notReady) > 0 {
+			notes.AppendWarning("Nodes: %d not ready - %s", len(notReady), strings.Join(notReady, "; "))
+		}
+		if len(schedulingDisabled) > 0 {
+			notes.AppendWarning("Nodes: %d scheduling disabled - %s", len(schedulingDisabled), strings.Join(schedulingDisabled, ", "))
+		}
+		if len(conditionIssues) > 0 {
+			notes.AppendWarning("Node Conditions: %d issue(s) - %s", len(conditionIssues), strings.Join(conditionIssues, "; "))
+		}
+	}
+
+	if len(tainted) > 0 {
+		notes.AppendWarning("Node Taints: %d taint(s) found:\n  %s", len(tainted), strings.Join(tainted, "\n  "))
+	}
+}
+
+// checkCapacity reports per-node resource pre-allocation and current utilization via the metrics API.
+func (i *Investigation) checkCapacity(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
+	nodeList := &corev1.NodeList{}
+	if err := r.K8sClient.List(ctx, nodeList); err != nil {
+		notes.AppendWarning("Capacity: failed to list nodes - %v", err)
+		return
+	}
+
+	if len(nodeList.Items) == 0 {
+		notes.AppendWarning("Capacity: no nodes found")
+		return
+	}
+
+	const capacityThreshold = 80
+
+	nodeCapacity := make(map[string]corev1.ResourceList, len(nodeList.Items))
+	perNode := make([]string, 0, len(nodeList.Items))
+	var overThreshold []string
+
+	for _, node := range nodeList.Items {
+		cpuCap := node.Status.Capacity[corev1.ResourceCPU]
+		cpuAlloc := node.Status.Allocatable[corev1.ResourceCPU]
+		memCap := node.Status.Capacity[corev1.ResourceMemory]
+		memAlloc := node.Status.Allocatable[corev1.ResourceMemory]
+
+		nodeCapacity[node.Name] = node.Status.Capacity
+
+		// calculate pre-allocation percentage (reserved = capacity - allocatable)
+		cpuPct := 0
+		if cpuCap.MilliValue() > 0 {
+			cpuPct = int(math.Round(float64(cpuCap.MilliValue()-cpuAlloc.MilliValue()) * 100 / float64(cpuCap.MilliValue())))
+		}
+		memPct := 0
+		if memCap.Value() > 0 {
+			memPct = int(math.Round(float64(memCap.Value()-memAlloc.Value()) * 100 / float64(memCap.Value())))
+		}
+
+		perNode = append(perNode, fmt.Sprintf("%s: CPU %d%%, Memory %d%% (%s/%s)", node.Name, cpuPct, memPct, formatBytes(memAlloc.Value()), formatBytes(memCap.Value())))
+
+		if cpuPct >= capacityThreshold || memPct >= capacityThreshold {
+			overThreshold = append(overThreshold, fmt.Sprintf("%s (CPU: %d%%, Memory: %d%% [%s/%s])", node.Name, cpuPct, memPct, formatBytes(memAlloc.Value()), formatBytes(memCap.Value())))
+		}
+	}
+
+	if len(overThreshold) > 0 {
+		notes.AppendWarning("Capacity: %d node(s) with >=80%% pre-allocation - %s", len(overThreshold), strings.Join(overThreshold, "; "))
+	} else {
+		notes.AppendSuccess("Capacity: all %d nodes have less than 80%% CPU and Memory pre-allocation", len(nodeList.Items))
+	}
+	notes.AppendAutomation("Capacity per-node pre-allocation:\n  %s", strings.Join(perNode, "\n  "))
+
+	i.checkCurrentUtilization(ctx, r, nodeCapacity, notes)
+}
+
+type nodeMetricsList struct {
+	Items []nodeMetrics `json:"items"`
+}
+
+type nodeMetrics struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Usage map[string]string `json:"usage"`
+}
+
+func (i *Investigation) checkCurrentUtilization(ctx context.Context, r *investigation.Resources, nodeCapacity map[string]corev1.ResourceList, notes *notewriter.NoteWriter) {
+	restConfig, err := getRestConfig(r)
+	if err != nil {
+		notes.AppendWarning("Capacity Utilization: unable to get REST config - %v", err)
+		return
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		notes.AppendWarning("Capacity Utilization: failed to create clientset - %v", err)
+		return
+	}
+
+	body, err := clientset.Discovery().RESTClient().Get().AbsPath("/apis/metrics.k8s.io/v1beta1/nodes").DoRaw(ctx)
+	if err != nil {
+		notes.AppendWarning("Capacity Utilization: unable to query metrics API - %v", err)
+		return
+	}
+
+	var metricsList nodeMetricsList
+	if err := json.Unmarshal(body, &metricsList); err != nil {
+		notes.AppendWarning("Capacity Utilization: failed to parse metrics response - %v", err)
+		return
+	}
+
+	const utilizationThreshold = 80
+
+	perNodeUtil := make([]string, 0, len(metricsList.Items))
+	var overThreshold []string
+
+	for _, nm := range metricsList.Items {
+		nodeCap, ok := nodeCapacity[nm.Metadata.Name]
+		if !ok {
+			continue
+		}
+
+		cpuUsage, err := resource.ParseQuantity(nm.Usage["cpu"])
+		if err != nil {
+			continue
+		}
+		memUsage, err := resource.ParseQuantity(nm.Usage["memory"])
+		if err != nil {
+			continue
+		}
+		cpuCap := nodeCap[corev1.ResourceCPU]
+		memCap := nodeCap[corev1.ResourceMemory]
+
+		cpuPct := 0
+		if cpuCap.MilliValue() > 0 {
+			cpuPct = int(math.Round(float64(cpuUsage.MilliValue()) * 100 / float64(cpuCap.MilliValue())))
+		}
+		memPct := 0
+		if memCap.Value() > 0 {
+			memPct = int(math.Round(float64(memUsage.Value()) * 100 / float64(memCap.Value())))
+		}
+
+		perNodeUtil = append(perNodeUtil, fmt.Sprintf("%s: CPU %d%%, Memory %d%% (%s/%s)", nm.Metadata.Name, cpuPct, memPct, formatBytes(memUsage.Value()), formatBytes(memCap.Value())))
+
+		if cpuPct >= utilizationThreshold || memPct >= utilizationThreshold {
+			overThreshold = append(overThreshold, fmt.Sprintf("%s (CPU: %d%%, Memory: %d%% [%s/%s])", nm.Metadata.Name, cpuPct, memPct, formatBytes(memUsage.Value()), formatBytes(memCap.Value())))
+		}
+	}
+
+	if len(perNodeUtil) == 0 {
+		notes.AppendWarning("Capacity Utilization: no node metrics available")
+		return
+	}
+
+	if len(overThreshold) > 0 {
+		notes.AppendWarning("Capacity Utilization: %d node(s) with >=80%% utilization - %s", len(overThreshold), strings.Join(overThreshold, "; "))
+	} else {
+		notes.AppendSuccess("Capacity Utilization: all nodes have less than 80%% CPU and Memory utilization")
+	}
+	notes.AppendAutomation("Capacity per-node utilization:\n  %s", strings.Join(perNodeUtil, "\n  "))
+}
+
+func formatBytes(bytes int64) string {
+	const (
+		gi = 1024 * 1024 * 1024
+		mi = 1024 * 1024
+	)
+	switch {
+	case bytes >= gi:
+		return fmt.Sprintf("%dGi", bytes/gi)
+	case bytes >= mi:
+		return fmt.Sprintf("%dMi", bytes/mi)
+	default:
+		return fmt.Sprintf("%dKi", bytes/1024)
+	}
+}
+
+// checkFiringAlerts queries the Alertmanager API via pod exec and reports any firing alerts.
+func (i *Investigation) checkFiringAlerts(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
+	restConfig, err := getRestConfig(r)
+	if err != nil {
+		notes.AppendWarning("Firing Alerts: unable to get REST config - %v", err)
+		return
+	}
+
+	fetcher := i.alertsFetcher
+	if fetcher == nil {
+		fetcher = &defaultAlertsFetcher{}
+	}
+
+	alerts, err := fetcher.fetchFiringAlerts(ctx, r.K8sClient, restConfig)
+	if err != nil {
+		notes.AppendWarning("Firing Alerts: failed to fetch - %v", err)
+		return
+	}
+
+	if len(alerts) == 0 {
+		notes.AppendSuccess("Firing Alerts: none")
+		return
+	}
+
+	bySeverity := map[string][]firingAlert{}
+	for _, a := range alerts {
+		bySeverity[a.Severity] = append(bySeverity[a.Severity], a)
+	}
+
+	var summary strings.Builder
+	summary.WriteString(fmt.Sprintf("%d firing alert(s):\n", len(alerts)))
+	for _, sev := range []string{"critical", "warning", "info", "none"} {
+		alertsForSev, ok := bySeverity[sev]
+		if !ok {
+			continue
+		}
+		for _, a := range alertsForSev {
+			summary.WriteString(fmt.Sprintf("  [%s] %s", sev, a.Name))
+			if a.Summary != "" {
+				summary.WriteString(fmt.Sprintf(" - %s", a.Summary))
+			}
+			summary.WriteString("\n")
+		}
+		delete(bySeverity, sev)
+	}
+	for sev, alertsForSev := range bySeverity {
+		for _, a := range alertsForSev {
+			summary.WriteString(fmt.Sprintf("  [%s] %s", sev, a.Name))
+			if a.Summary != "" {
+				summary.WriteString(fmt.Sprintf(" - %s", a.Summary))
+			}
+			summary.WriteString("\n")
+		}
+	}
+
+	notes.AppendWarning("Firing Alerts: %s", summary.String())
+}
+
+type alertmanagerAlert struct {
+	Labels      map[string]string       `json:"labels"`
+	Annotations map[string]string       `json:"annotations"`
+	Status      alertmanagerAlertStatus `json:"status"`
+}
+
+type alertmanagerAlertStatus struct {
+	State string `json:"state"`
+}
+
+type defaultAlertsFetcher struct{}
+
+func (d *defaultAlertsFetcher) fetchFiringAlerts(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config) ([]firingAlert, error) {
+	podList := &corev1.PodList{}
+	err := k8sClient.List(ctx, podList,
+		client.InNamespace("openshift-monitoring"),
+		client.MatchingLabels{"app.kubernetes.io/name": "alertmanager"},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list alertmanager pods: %w", err)
+	}
+
+	var amPod *corev1.Pod
+	for idx := range podList.Items {
+		if podList.Items[idx].Status.Phase == corev1.PodRunning {
+			amPod = &podList.Items[idx]
+			break
+		}
+	}
+	if amPod == nil {
+		return nil, fmt.Errorf("no running alertmanager pods found in openshift-monitoring")
+	}
+
+	output, err := k8sclient.ExecInPod(ctx, restConfig, amPod, "alertmanager", []string{
+		"wget", "-qO-", "http://localhost:9093/api/v2/alerts?active=true",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to exec in alertmanager pod: %w", err)
+	}
+
+	var amAlerts []alertmanagerAlert
+	if err := json.Unmarshal([]byte(output), &amAlerts); err != nil {
+		return nil, fmt.Errorf("failed to decode alertmanager response: %w", err)
+	}
+
+	var firing []firingAlert
+	for _, a := range amAlerts {
+		if a.Status.State == "active" || a.Status.State == "firing" {
+			alert := firingAlert{
+				Name:     a.Labels["alertname"],
+				Severity: a.Labels["severity"],
+				State:    a.Status.State,
+				Summary:  a.Annotations["summary"],
+			}
+			firing = append(firing, alert)
+		}
+	}
+
+	return firing, nil
+}
+
+// checkClusterVersion reports the current cluster version, any update conditions, and EOL status.
+func (i *Investigation) checkClusterVersion(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	cv := &configv1.ClusterVersion{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "version"}, cv); err != nil {
+		notes.AppendWarning("Cluster Version: failed to get - %v", err)
+		return
+	}
+
+	version := "unknown"
+	for _, h := range cv.Status.History {
+		if h.State == configv1.CompletedUpdate {
+			version = h.Version
+			break
+		}
+	}
+
+	var issues []string
+	for _, cond := range cv.Status.Conditions {
+		switch {
+		case cond.Type == "Failing" && cond.Status == configv1.ConditionTrue:
+			issues = append(issues, fmt.Sprintf("Failing: %s", cond.Message))
+		case cond.Type == "Progressing" && cond.Status == configv1.ConditionTrue:
+			issues = append(issues, fmt.Sprintf("Progressing: %s", cond.Message))
+		case cond.Type == "RetrievedUpdates" && cond.Status == configv1.ConditionFalse:
+			issues = append(issues, fmt.Sprintf("Cannot retrieve updates: %s", cond.Message))
+		}
+	}
+
+	eolWarning := i.checkEOL(ctx, cv)
+	if eolWarning != "" {
+		issues = append(issues, eolWarning)
+	}
+
+	if len(issues) == 0 {
+		notes.AppendSuccess("Cluster Version: %s", version)
+	} else {
+		notes.AppendWarning("Cluster Version: %s - %s", version, strings.Join(issues, "; "))
+	}
+}
+
+func (i *Investigation) checkEOL(ctx context.Context, cv *configv1.ClusterVersion) string {
+	currentVersion := ""
+	for _, h := range cv.Status.History {
+		if h.State == configv1.CompletedUpdate {
+			currentVersion = h.Version
+			break
+		}
+	}
+	if currentVersion == "" {
+		return ""
+	}
+
+	currentMinor := parseMinorVersion(currentVersion)
+	if currentMinor < 0 {
+		return ""
+	}
+
+	// Extract the channel prefix (e.g., "stable" from "stable-4.16")
+	channel := cv.Spec.Channel
+	channelPrefix := "stable"
+	if channel != "" {
+		if idx := strings.LastIndex(channel, "-"); idx >= 0 {
+			channelPrefix = channel[:idx]
+		}
+	}
+
+	checker := i.eolChecker
+	if checker == nil {
+		checker = &defaultEOLChecker{}
+	}
+
+	latestMinor, err := checker.checkEOL(ctx, channelPrefix, currentMinor)
+	if err != nil || latestMinor < 0 {
+		return ""
+	}
+
+	if latestMinor-currentMinor > 2 {
+		return fmt.Sprintf("EOL: cluster version %s is more than 2 minor versions behind latest available (%s-4.%d)", currentVersion, channelPrefix, latestMinor)
+	}
+	return ""
+}
+
+type upgradeGraphResponse struct {
+	Nodes []struct {
+		Version string `json:"version"`
+	} `json:"nodes"`
+}
+
+type defaultEOLChecker struct{}
+
+func (d *defaultEOLChecker) checkEOL(ctx context.Context, channelPrefix string, currentMinor int) (int, error) {
+	const openshiftAPI = "https://api.openshift.com/api/upgrades_info/v1/graph?channel="
+	// OpenShift minor versions are released roughly every 4 months; 10 is more than enough headroom.
+	const maxMinorVersionsAhead = 10
+
+	latestMinor := currentMinor
+	for nextMinor := currentMinor + 1; nextMinor < currentMinor+maxMinorVersionsAhead; nextMinor++ {
+		apiURL := fmt.Sprintf("%s%s-4.%d", openshiftAPI, channelPrefix, nextMinor)
+		hasVersions, err := d.channelHasVersions(ctx, apiURL)
+		if err != nil {
+			return latestMinor, err
+		}
+		if !hasVersions {
+			break
+		}
+		latestMinor = nextMinor
+	}
+
+	return latestMinor, nil
+}
+
+// eolHTTPClient is the HTTP client used for EOL checks, with a reasonable timeout.
+var eolHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// channelHasVersions queries the OpenShift upgrade graph API and returns whether
+// the given channel has any versions available.
+func (d *defaultEOLChecker) channelHasVersions(ctx context.Context, apiURL string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := eolHTTPClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, err
+	}
+
+	var graphResp upgradeGraphResponse
+	if err := json.Unmarshal(body, &graphResp); err != nil {
+		return false, err
+	}
+
+	return len(graphResp.Nodes) > 0, nil
+}
+
+func parseMinorVersion(version string) int {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return -1
+	}
+	minor := 0
+	for _, c := range parts[1] {
+		if c < '0' || c > '9' {
+			return -1
+		}
+		minor = minor*10 + int(c-'0')
+	}
+	return minor
+}
+
+// checkFailingPods reports pods in a failed state, with excessive restarts, or in error waiting states.
+func (i *Investigation) checkFailingPods(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(ctx, podList); err != nil {
+		notes.AppendWarning("Failing Pods: failed to list - %v", err)
+		return
+	}
+
+	type podIssue struct {
+		name      string
+		namespace string
+		reason    string
+	}
+
+	var issues []podIssue
+
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodSucceeded {
+			continue
+		}
+
+		if pod.Status.Phase == corev1.PodFailed {
+			reason := pod.Status.Reason
+			if reason == "" {
+				reason = "Failed"
+			}
+			issues = append(issues, podIssue{
+				name:      pod.Name,
+				namespace: pod.Namespace,
+				reason:    reason,
+			})
+			continue
+		}
+
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.RestartCount > 10 {
+				issues = append(issues, podIssue{
+					name:      pod.Name,
+					namespace: pod.Namespace,
+					reason:    fmt.Sprintf("container %s has %d restarts", cs.Name, cs.RestartCount),
+				})
+			}
+			if cs.State.Waiting != nil && (cs.State.Waiting.Reason == "CrashLoopBackOff" ||
+				cs.State.Waiting.Reason == "Error" ||
+				cs.State.Waiting.Reason == "ImagePullBackOff" ||
+				cs.State.Waiting.Reason == "ErrImagePull") {
+				issues = append(issues, podIssue{
+					name:      pod.Name,
+					namespace: pod.Namespace,
+					reason:    fmt.Sprintf("container %s: %s", cs.Name, cs.State.Waiting.Reason),
+				})
+			}
+		}
+	}
+
+	if len(issues) == 0 {
+		notes.AppendSuccess("Failing Pods: none")
+	} else {
+		maxDisplay := 50
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d pod(s) with issues:\n", len(issues)))
+
+		sort.Slice(issues, func(a, b int) bool {
+			if issues[a].namespace != issues[b].namespace {
+				return issues[a].namespace < issues[b].namespace
+			}
+			return issues[a].name < issues[b].name
+		})
+
+		displayed := 0
+		for _, issue := range issues {
+			if displayed >= maxDisplay {
+				sb.WriteString(fmt.Sprintf("  ... and %d more\n", len(issues)-maxDisplay))
+				break
+			}
+			sb.WriteString(fmt.Sprintf("  %s/%s: %s\n", issue.namespace, issue.name, issue.reason))
+			displayed++
+		}
+
+		notes.AppendWarning("Failing Pods: %s", sb.String())
+	}
+}
+
+// checkRestrictivePDBs reports PodDisruptionBudgets that are actively blocking disruptions.
+func (i *Investigation) checkRestrictivePDBs(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	pdbList := &policyv1.PodDisruptionBudgetList{}
+	if err := k8sClient.List(ctx, pdbList); err != nil {
+		notes.AppendWarning("Restrictive PDBs: failed to list - %v", err)
+		return
+	}
+
+	var restrictive []string
+
+	for _, pdb := range pdbList.Items {
+		// (disruptionsAllowed == 0)
+		if pdb.Status.DisruptionsAllowed > 0 {
+			continue
+		}
+
+		isRestrictive := false
+		reason := ""
+
+		if pdb.Spec.MaxUnavailable != nil {
+			if (pdb.Spec.MaxUnavailable.Type == intstr.Int && pdb.Spec.MaxUnavailable.IntVal == 0) ||
+				(pdb.Spec.MaxUnavailable.Type == intstr.String && pdb.Spec.MaxUnavailable.StrVal == "0%") {
+				isRestrictive = true
+				reason = fmt.Sprintf("maxUnavailable=%s", pdb.Spec.MaxUnavailable.String())
+			}
+		}
+
+		// Check minAvailable = 100% or equal to total expected pods
+		if pdb.Spec.MinAvailable != nil {
+			if pdb.Spec.MinAvailable.Type == intstr.String {
+				if pdb.Spec.MinAvailable.StrVal == "100%" {
+					isRestrictive = true
+					reason = "minAvailable=100%"
+				}
+			} else if pdb.Status.ExpectedPods > 0 && pdb.Spec.MinAvailable.IntValue() >= int(pdb.Status.ExpectedPods) {
+				isRestrictive = true
+				reason = fmt.Sprintf("minAvailable=%d (expectedPods=%d)", pdb.Spec.MinAvailable.IntValue(), pdb.Status.ExpectedPods)
+			}
+		}
+
+		if isRestrictive {
+			restrictive = append(restrictive, fmt.Sprintf("%s/%s (%s)",
+				pdb.Namespace, pdb.Name, reason))
+		}
+	}
+
+	if len(restrictive) == 0 {
+		notes.AppendSuccess("Restrictive PDBs: none")
+	} else {
+		notes.AppendWarning("Restrictive PDBs: %d found - %s", len(restrictive), strings.Join(restrictive, "; "))
+	}
+}
+
+// checkNonNormalEvents reports cluster events with a type other than Normal.
+func (i *Investigation) checkNonNormalEvents(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	eventList := &corev1.EventList{}
+	if err := k8sClient.List(ctx, eventList); err != nil {
+		notes.AppendWarning("Events: failed to list - %v", err)
+		return
+	}
+
+	type eventSummary struct {
+		reason    string
+		object    string
+		message   string
+		count     int32
+		namespace string
+	}
+
+	var nonNormal []eventSummary
+	for _, event := range eventList.Items {
+		if event.Type != corev1.EventTypeNormal {
+			nonNormal = append(nonNormal, eventSummary{
+				reason:    event.Reason,
+				object:    fmt.Sprintf("%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Name),
+				message:   event.Message,
+				count:     event.Count,
+				namespace: event.Namespace,
+			})
+		}
+	}
+
+	if len(nonNormal) == 0 {
+		notes.AppendSuccess("Events: no non-normal events")
+	} else {
+		maxDisplay := 50
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d non-normal event(s):\n", len(nonNormal)))
+
+		sort.Slice(nonNormal, func(a, b int) bool {
+			if nonNormal[a].namespace != nonNormal[b].namespace {
+				return nonNormal[a].namespace < nonNormal[b].namespace
+			}
+			return nonNormal[a].reason < nonNormal[b].reason
+		})
+
+		displayed := 0
+		for _, e := range nonNormal {
+			if displayed >= maxDisplay {
+				sb.WriteString(fmt.Sprintf("  ... and %d more\n", len(nonNormal)-maxDisplay))
+				break
+			}
+			countStr := ""
+			if e.count > 1 {
+				countStr = fmt.Sprintf(" (x%d)", e.count)
+			}
+			msg := e.message
+			if len(msg) > 120 {
+				msg = msg[:120] + "..."
+			}
+			sb.WriteString(fmt.Sprintf("  %s/%s: %s%s - %s\n", e.namespace, e.object, e.reason, countStr, msg))
+			displayed++
+		}
+
+		notes.AppendWarning("Events: %s", sb.String())
+	}
+}
+
+func getRestConfig(r *investigation.Resources) (*rest.Config, error) {
+	if r.RestConfig != nil {
+		return &r.RestConfig.Config, nil
+	}
+	return k8sclient.GetRestConfig(r.K8sClient)
+}
+
+func (i *Investigation) Name() string {
+	return "clusterhealthcheck"
+}
+
+func (i *Investigation) AlertTitle() string {
+	return ""
+}
+
+func (i *Investigation) Description() string {
+	return "Run comprehensive health checks against the cluster (cluster operators, API, etcd, nodes, pods, events, etc.)"
+}
+
+func (i *Investigation) IsExperimental() bool {
+	return true
+}

--- a/pkg/investigations/clusterhealthcheck/clusterhealthcheck_test.go
+++ b/pkg/investigations/clusterhealthcheck/clusterhealthcheck_test.go
@@ -1,0 +1,1574 @@
+package clusterhealthcheck
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/backplane"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+
+	certsv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// testScheme returns a scheme with all the types the health check needs.
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = configv1.Install(s)
+	_ = mcfgv1.Install(s)
+	_ = certsv1.AddToScheme(s)
+	_ = policyv1.AddToScheme(s)
+	return s
+}
+
+// clientImpl wraps a controller-runtime client to satisfy k8sclient.Client
+type clientImpl struct {
+	client.Client
+}
+
+func newFakeClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(objs...).Build()
+}
+
+func newTestCluster(id string) *cmv1.Cluster {
+	cluster, _ := cmv1.NewCluster().ID(id).Build()
+	return cluster
+}
+
+func newTestNotes() *notewriter.NoteWriter {
+	return notewriter.New("clusterhealthcheck", nil)
+}
+
+// --- Mock implementations ---
+
+type mockAlertsFetcher struct {
+	alerts []firingAlert
+	err    error
+}
+
+func (m *mockAlertsFetcher) fetchFiringAlerts(_ context.Context, _ k8sclient.Client, _ *rest.Config) ([]firingAlert, error) {
+	return m.alerts, m.err
+}
+
+type mockEtcdHealthChecker struct {
+	output string
+	err    error
+}
+
+func (m *mockEtcdHealthChecker) checkEtcdHealth(_ context.Context, _ k8sclient.Client, _ *rest.Config, _ string) (string, error) {
+	return m.output, m.err
+}
+
+type mockAPIHealthChecker struct {
+	result apiHealthResult
+	err    error
+}
+
+func (m *mockAPIHealthChecker) checkHealth(_ context.Context, _ *rest.Config) (apiHealthResult, error) {
+	return m.result, m.err
+}
+
+type mockEOLChecker struct {
+	latestMinor int
+	err         error
+}
+
+func (m *mockEOLChecker) checkEOL(_ context.Context, _ string, _ int) (int, error) {
+	return m.latestMinor, m.err
+}
+
+// --- Investigation interface tests ---
+
+func TestName(t *testing.T) {
+	inv := &Investigation{}
+	if inv.Name() != "clusterhealthcheck" {
+		t.Errorf("expected name 'clusterhealthcheck', got %q", inv.Name())
+	}
+}
+
+func TestAlertTitle(t *testing.T) {
+	inv := &Investigation{}
+	if inv.AlertTitle() != "" {
+		t.Errorf("expected empty alert title, got %q", inv.AlertTitle())
+	}
+}
+
+func TestIsExperimental(t *testing.T) {
+	inv := &Investigation{}
+	if !inv.IsExperimental() {
+		t.Error("expected IsExperimental to return true")
+	}
+}
+
+func TestDescription(t *testing.T) {
+	inv := &Investigation{}
+	if inv.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+}
+
+// --- Run tests ---
+
+func TestRun_HealthyCluster(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1", Labels: map[string]string{"node-role.kubernetes.io/worker": ""}},
+		Status: corev1.NodeStatus{
+			Conditions:  []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Capacity:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("16Gi")},
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3500m"), corev1.ResourceMemory: resource.MustParse("15Gi")},
+		},
+	}
+
+	co := &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: "monitoring"},
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+				{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+
+	cv := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{{State: configv1.CompletedUpdate, Version: "4.16.5"}},
+		},
+	}
+
+	mcp := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		Status: mcfgv1.MachineConfigPoolStatus{
+			MachineCount:        2,
+			UpdatedMachineCount: 2,
+			Conditions: []mcfgv1.MachineConfigPoolCondition{
+				{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
+				{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+
+	fakeK8s := newFakeClient(node, co, cv, mcp)
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:   newTestCluster("test-cluster"),
+			K8sClient: clientImpl{fakeK8s},
+			Params:    map[string]string{},
+		},
+	}
+
+	inv := &Investigation{
+		alertsFetcher:    &mockAlertsFetcher{alerts: nil},
+		etcdChecker:      &mockEtcdHealthChecker{output: "endpoint health: healthy"},
+		apiHealthChecker: &mockAPIHealthChecker{result: apiHealthResult{healthz: "ok", livez: "ok", readyz: "ok"}},
+		eolChecker:       &mockEOLChecker{latestMinor: 16},
+	}
+
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Actions) != 2 {
+		t.Fatalf("expected 2 actions (backplane report + PD note), got %d", len(result.Actions))
+	}
+}
+
+func TestRun_HCPCluster(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Status: corev1.NodeStatus{
+			Conditions:  []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Capacity:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("16Gi")},
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3500m"), corev1.ResourceMemory: resource.MustParse("15Gi")},
+		},
+	}
+
+	co := &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: "monitoring"},
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+			},
+		},
+	}
+
+	cv := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{{State: configv1.CompletedUpdate, Version: "4.16.5"}},
+		},
+	}
+
+	fakeK8s := newFakeClient(node, co, cv)
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:   newTestCluster("test-hcp-cluster"),
+			K8sClient: clientImpl{fakeK8s},
+			IsHCP:     true,
+			Params:    map[string]string{},
+		},
+	}
+
+	inv := &Investigation{
+		alertsFetcher:    &mockAlertsFetcher{alerts: nil},
+		etcdChecker:      &mockEtcdHealthChecker{output: "healthy"},
+		apiHealthChecker: &mockAPIHealthChecker{result: apiHealthResult{healthz: "ok", livez: "ok", readyz: "ok"}},
+		eolChecker:       &mockEOLChecker{latestMinor: 16},
+	}
+
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Actions) == 0 {
+		t.Fatal("expected actions to be returned")
+	}
+}
+
+func TestRun_ClusterAccessError(t *testing.T) {
+	rb := &investigation.ResourceBuilderMock{
+		BuildError: investigation.RestConfigError{
+			ClusterID: "test-cluster",
+			Err:       fmt.Errorf("cannot create remediations on hive, management or service clusters"),
+		},
+	}
+
+	inv := &Investigation{}
+
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("cluster access errors should not return an error, got: %v", err)
+	}
+
+	if len(result.Actions) == 0 {
+		t.Fatal("expected a note action for cluster access error")
+	}
+}
+
+func TestRun_BuildError(t *testing.T) {
+	rb := &investigation.ResourceBuilderMock{
+		BuildError: fmt.Errorf("some unexpected infrastructure error"),
+	}
+
+	inv := &Investigation{}
+
+	_, err := inv.Run(rb)
+	if err == nil {
+		t.Fatal("expected an error for non-cluster-access build failures")
+	}
+}
+
+// --- Individual check tests ---
+
+func TestCheckClusterOperators_AllHealthy(t *testing.T) {
+	co1 := &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: "monitoring"},
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+				{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+	co2 := &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: "ingress"},
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+				{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+
+	k8s := newFakeClient(co1, co2)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkClusterOperators(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "all 2 operators are healthy") {
+		t.Errorf("expected healthy message, got:\n%s", output)
+	}
+}
+
+func TestCheckClusterOperators_Degraded(t *testing.T) {
+	co := &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: "monitoring"},
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue, Reason: "UserConfigError"},
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse, Reason: "ComponentUnavailable"},
+			},
+		},
+	}
+
+	k8s := newFakeClient(co)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkClusterOperators(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "degraded") {
+		t.Errorf("expected degraded warning, got:\n%s", output)
+	}
+	if !strings.Contains(output, "unavailable") {
+		t.Errorf("expected unavailable warning, got:\n%s", output)
+	}
+}
+
+func TestCheckClusterOperators_Progressing(t *testing.T) {
+	co := &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver"},
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "Updating"},
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+				{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+
+	k8s := newFakeClient(co)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkClusterOperators(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "progressing") {
+		t.Errorf("expected progressing warning, got:\n%s", output)
+	}
+}
+
+func TestCheckClusterOperators_None(t *testing.T) {
+	k8s := newFakeClient()
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkClusterOperators(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "none found") {
+		t.Errorf("expected 'none found' warning, got:\n%s", output)
+	}
+}
+
+func TestCheckAPIServerHealth_AllOK(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{
+		apiHealthChecker: &mockAPIHealthChecker{
+			result: apiHealthResult{healthz: "ok", livez: "ok", readyz: "ok"},
+		},
+	}
+
+	r := &investigation.Resources{
+		K8sClient:  clientImpl{newFakeClient()},
+		RestConfig: &backplane.RestConfig{},
+	}
+	inv.checkAPIServerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "all endpoints healthy") {
+		t.Errorf("expected healthy message, got:\n%s", output)
+	}
+}
+
+func TestCheckAPIServerHealth_Unhealthy(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{
+		apiHealthChecker: &mockAPIHealthChecker{
+			result: apiHealthResult{healthz: "ok", livez: "error: connection refused", readyz: "ok"},
+		},
+	}
+
+	r := &investigation.Resources{
+		K8sClient:  clientImpl{newFakeClient()},
+		RestConfig: &backplane.RestConfig{},
+	}
+	inv.checkAPIServerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "livez=error") {
+		t.Errorf("expected unhealthy livez in output, got:\n%s", output)
+	}
+}
+
+func TestCheckAPIServerHealth_Error(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{
+		apiHealthChecker: &mockAPIHealthChecker{
+			err: fmt.Errorf("connection refused"),
+		},
+	}
+
+	r := &investigation.Resources{
+		K8sClient:  clientImpl{newFakeClient()},
+		RestConfig: &backplane.RestConfig{},
+	}
+	inv.checkAPIServerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "check failed") {
+		t.Errorf("expected check failed warning, got:\n%s", output)
+	}
+}
+
+func TestCheckAPIServerPods_AllReady(t *testing.T) {
+	ocpPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "apiserver-1", Namespace: "openshift-apiserver", Labels: map[string]string{"app": "openshift-apiserver-a"}},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	kubePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-1", Namespace: "openshift-kube-apiserver", Labels: map[string]string{"app": "openshift-kube-apiserver"}},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+
+	k8s := newFakeClient(ocpPod, kubePod)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkAPIServerPods(context.Background(), clientImpl{k8s}, false, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "OpenShift API Server Pods: all 1 pods are Ready") {
+		t.Errorf("expected all OCP API pods ready, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Kube API Server Pods: all 1 pods are Ready") {
+		t.Errorf("expected all Kube API pods ready, got:\n%s", output)
+	}
+}
+
+func TestCheckAPIServerPods_NotReady(t *testing.T) {
+	ocpPod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "apiserver-1", Namespace: "openshift-apiserver", Labels: map[string]string{"app": "openshift-apiserver-a"}},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	ocpPod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "apiserver-2", Namespace: "openshift-apiserver", Labels: map[string]string{"app": "openshift-apiserver-a"}},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"}},
+		},
+	}
+
+	k8s := newFakeClient(ocpPod1, ocpPod2)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkAPIServerPods(context.Background(), clientImpl{k8s}, false, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "1/2 not ready") {
+		t.Errorf("expected 1/2 not ready, got:\n%s", output)
+	}
+	if !strings.Contains(output, "apiserver-2") {
+		t.Errorf("expected apiserver-2 in output, got:\n%s", output)
+	}
+}
+
+func TestCheckAPIServerPods_NoPods(t *testing.T) {
+	k8s := newFakeClient()
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkAPIServerPods(context.Background(), clientImpl{k8s}, false, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no pods found") {
+		t.Errorf("expected no pods found warning, got:\n%s", output)
+	}
+}
+
+func TestCheckAPIServerPods_HCP(t *testing.T) {
+	k8s := newFakeClient()
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkAPIServerPods(context.Background(), clientImpl{k8s}, true, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "skipped") {
+		t.Errorf("expected skipped message for HCP, got:\n%s", output)
+	}
+}
+
+func TestCheckMachineConfigPools_Healthy(t *testing.T) {
+	mcp := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		Status: mcfgv1.MachineConfigPoolStatus{
+			MachineCount:        3,
+			UpdatedMachineCount: 3,
+			Conditions: []mcfgv1.MachineConfigPoolCondition{
+				{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
+				{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+
+	k8s := newFakeClient(mcp)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkMachineConfigPools(context.Background(), clientImpl{k8s}, false, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "all 1 pools are healthy") {
+		t.Errorf("expected healthy MCP message, got:\n%s", output)
+	}
+}
+
+func TestCheckMachineConfigPools_Degraded(t *testing.T) {
+	mcp := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		Status: mcfgv1.MachineConfigPoolStatus{
+			MachineCount:        3,
+			UpdatedMachineCount: 1,
+			Conditions: []mcfgv1.MachineConfigPoolCondition{
+				{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionTrue, Reason: "NodeFailing", Message: "node worker-2 is failing"},
+			},
+		},
+	}
+
+	k8s := newFakeClient(mcp)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkMachineConfigPools(context.Background(), clientImpl{k8s}, false, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "degraded") {
+		t.Errorf("expected degraded MCP warning, got:\n%s", output)
+	}
+}
+
+func TestCheckMachineConfigPools_Updating(t *testing.T) {
+	mcp := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "master"},
+		Status: mcfgv1.MachineConfigPoolStatus{
+			MachineCount:        3,
+			UpdatedMachineCount: 1,
+			Conditions: []mcfgv1.MachineConfigPoolCondition{
+				{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	k8s := newFakeClient(mcp)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkMachineConfigPools(context.Background(), clientImpl{k8s}, false, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "updating") {
+		t.Errorf("expected updating MCP warning, got:\n%s", output)
+	}
+	if !strings.Contains(output, "1/3 updated") {
+		t.Errorf("expected update count in output, got:\n%s", output)
+	}
+}
+
+func TestCheckMachineConfigPools_HCP(t *testing.T) {
+	k8s := newFakeClient()
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkMachineConfigPools(context.Background(), clientImpl{k8s}, true, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "skipped") {
+		t.Errorf("expected skipped message for HCP, got:\n%s", output)
+	}
+}
+
+func TestCheckPendingCSRs_None(t *testing.T) {
+	csr := &certsv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "csr-1"},
+		Spec:       certsv1.CertificateSigningRequestSpec{SignerName: "kubernetes.io/kubelet-serving", Username: "system:node:worker-1"},
+		Status: certsv1.CertificateSigningRequestStatus{
+			Conditions: []certsv1.CertificateSigningRequestCondition{
+				{Type: certsv1.CertificateApproved},
+			},
+		},
+	}
+
+	k8s := newFakeClient(csr)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkPendingCSRs(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Pending CSRs: none") {
+		t.Errorf("expected no pending CSRs, got:\n%s", output)
+	}
+}
+
+func TestCheckPendingCSRs_Pending(t *testing.T) {
+	csr := &certsv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "csr-pending", CreationTimestamp: metav1.Now()},
+		Spec:       certsv1.CertificateSigningRequestSpec{SignerName: "kubernetes.io/kubelet-serving", Username: "system:node:worker-1"},
+		Status:     certsv1.CertificateSigningRequestStatus{},
+	}
+
+	k8s := newFakeClient(csr)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkPendingCSRs(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "1 pending") {
+		t.Errorf("expected 1 pending CSR, got:\n%s", output)
+	}
+}
+
+func TestCheckNodeStatus_AllReady(t *testing.T) {
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-2"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+
+	k8s := newFakeClient(node1, node2)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNodeStatus(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "all 2 nodes are Ready and healthy") {
+		t.Errorf("expected all nodes ready, got:\n%s", output)
+	}
+}
+
+func TestCheckNodeStatus_NotReady(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionFalse, Reason: "KubeletNotReady"},
+			},
+		},
+	}
+
+	k8s := newFakeClient(node)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNodeStatus(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "not ready") {
+		t.Errorf("expected not ready warning, got:\n%s", output)
+	}
+	if !strings.Contains(output, "KubeletNotReady") {
+		t.Errorf("expected reason in output, got:\n%s", output)
+	}
+}
+
+func TestCheckNodeStatus_Unschedulable(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Spec:       corev1.NodeSpec{Unschedulable: true},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+
+	k8s := newFakeClient(node)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNodeStatus(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "scheduling disabled") {
+		t.Errorf("expected scheduling disabled warning, got:\n%s", output)
+	}
+}
+
+func TestCheckNodeStatus_MemoryPressure(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	k8s := newFakeClient(node)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNodeStatus(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "MemoryPressure") {
+		t.Errorf("expected MemoryPressure condition, got:\n%s", output)
+	}
+}
+
+func TestCheckNodeStatus_DiskPressure(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				{Type: corev1.NodeDiskPressure, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	k8s := newFakeClient(node)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNodeStatus(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "DiskPressure") {
+		t.Errorf("expected DiskPressure condition, got:\n%s", output)
+	}
+}
+
+func TestCheckNodeStatus_Tainted(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "master-1"},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+
+	k8s := newFakeClient(node)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNodeStatus(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Node Taints") {
+		t.Errorf("expected taint report, got:\n%s", output)
+	}
+	if !strings.Contains(output, "NoSchedule") {
+		t.Errorf("expected NoSchedule taint, got:\n%s", output)
+	}
+}
+
+func TestCheckNodeStatus_None(t *testing.T) {
+	k8s := newFakeClient()
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNodeStatus(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "none found") {
+		t.Errorf("expected 'none found' warning, got:\n%s", output)
+	}
+}
+
+func TestCheckCapacity(t *testing.T) {
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Status: corev1.NodeStatus{
+			Capacity:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("16Gi")},
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3500m"), corev1.ResourceMemory: resource.MustParse("15Gi")},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-2"},
+		Status: corev1.NodeStatus{
+			Capacity:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("16Gi")},
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3500m"), corev1.ResourceMemory: resource.MustParse("15Gi")},
+		},
+	}
+
+	k8s := newFakeClient(node1, node2)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	r := &investigation.Resources{K8sClient: clientImpl{k8s}}
+	inv.checkCapacity(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "less than 80%") {
+		t.Errorf("expected threshold message in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "worker-1: CPU") {
+		t.Errorf("expected per-node info for worker-1, got:\n%s", output)
+	}
+	if !strings.Contains(output, "worker-2: CPU") {
+		t.Errorf("expected per-node info for worker-2, got:\n%s", output)
+	}
+}
+
+func TestCheckCapacity_OverThreshold(t *testing.T) {
+	// Node with very high reservation (only 500m of 4 CPU allocatable = 87% reserved)
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "overloaded-1"},
+		Status: corev1.NodeStatus{
+			Capacity:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("16Gi")},
+			Allocatable: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("2Gi")},
+		},
+	}
+
+	k8s := newFakeClient(node)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	r := &investigation.Resources{K8sClient: clientImpl{k8s}}
+	inv.checkCapacity(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, ">=80%") {
+		t.Errorf("expected over-threshold warning, got:\n%s", output)
+	}
+}
+
+func TestCheckClusterVersion_Healthy(t *testing.T) {
+	cv := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Version: "4.16.5"},
+			},
+		},
+	}
+
+	k8s := newFakeClient(cv)
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		eolChecker: &mockEOLChecker{latestMinor: 16},
+	}
+	inv.checkClusterVersion(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "4.16.5") {
+		t.Errorf("expected version 4.16.5, got:\n%s", output)
+	}
+}
+
+func TestCheckClusterVersion_Failing(t *testing.T) {
+	cv := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Version: "4.16.5"},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: "Failing", Status: configv1.ConditionTrue, Message: "upgrade is stuck"},
+			},
+		},
+	}
+
+	k8s := newFakeClient(cv)
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		eolChecker: &mockEOLChecker{latestMinor: 16},
+	}
+	inv.checkClusterVersion(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Failing") {
+		t.Errorf("expected Failing condition in output, got:\n%s", output)
+	}
+}
+
+func TestCheckClusterVersion_Progressing(t *testing.T) {
+	cv := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Version: "4.15.0"},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: "Progressing", Status: configv1.ConditionTrue, Message: "Working towards 4.16.0"},
+			},
+		},
+	}
+
+	k8s := newFakeClient(cv)
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		eolChecker: &mockEOLChecker{latestMinor: 16},
+	}
+	inv.checkClusterVersion(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Progressing") {
+		t.Errorf("expected Progressing condition in output, got:\n%s", output)
+	}
+}
+
+func TestCheckClusterVersion_EOL(t *testing.T) {
+	cv := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Spec:       configv1.ClusterVersionSpec{Channel: "stable-4.14"},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Version: "4.14.5"},
+			},
+		},
+	}
+
+	k8s := newFakeClient(cv)
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		eolChecker: &mockEOLChecker{latestMinor: 18}, // latest is 4.18, current is 4.14 (4 behind)
+	}
+	inv.checkClusterVersion(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "EOL") {
+		t.Errorf("expected EOL warning for 4.14 vs latest 4.18, got:\n%s", output)
+	}
+}
+
+func TestCheckClusterVersion_NotEOL(t *testing.T) {
+	cv := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Spec:       configv1.ClusterVersionSpec{Channel: "stable-4.15"},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Version: "4.15.0"},
+			},
+		},
+	}
+
+	k8s := newFakeClient(cv)
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		eolChecker: &mockEOLChecker{latestMinor: 16}, // latest is 4.16, current is 4.15 (1 behind)
+	}
+	inv.checkClusterVersion(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if strings.Contains(output, "EOL") {
+		t.Errorf("should not report EOL for 4.15 vs latest 4.16, got:\n%s", output)
+	}
+}
+
+func TestCheckClusterVersion_EOLCheckerError(t *testing.T) {
+	cv := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Spec:       configv1.ClusterVersionSpec{Channel: "stable-4.14"},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Version: "4.14.5"},
+			},
+		},
+	}
+
+	k8s := newFakeClient(cv)
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		eolChecker: &mockEOLChecker{latestMinor: -1, err: fmt.Errorf("network error")},
+	}
+	inv.checkClusterVersion(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if strings.Contains(output, "EOL") {
+		t.Errorf("should not report EOL when checker returns an error, got:\n%s", output)
+	}
+	if !strings.Contains(output, "4.14.5") {
+		t.Errorf("expected version in output despite EOL check error, got:\n%s", output)
+	}
+}
+
+func TestParseMinorVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"4.16.5", 16},
+		{"4.14.0", 14},
+		{"4.21.10", 21},
+		{"4.0.0", 0},
+		{"invalid", -1},
+		{"4", -1},
+	}
+	for _, tt := range tests {
+		result := parseMinorVersion(tt.input)
+		if result != tt.expected {
+			t.Errorf("parseMinorVersion(%q) = %d, want %d", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestCheckFailingPods_None(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "healthy-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	k8s := newFakeClient(pod)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkFailingPods(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Failing Pods: none") {
+		t.Errorf("expected no failing pods, got:\n%s", output)
+	}
+}
+
+func TestCheckFailingPods_Failed(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodFailed, Reason: "OOMKilled"},
+	}
+
+	k8s := newFakeClient(pod)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkFailingPods(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "1 pod(s) with issues") {
+		t.Errorf("expected 1 failing pod, got:\n%s", output)
+	}
+	if !strings.Contains(output, "OOMKilled") {
+		t.Errorf("expected OOMKilled reason, got:\n%s", output)
+	}
+}
+
+func TestCheckFailingPods_HighRestarts(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "crashloop-pod", Namespace: "openshift-monitoring"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "prometheus", RestartCount: 15},
+			},
+		},
+	}
+
+	k8s := newFakeClient(pod)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkFailingPods(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "15 restarts") {
+		t.Errorf("expected restart count in output, got:\n%s", output)
+	}
+}
+
+func TestCheckFailingPods_CrashLoopBackOff(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "crash-pod", Namespace: "test-ns"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "app",
+					RestartCount: 3,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+					},
+				},
+			},
+		},
+	}
+
+	k8s := newFakeClient(pod)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkFailingPods(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "CrashLoopBackOff") {
+		t.Errorf("expected CrashLoopBackOff in output, got:\n%s", output)
+	}
+}
+
+func TestCheckFailingPods_SkipsSucceeded(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "completed-job", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+
+	k8s := newFakeClient(pod)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkFailingPods(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Failing Pods: none") {
+		t.Errorf("expected no failing pods (succeeded should be skipped), got:\n%s", output)
+	}
+}
+
+func TestCheckRestrictivePDBs_None(t *testing.T) {
+	maxUnavail := intstr.FromInt32(1)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "normal-pdb", Namespace: "default"},
+		Spec:       policyv1.PodDisruptionBudgetSpec{MaxUnavailable: &maxUnavail},
+	}
+
+	k8s := newFakeClient(pdb)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkRestrictivePDBs(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Restrictive PDBs: none") {
+		t.Errorf("expected no restrictive PDBs, got:\n%s", output)
+	}
+}
+
+func TestCheckRestrictivePDBs_NotBlockingDisruptions(t *testing.T) {
+	maxUnavail := intstr.FromInt32(0)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "not-blocking-pdb", Namespace: "app-ns"},
+		Spec:       policyv1.PodDisruptionBudgetSpec{MaxUnavailable: &maxUnavail},
+		Status:     policyv1.PodDisruptionBudgetStatus{DisruptionsAllowed: 1},
+	}
+
+	k8s := newFakeClient(pdb)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkRestrictivePDBs(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Restrictive PDBs: none") {
+		t.Errorf("PDB with disruptionsAllowed>0 should not be flagged, got:\n%s", output)
+	}
+}
+
+func TestCheckRestrictivePDBs_MaxUnavailableZero(t *testing.T) {
+	maxUnavail := intstr.FromInt32(0)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "restrictive-pdb", Namespace: "app-ns"},
+		Spec:       policyv1.PodDisruptionBudgetSpec{MaxUnavailable: &maxUnavail},
+		Status:     policyv1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+	}
+
+	k8s := newFakeClient(pdb)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkRestrictivePDBs(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "maxUnavailable=0") {
+		t.Errorf("expected maxUnavailable=0 warning, got:\n%s", output)
+	}
+}
+
+func TestCheckRestrictivePDBs_MaxUnavailableZeroPercent(t *testing.T) {
+	maxUnavail := intstr.FromString("0%")
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "restrictive-pdb-pct", Namespace: "app-ns"},
+		Spec:       policyv1.PodDisruptionBudgetSpec{MaxUnavailable: &maxUnavail},
+		Status:     policyv1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+	}
+
+	k8s := newFakeClient(pdb)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkRestrictivePDBs(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "maxUnavailable=0%") {
+		t.Errorf("expected maxUnavailable=0%% warning, got:\n%s", output)
+	}
+}
+
+func TestCheckRestrictivePDBs_MinAvailable100Percent(t *testing.T) {
+	minAvail := intstr.FromString("100%")
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "full-min-pdb", Namespace: "app-ns"},
+		Spec:       policyv1.PodDisruptionBudgetSpec{MinAvailable: &minAvail},
+		Status:     policyv1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0, ExpectedPods: 3},
+	}
+
+	k8s := newFakeClient(pdb)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkRestrictivePDBs(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "minAvailable=100%") {
+		t.Errorf("expected minAvailable=100%% warning, got:\n%s", output)
+	}
+}
+
+func TestCheckNonNormalEvents_None(t *testing.T) {
+	event := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "normal-event", Namespace: "default"},
+		Type:           corev1.EventTypeNormal,
+		Reason:         "Scheduled",
+		Message:        "Successfully assigned pod to node",
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "test-pod"},
+	}
+
+	k8s := newFakeClient(event)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNonNormalEvents(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no non-normal events") {
+		t.Errorf("expected no non-normal events, got:\n%s", output)
+	}
+}
+
+func TestCheckNonNormalEvents_Warning(t *testing.T) {
+	event := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "warning-event", Namespace: "default"},
+		Type:           "Warning",
+		Reason:         "FailedMount",
+		Message:        "MountVolume.SetUp failed",
+		Count:          3,
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "app-pod"},
+	}
+
+	k8s := newFakeClient(event)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNonNormalEvents(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "1 non-normal event") {
+		t.Errorf("expected 1 non-normal event, got:\n%s", output)
+	}
+	if !strings.Contains(output, "FailedMount") {
+		t.Errorf("expected FailedMount in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "(x3)") {
+		t.Errorf("expected count (x3) in output, got:\n%s", output)
+	}
+}
+
+func TestCheckFiringAlerts_None(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{
+		alertsFetcher: &mockAlertsFetcher{alerts: nil},
+	}
+
+	r := &investigation.Resources{
+		K8sClient:  clientImpl{newFakeClient()},
+		RestConfig: &backplane.RestConfig{},
+	}
+	inv.checkFiringAlerts(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Firing Alerts: none") {
+		t.Errorf("expected no firing alerts, got:\n%s", output)
+	}
+}
+
+func TestCheckFiringAlerts_WithAlerts(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{
+		alertsFetcher: &mockAlertsFetcher{
+			alerts: []firingAlert{
+				{Name: "HighMemoryUsage", Severity: "critical", State: "firing", Summary: "Memory > 90%"},
+				{Name: "DiskAlmostFull", Severity: "warning", State: "firing", Summary: "Disk > 85%"},
+			},
+		},
+	}
+
+	r := &investigation.Resources{
+		K8sClient:  clientImpl{newFakeClient()},
+		RestConfig: &backplane.RestConfig{},
+	}
+	inv.checkFiringAlerts(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "2 firing alert(s)") {
+		t.Errorf("expected 2 firing alerts, got:\n%s", output)
+	}
+	if !strings.Contains(output, "[critical] HighMemoryUsage") {
+		t.Errorf("expected critical alert in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "[warning] DiskAlmostFull") {
+		t.Errorf("expected warning alert in output, got:\n%s", output)
+	}
+}
+
+func TestCheckFiringAlerts_FetchError(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{
+		alertsFetcher: &mockAlertsFetcher{err: fmt.Errorf("connection refused")},
+	}
+
+	r := &investigation.Resources{
+		K8sClient:  clientImpl{newFakeClient()},
+		RestConfig: &backplane.RestConfig{},
+	}
+	inv.checkFiringAlerts(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "failed to fetch") {
+		t.Errorf("expected fetch error warning, got:\n%s", output)
+	}
+}
+
+func TestCheckFiringAlerts_NoPod(t *testing.T) {
+	fakeK8s := newFakeClient()
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		alertsFetcher: &mockAlertsFetcher{},
+	}
+
+	r := &investigation.Resources{
+		K8sClient: clientImpl{fakeK8s},
+	}
+	inv.checkFiringAlerts(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Firing Alerts") {
+		t.Errorf("expected Firing Alerts in output, got:\n%s", output)
+	}
+}
+
+func TestCheckEtcdStatus_NoRestConfig(t *testing.T) {
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		etcdChecker: &mockEtcdHealthChecker{
+			output: "https://10.0.0.1:2379 is healthy: successfully committed proposal",
+		},
+	}
+
+	r := &investigation.Resources{
+		K8sClient: clientImpl{newFakeClient()},
+		IsHCP:     false,
+	}
+	inv.checkEtcdStatus(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "unable to get REST config") {
+		t.Errorf("expected 'unable to get REST config' warning, got:\n%s", output)
+	}
+}
+
+func TestCheckEtcdStatus_HCP(t *testing.T) {
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		etcdChecker: &mockEtcdHealthChecker{output: "healthy"},
+	}
+
+	r := &investigation.Resources{
+		K8sClient: clientImpl{newFakeClient()},
+		IsHCP:     true,
+	}
+	inv.checkEtcdStatus(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "skipped") {
+		t.Errorf("expected skipped message for HCP, got:\n%s", output)
+	}
+}
+
+func TestCheckEtcdStatus_Error(t *testing.T) {
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		etcdChecker: &mockEtcdHealthChecker{err: fmt.Errorf("etcd cluster is unhealthy")},
+	}
+
+	r := &investigation.Resources{
+		K8sClient:  clientImpl{newFakeClient()},
+		RestConfig: &backplane.RestConfig{},
+		IsHCP:      false,
+	}
+	inv.checkEtcdStatus(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "check failed") {
+		t.Errorf("expected 'check failed' warning, got:\n%s", output)
+	}
+}
+
+func TestCheckEtcdStatus_UnhealthyWithOutput(t *testing.T) {
+	notes := newTestNotes()
+
+	inv := &Investigation{
+		etcdChecker: &mockEtcdHealthChecker{
+			output: "https://10.0.0.1:2379 is healthy\nhttps://10.0.0.2:2379 is unhealthy",
+			err:    fmt.Errorf("etcd cluster is unhealthy"),
+		},
+	}
+
+	r := &investigation.Resources{
+		K8sClient:  clientImpl{newFakeClient()},
+		RestConfig: &backplane.RestConfig{},
+		IsHCP:      false,
+	}
+	inv.checkEtcdStatus(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "is unhealthy") {
+		t.Errorf("expected etcd output with unhealthy member, got:\n%s", output)
+	}
+	if strings.Contains(output, "check failed") {
+		t.Errorf("should show etcd output instead of generic 'check failed' when output is available, got:\n%s", output)
+	}
+}
+
+func TestCheckFailingPods_Truncation(t *testing.T) {
+	var pods []client.Object
+	for i := 0; i < 55; i++ {
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("bad-pod-%d", i), Namespace: "default"},
+			Status:     corev1.PodStatus{Phase: corev1.PodFailed, Reason: "OOMKilled"},
+		})
+	}
+
+	k8s := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(pods...).Build()
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkFailingPods(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "55 pod(s) with issues") {
+		t.Errorf("expected 55 pods count, got:\n%s", output)
+	}
+	if !strings.Contains(output, "... and 5 more") {
+		t.Errorf("expected truncation message, got:\n%s", output)
+	}
+}
+
+func TestCheckNonNormalEvents_Truncation(t *testing.T) {
+	var events []client.Object
+	for i := 0; i < 55; i++ {
+		events = append(events, &corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: fmt.Sprintf("warn-event-%d", i), Namespace: "default"},
+			Type:           "Warning",
+			Reason:         "BackOff",
+			Message:        "Back-off restarting failed container",
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: fmt.Sprintf("pod-%d", i)},
+		})
+	}
+
+	k8s := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(events...).Build()
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNonNormalEvents(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "55 non-normal event") {
+		t.Errorf("expected 55 events count, got:\n%s", output)
+	}
+	if !strings.Contains(output, "... and 5 more") {
+		t.Errorf("expected truncation message, got:\n%s", output)
+	}
+}
+
+func TestCheckNonNormalEvents_LongMessage(t *testing.T) {
+	longMsg := strings.Repeat("x", 200)
+	event := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "long-event", Namespace: "default"},
+		Type:           "Warning",
+		Reason:         "FailedMount",
+		Message:        longMsg,
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "test-pod"},
+	}
+
+	k8s := newFakeClient(event)
+	notes := newTestNotes()
+
+	inv := &Investigation{}
+	inv.checkNonNormalEvents(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "...") {
+		t.Errorf("expected truncated message with '...', got:\n%s", output)
+	}
+	if strings.Contains(output, longMsg) {
+		t.Errorf("expected message to be truncated, but found full message in output")
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected string
+	}{
+		{1024, "1Ki"},
+		{1024 * 1024, "1Mi"},
+		{1024 * 1024 * 1024, "1Gi"},
+		{2 * 1024 * 1024 * 1024, "2Gi"},
+		{512 * 1024, "512Ki"},
+		{256 * 1024 * 1024, "256Mi"},
+	}
+
+	for _, tt := range tests {
+		result := formatBytes(tt.input)
+		if result != tt.expected {
+			t.Errorf("formatBytes(%d) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}

--- a/pkg/investigations/clusterhealthcheck/metadata.yaml
+++ b/pkg/investigations/clusterhealthcheck/metadata.yaml
@@ -1,0 +1,45 @@
+name: clusterhealthcheck
+rbac:
+  roles:
+    - namespace: "openshift-etcd"
+      rules:
+        - apiGroups: ['']
+          resources: ['pods']
+          verbs: ['get', 'list']
+        - apiGroups: ['']
+          resources: ['pods/exec']
+          verbs: ['create']
+    - namespace: "openshift-monitoring"
+      rules:
+        - apiGroups: ['']
+          resources: ['pods']
+          verbs: ['get', 'list']
+        - apiGroups: ['']
+          resources: ['pods/exec']
+          verbs: ['create']
+  clusterRoleRules:
+    - apiGroups: ['']
+      resources: ['namespaces']
+      verbs: ['get', 'list', 'watch']
+    - apiGroups: ['']
+      resources: ['nodes', 'events']
+      verbs: ['get', 'list']
+    - apiGroups: ['']
+      resources: ['pods', 'pods/log']
+      verbs: ['get', 'list', 'watch']
+    - apiGroups: ['config.openshift.io']
+      resources: ['clusteroperators', 'clusterversions']
+      verbs: ['get', 'list']
+    - apiGroups: ['machineconfiguration.openshift.io']
+      resources: ['machineconfigpools']
+      verbs: ['get', 'list']
+    - apiGroups: ['certificates.k8s.io']
+      resources: ['certificatesigningrequests']
+      verbs: ['get', 'list']
+    - apiGroups: ['policy']
+      resources: ['poddisruptionbudgets']
+      verbs: ['get', 'list']
+    - apiGroups: ['metrics.k8s.io']
+      resources: ['nodes']
+      verbs: ['get', 'list']
+customerDataAccess: true

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/cannotretrieveupdatessre"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/chgm"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clusterhealthcheck"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clustermonitoringerrorbudgetburn"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/cpd"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/describenodes"
@@ -30,6 +31,7 @@ var availableInvestigations = []investigation.Investigation{
 	&cannotretrieveupdatessre.Investigation{},
 	&mustgather.Investigation{},
 	&describenodes.Investigation{},
+	&clusterhealthcheck.Investigation{},
 }
 
 // GetInvestigation returns the first Investigation that applies to the given alert title.

--- a/pkg/k8s/exec.go
+++ b/pkg/k8s/exec.go
@@ -63,11 +63,11 @@ func ExecInPod(ctx context.Context, restConfig *rest.Config, pod *corev1.Pod, co
 		Stderr: errorCapture,
 		Tty:    false,
 	})
+	cmdOutput := capture.GetStdOut()
 	if err != nil {
-		return "", fmt.Errorf("failed to execute command in pod: %w", err)
+		return cmdOutput, fmt.Errorf("failed to execute command in pod: %w", err)
 	}
 
-	cmdOutput := capture.GetStdOut()
 	return cmdOutput, nil
 }
 

--- a/pkg/k8s/scheme.go
+++ b/pkg/k8s/scheme.go
@@ -5,8 +5,11 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	certsv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -28,6 +31,18 @@ func initScheme() (*runtime.Scheme, error) {
 
 	if err := machinev1beta1.AddToScheme(scheme); err != nil {
 		return nil, fmt.Errorf("unable to add machine.openshift.io/v1beta1 scheme: %w", err)
+	}
+
+	if err := mcfgv1.Install(scheme); err != nil {
+		return nil, fmt.Errorf("unable to add machineconfiguration.openshift.io/v1 scheme: %w", err)
+	}
+
+	if err := certsv1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("unable to add certificates.k8s.io/v1 scheme: %w", err)
+	}
+
+	if err := policyv1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("unable to add policy/v1 scheme: %w", err)
 	}
 
 	return scheme, nil


### PR DESCRIPTION
### What type of PR is this?

feat

### What this PR does / Why we need it?

Implements a cluster-health-check action in CAD that replicates the functionality of the managed-scripts health/cluster-health-check (https://github.com/openshift/managed-scripts/tree/main/scripts/health/cluster-health-check).

### Special notes for your reviewer

- The firing alerts check uses pods/exec in openshift-monitoring to query the Alertmanager API via wget http://localhost:9093/api/v2/alerts inside the alertmanager pod. The managed-scripts version uses a route + OAuth proxy approach, but that seems to fail in-practice.

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [x] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental cluster health check investigation to diagnose API server health, operators/pods/nodes, CSRs, MachineConfigPools, alerts, events, capacity/utilization and cluster version/EOL status.
  * Includes metadata/RBAC to allow the check to access required cluster resources.

* **Bug Fixes**
  * Manual investigation short name now recognizes the "cluster-health-check" alias.

* **Tests**
  * Added comprehensive unit tests for the new investigation.

* **Documentation**
  * Added README documenting the cluster health check and deviations from existing implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->