### PR TITLE
[SREP-4770] When falling back to the AI investigation check cluster exists.

### DIFF
--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -193,6 +193,11 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 
 	// If no formal investigation found, check if AI investigation should run
 	if investigation == nil {
+		resp := clusterExists(pdClient, ocmClient, pdi.stats)
+		if resp != nil {
+			return resp
+		}
+
 		if shouldRunAIInvestigation() {
 			logging.Infof("Launching AI investigation")
 			return &triggersv1.InterceptorResponse{Continue: true}
@@ -210,6 +215,27 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 	return &triggersv1.InterceptorResponse{
 		Continue: true,
 	}
+}
+
+// clusterExists retrieves the cluster ID from PagerDuty and verifies it
+// exists in OCM. It returns the cluster ID on success, or a short-circuit
+// InterceptorResponse (Continue: false) on failure.
+func clusterExists(pdClient pagerduty.Client, ocmClient ocm.Client, stats *InterceptorStats) *triggersv1.InterceptorResponse {
+	clusterID, err := pdClient.RetrieveClusterID()
+	if err != nil {
+		logging.Warnf("Could not retrieve cluster id from PD incident")
+		stats.CodeWithReasonToErrorsCount[ErrorCodeWithReason{404, "no cluster id in pagerduty"}]++
+		return &triggersv1.InterceptorResponse{Continue: false}
+	}
+
+	_, err = ocmClient.GetClusterInfo(clusterID)
+	if err != nil {
+		logging.Warnf("Could not retrieve cluster from OCM: %s", clusterID)
+		stats.CodeWithReasonToErrorsCount[ErrorCodeWithReason{404, "no cluster in OCM"}]++
+		return &triggersv1.InterceptorResponse{Continue: false}
+	}
+
+	return nil
 }
 
 // shouldRunAIInvestigation checks whether AI investigation is configured at all.

--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -128,6 +128,89 @@ func TestReassignToOrgEscalationPolicy(t *testing.T) {
 	}
 }
 
+func TestClusterExists(t *testing.T) {
+	tests := []struct {
+		name           string
+		clusterID      string
+		clusterIDErr   error
+		clusterInfoErr error
+		expectContinue *bool                // nil means we expect no response (success)
+		expectErrorKey *ErrorCodeWithReason // nil means no error stat expected
+	}{
+		{
+			name:           "scenario 1: RetrieveClusterID fails — short-circuit Continue:false",
+			clusterIDErr:   errors.New("no cluster ID found"),
+			expectContinue: boolPtr(false),
+			expectErrorKey: &ErrorCodeWithReason{404, "no cluster id in pagerduty"},
+		},
+		{
+			name:           "scenario 2: RetrieveClusterID ok but GetClusterInfo fails — short-circuit Continue:false",
+			clusterID:      "cluster-abc",
+			clusterInfoErr: errors.New("cluster not found in OCM"),
+			expectContinue: boolPtr(false),
+			expectErrorKey: &ErrorCodeWithReason{404, "no cluster in OCM"},
+		},
+		{
+			name:           "scenario 3: both succeed — nil response, clusterID returned",
+			clusterID:      "cluster-abc",
+			expectContinue: nil,
+			expectErrorKey: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockPD := pdmock.NewMockClient(ctrl)
+			mockOCM := ocmmock.NewMockClient(ctrl)
+			stats := CreateInterceptorStats()
+
+			// Setup expectations
+			if tt.clusterIDErr != nil {
+				mockPD.EXPECT().RetrieveClusterID().Return("", tt.clusterIDErr).Times(1)
+			} else {
+				mockPD.EXPECT().RetrieveClusterID().Return(tt.clusterID, nil).Times(1)
+				if tt.clusterInfoErr != nil {
+					mockOCM.EXPECT().GetClusterInfo(tt.clusterID).Return(nil, tt.clusterInfoErr).Times(1)
+				} else {
+					mockOCM.EXPECT().GetClusterInfo(tt.clusterID).Return(nil, nil).Times(1)
+				}
+			}
+
+			// Execute
+			resp := clusterExists(mockPD, mockOCM, stats)
+
+			// Assert response
+			if tt.expectContinue == nil {
+				if resp != nil {
+					t.Errorf("validateCluster() resp = %+v, want nil", resp)
+				}
+			} else {
+				if resp == nil {
+					t.Fatal("validateCluster() resp = nil, want non-nil")
+				}
+				if resp.Continue != *tt.expectContinue {
+					t.Errorf("validateCluster() resp.Continue = %v, want %v", resp.Continue, *tt.expectContinue)
+				}
+			}
+
+			// Assert error stats
+			if tt.expectErrorKey != nil {
+				count, ok := stats.CodeWithReasonToErrorsCount[*tt.expectErrorKey]
+				if !ok || count != 1 {
+					t.Errorf("expected error stat %+v with count 1, got count %d (present=%v)", *tt.expectErrorKey, count, ok)
+				}
+			} else if len(stats.CodeWithReasonToErrorsCount) != 0 {
+				t.Errorf("expected no error stats, got %v", stats.CodeWithReasonToErrorsCount)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && stringContains(s, substr)
 }


### PR DESCRIPTION
If there is no PD ClusterID or the cluster does not exist in OCM do not run any investigation.

### What type of PR is this?

bug

### What this PR does / Why we need it?

The configfile addition removed an implicit check that the fallthrough investigation only ran when the cluster is actually found.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [X] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
