### PR TITLE
+Ignoring PD Escalation errors if the reason is a misconfigured escalation policy or wrong incident id.

### DIFF
--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -527,6 +527,12 @@ func (c *SdkClient) EscalateIncident() error {
 			logging.Infof("Skipped escalating incident as it is already resolved.")
 			return nil
 		}
+		// Error below can be encountered if the Escalation Policy is misconfigured with only 1 layer
+		// CAD requires 2 layers in its deployment scenario
+		if strings.Contains(err.Error(), "the escalation policy or incident id are invalid") {
+			logging.Warnf("Escalation policy invalid - probably nowhere higher to escalate, skipping escalation")
+			return nil
+		}
 		return fmt.Errorf("could not escalate the incident: %w", err)
 	}
 	return nil


### PR DESCRIPTION


### What type of PR is this?

other

### What this PR does / Why we need it?
The new code logs a warning when CAD encounters a misconfigured policy instead of failing an investigation.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incident escalation error handling in PagerDuty integration. Operations with invalid escalation policies or incident IDs are now handled gracefully instead of failing, with appropriate warnings logged for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->