### PR TITLE
Fix must-gather panel not editable on dashboard

### DIFF
--- a/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
+++ b/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
@@ -682,12 +682,14 @@ data:
               },
               "mappings": [
                 {
+                  "type": "special",
                   "options": {
-                    "null": {
-                      "text": "No alerts"
+                    "match": "null",
+                    "result": {
+                      "text": "No alerts",
+                      "index": 0
                     }
-                  },
-                  "type": "special"
+                  }
                 }
               ],
               "thresholds": {


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Fixes the Grafana value mapping schema on the "Must-Gather Success Rate" panel in the CAD dashboard. The mapping used an old Grafana format (options.null.text) instead of the current format (options.match + options.result.text), which caused a TypeError: can't access property "text", je.result is   undefined crash when attempting to edit the panel.

### Special notes for your reviewer

The panel renders fine in view mode — only the panel editor crashes. Other panels are unaffected because they don't use special type value mappings.

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "Must-Gather Success Rate" gauge configuration on the Grafana dashboard to improve how null values are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->