### PR TITLE
Fix renovate indirect deps config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,20 @@
     "gomod",
     "dockerfile"
   ],
+  "gomod": {
+    "packageRules": [
+      {
+        "description": "Disable major updates for indirect Go dependencies - they update when their parent dependency updates",
+        "matchUpdateTypes": [
+          "major"
+        ],
+        "matchDepTypes": [
+          "indirect"
+        ],
+        "enabled": false
+      }
+    ]
+  },
   "dockerfile": {
     "pinDigests": true
   },
@@ -72,26 +86,10 @@
       "matchUpdateTypes": [
         "major"
       ],
-      "matchDepTypes": [
-        "!indirect"
-      ],
       "addLabels": [
         "area/dependency",
         "ok-to-test"
       ]
-    },
-    {
-      "description": "Disable major updates for indirect Go dependencies - they update when their parent dependency updates",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "matchDepTypes": [
-        "indirect"
-      ],
-      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,7 +50,7 @@
         "dockerfile"
       ],
       "matchPackageNames": [
-        "redhat-services-prod/openshift/boilerplate",
+        "quay.io/redhat-services-prod/openshift/boilerplate",
         "openshift4/ose-operator-registry"
       ],
       "enabled": false


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?
The Mintmaker preset (konflux-ci/mintmaker) enables all indirect Go
module updates via gomod.packageRules. 
https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json#L614

Our top-level packageRules disable rule for major indirect updates was being overridden because manager-level packageRules are applied after top-level ones.

Also remove the non-functional matchDepTypes: ["!indirect"] from the
major updates manual review rule — matchDepTypes does not support
negation, so that filter was silently matching nothing.

Also fixes the path for the boilerplate image to avoid updating and pinning it, see https://github.com/openshift/configuration-anomaly-detection/pull/816
