### PR TITLE
Update osd-network-verifier to v1.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/backplane-api v0.0.0-20260205054653-459856398d59
 	github.com/openshift/backplane-cli v0.7.0
 	github.com/openshift/hive/apis v0.0.0-20250725035156-a29a23859060
-	github.com/openshift/osd-network-verifier v1.6.1
+	github.com/openshift/osd-network-verifier v1.7.0
 	github.com/openshift/osde2e-common v0.0.0-20250804220455-7806b74ec777
 	github.com/pkg/sftp v1.13.10
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ github.com/openshift/backplane-cli v0.7.0 h1:oq4AvLRGQnBLdDWrSOzB3boRWuAC3r1XXJe
 github.com/openshift/backplane-cli v0.7.0/go.mod h1:T9FMS0VDHzhFfrnJyFy4qy9VUaWs69DRSKULLbE+ybY=
 github.com/openshift/hive/apis v0.0.0-20250725035156-a29a23859060 h1:MIseGDYL78FNVjzoek+UcA94pbzEAnlpytdN6aaB8zc=
 github.com/openshift/hive/apis v0.0.0-20250725035156-a29a23859060/go.mod h1:XUEuhGkTuSXP+eb0LtY3/iJTs/3Fc18CVkqMsmgN+gg=
-github.com/openshift/osd-network-verifier v1.6.1 h1:3Qtlo24bgKNxNdhoYXWjc/UvtCL1k5kULa6lPsO93gg=
-github.com/openshift/osd-network-verifier v1.6.1/go.mod h1:WBsoc9YeIdm3ZtWPad+j20qxkgBDrRK2Kiu4N/MeenE=
+github.com/openshift/osd-network-verifier v1.7.0 h1:uYIA1Tk9y350QaIJXm/luXIwN/Gp5/sBtceHaeGUWn8=
+github.com/openshift/osd-network-verifier v1.7.0/go.mod h1:WBsoc9YeIdm3ZtWPad+j20qxkgBDrRK2Kiu4N/MeenE=
 github.com/openshift/osde2e-common v0.0.0-20250804220455-7806b74ec777 h1:tAgQfMTlBbfH88Q3pA6DeyifRZ4j0Yj6Wx9eySJDbuk=
 github.com/openshift/osde2e-common v0.0.0-20250804220455-7806b74ec777/go.mod h1:PVd8CEETL2pM+J4f0yLF6B+6PLfaZ2hVKiAOm+ejoFQ=
 github.com/openzipkin/zipkin-go v0.4.3 h1:9EGwpqkgnwdEIJ+Od7QVSEIH+ocmm5nPat0G7sjsSdg=


### PR DESCRIPTION
Updated the osd-network-verifier dependency from v1.6.1 to v1.7.0. All tests pass successfully with the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### What type of PR is this?
verifier version bump

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to their latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->