### PR TITLE
Add metrics tracking for manually triggered investigations

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -263,6 +263,14 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 	return nil, fmt.Errorf("no valid controller configuration provided")
 }
 
+// formatBool converts boolean to string for metrics labels
+func formatBool(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
 func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId string, inv investigation.Investigation, pdClient *pagerduty.SdkClient, filterCtx *types.FilterContext, params map[string]string) error {
 	metrics.Inc(metrics.Alerts, inv.Name())
 
@@ -299,6 +307,8 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 			}
 		}
 		if err != nil {
+			// Record error completion for manual investigations before handling failure
+			c.recordManualCompletion(inv.Name(), pdClient, "error")
 			handleCADFailure(err, builder, pdClient)
 		}
 	}()
@@ -313,16 +323,19 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 			return fmt.Errorf("failed to execute precheck actions: %w", err)
 		}
 		// We stop if the precheck returns any action this mean we do not want to run anything else.
+		c.recordManualCompletion(inv.Name(), pdClient, "precheck_stopped")
 		return nil
 	}
 	if result.StopInvestigations != nil {
 		logging.Errorf("Stopping investigations due to: %w", result.StopInvestigations)
+		c.recordManualCompletion(inv.Name(), pdClient, "stop_investigations")
 		return nil
 	}
 
 	// Evaluate the investigation filter if one is configured for this investigation.
 	// Only populate OCM fields (org ID, owner) when a filter actually needs them.
 	if filtered := c.evaluateFilter(inv.Name(), filterCtx, builder, clusterId, pdClient); filtered {
+		c.recordManualCompletion(inv.Name(), pdClient, "filtered")
 		return nil
 	}
 
@@ -344,6 +357,7 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 		// be able to proceed. To handle this case we will *only* return when CCAM found something and it's CGHM - handling
 		// non-AWS access is up to following investigations.
 		if inv.AlertTitle() == chgmInv.AlertTitle() {
+			c.recordManualCompletion(inv.Name(), pdClient, "ccam_stopped")
 			return nil
 		}
 	}
@@ -364,7 +378,13 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 	result = investigation.InvestigationResult{
 		Actions: []types.Action{&a},
 	}
-	return c.executeActions(builder, &result, inv.Name())
+	if err := c.executeActions(builder, &result, inv.Name()); err != nil {
+		return fmt.Errorf("failed to execute PagerDuty title update: %w", err)
+	}
+
+	// Record successful completion for manual investigations
+	c.recordManualCompletion(inv.Name(), pdClient, "success")
+	return nil
 }
 
 // runInvestigationWithRetry executes an investigation with retry logic for transient errors.
@@ -467,6 +487,16 @@ func updateMetrics(investigationName string, result *investigation.Investigation
 	}
 	if result.EtcdDatabaseAnalysis.Performed {
 		metrics.Inc(metrics.EtcdDatabaseAnalysis, append([]string{investigationName}, result.EtcdDatabaseAnalysis.Labels...)...)
+	}
+}
+
+// recordManualCompletion records manual investigation completion metric
+// Only tracks if this is a manual investigation (pdClient is nil)
+func (c *investigationRunner) recordManualCompletion(invName string, pdClient *pagerduty.SdkClient, status string) {
+	if pdClient == nil {
+		// This is a manual investigation
+		dryRun := formatBool(c.dryRun)
+		metrics.Inc(metrics.ManualInvestigationCompleted, invName, status, dryRun)
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -263,14 +263,6 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 	return nil, fmt.Errorf("no valid controller configuration provided")
 }
 
-// formatBool converts boolean to string for metrics labels
-func formatBool(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
-}
-
 func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId string, inv investigation.Investigation, pdClient *pagerduty.SdkClient, filterCtx *types.FilterContext, params map[string]string) error {
 	metrics.Inc(metrics.Alerts, inv.Name())
 
@@ -349,7 +341,7 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 
 	// Execute ccam actions if any
 	if len(result.Actions) > 0 {
-		if err := c.executeActions(builder, &result, "ccam"); err != nil {
+		if err = c.executeActions(builder, &result, "ccam"); err != nil {
 			return fmt.Errorf("failed to execute ccam actions: %w", err)
 		}
 		chgmInv := chgm.Investigation{}
@@ -369,8 +361,11 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 	}
 	updateMetrics(inv.Name(), &result)
 
+	// FIXME: This will work, once all notes are taken using executor note write and not the resources notes.
+	hasFindings := len(result.Actions) > 0
+
 	// Execute investigation actions if any
-	if err := c.executeActions(builder, &result, inv.Name()); err != nil {
+	if err = c.executeActions(builder, &result, inv.Name()); err != nil {
 		return fmt.Errorf("failed to execute %s actions: %w", inv.Name(), err)
 	}
 
@@ -378,12 +373,16 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 	result = investigation.InvestigationResult{
 		Actions: []types.Action{&a},
 	}
-	if err := c.executeActions(builder, &result, inv.Name()); err != nil {
+	if err = c.executeActions(builder, &result, inv.Name()); err != nil {
 		return fmt.Errorf("failed to execute PagerDuty title update: %w", err)
 	}
 
-	// Record successful completion for manual investigations
-	c.recordManualCompletion(inv.Name(), pdClient, "success")
+	// Record completion for manual investigations with outcome
+	if hasFindings {
+		c.recordManualCompletion(inv.Name(), pdClient, "success")
+	} else {
+		c.recordManualCompletion(inv.Name(), pdClient, "no_findings")
+	}
 	return nil
 }
 
@@ -495,7 +494,7 @@ func updateMetrics(investigationName string, result *investigation.Investigation
 func (c *investigationRunner) recordManualCompletion(invName string, pdClient *pagerduty.SdkClient, status string) {
 	if pdClient == nil {
 		// This is a manual investigation
-		dryRun := formatBool(c.dryRun)
+		dryRun := strconv.FormatBool(c.dryRun)
 		metrics.Inc(metrics.ManualInvestigationCompleted, invName, status, dryRun)
 	}
 }

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/aiassisted"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 )
 
@@ -63,6 +64,10 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 		investigationList := strings.Join(availableInvestigations, "\n")
 		return fmt.Errorf("unknown investigation: %s - must be one of:\n%s", c.manual.InvestigationName, investigationList)
 	}
+
+	// Track manual investigation start
+	dryRun := formatBool(c.dryRun)
+	metrics.Inc(metrics.ManualInvestigationStarted, alertInvestigation.Name(), dryRun)
 
 	// For AI investigations, create a new instance with the runtime config from the global config.
 	if _, ok := alertInvestigation.(*aiassisted.Investigation); ok {

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -66,7 +66,7 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 	}
 
 	// Track manual investigation start
-	dryRun := formatBool(c.dryRun)
+	dryRun := strconv.FormatBool(c.dryRun)
 	metrics.Inc(metrics.ManualInvestigationStarted, alertInvestigation.Name(), dryRun)
 
 	// For AI investigations, create a new instance with the runtime config from the global config.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -22,6 +22,8 @@ func Push() {
 		promPusher.Collector(MustGatherPerformed)
 		promPusher.Collector(EtcdDatabaseAnalysis)
 		promPusher.Collector(EtcdSnapshotCleanup)
+		promPusher.Collector(ManualInvestigationStarted)
+		promPusher.Collector(ManualInvestigationCompleted)
 		err := promPusher.Add()
 		if err != nil {
 			logging.Errorf("failed to push metrics: %w", err)
@@ -46,6 +48,8 @@ const (
 	alertTypeLabel       = "alert_type"
 	lsSummaryLabel       = "ls_summary"
 	mustgatherLabel      = "product"
+	dryRunLabel          = "dry_run"
+	statusLabel          = "status"
 )
 
 var (
@@ -97,4 +101,18 @@ var (
 			Name: "etcd_snapshot_cleanup_total",
 			Help: "counts etcd snapshot cleanup attempts by alert type and status",
 		}, []string{alertTypeLabel, "status"})
+	// ManualInvestigationStarted tracks when manual investigations are initiated
+	ManualInvestigationStarted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystemInvestigate,
+			Name: "manual_started_total",
+			Help: "counts manually triggered investigations by investigation name and dry-run mode",
+		}, []string{alertTypeLabel, dryRunLabel})
+	// ManualInvestigationCompleted tracks manual investigation outcomes
+	ManualInvestigationCompleted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystemInvestigate,
+			Name: "manual_completed_total",
+			Help: "counts manually triggered investigation completions by name, status, and dry-run mode",
+		}, []string{alertTypeLabel, statusLabel, dryRunLabel})
 )


### PR DESCRIPTION

### What type of PR is this?

feature
jira: https://redhat.atlassian.net/browse/SREP-4672

### What this PR does / Why we need it?

Introduces two new Prometheus CounterVec metrics to track manual investigation lifecycle:

- cad_investigate_manual_started_total: Tracks when manual investigations are initiated via 'cadctl run' command, with labels for investigation name and dry-run mode

- cad_investigate_manual_completed_total: Tracks investigation outcomes with status labels (success, error, filtered, precheck_stopped, stop_investigations, ccam_stopped) and dry-run mode

The metrics are only incremented for manual investigations (when pdClient is nil) and are pushed to the Prometheus Pushgateway alongside existing metrics. This enables monitoring of manual investigation usage, success rates, and operational efficiency.

All completion paths in runInvestigation() are instrumented to ensure accurate tracking across success, error, and early-exit scenarios.


### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive metrics for manual investigations: records when manual runs start and when they complete, capturing outcomes (error, precheck stopped, stopped, filtered, CCAM stopped, success, no findings) and whether runs are dry-run.

* **Bug Fixes**
  * Improved and clarified error message for failures during PagerDuty title update action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->