### PR TITLE
SREP-4911: Fix premature automation notes and distinguish uncertain infra cluster detection

### DIFF
--- a/docs/architecture/investigation-guidelines.md
+++ b/docs/architecture/investigation-guidelines.md
@@ -74,9 +74,10 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (result investigat
 
     // Perform investigation logic
     if problemDetected {
-        notes.AppendAutomation("Problem detected, sending service log and silencing alert")
+        notes.AppendWarning("Problem detected")
 
         // ✅ DO: Return actions for the executor to handle
+        // The executor will append automation notes after actions are actually executed.
         result.Actions = []types.Action{
             executor.NewServiceLogAction(sl.Severity, sl.Summary).
                 WithDescription(sl.Description).
@@ -271,7 +272,9 @@ Use when the customer has misconfigured something and can fix it themselves.
 
 ```go
 if customerMisconfigurationDetected {
-    notes.AppendAutomation("Customer misconfigured X, sending service log and silencing alert")
+    notes.AppendWarning("Customer misconfigured X")
+    // Note: Do NOT write "sending service log" in the notes here.
+    // The executor appends automation notes after actions are actually executed.
 
     serviceLog := &ocm.ServiceLog{
         Severity:    "Major",
@@ -298,7 +301,9 @@ Use when the customer performed an unsupported action (e.g., stopped instances).
 
 ```go
 if unsupportedActionDetected {
-    notes.AppendAutomation("Customer performed unsupported action, setting limited support")
+    notes.AppendWarning("Customer performed unsupported action")
+    // Note: Do NOT write "setting limited support" in the notes here.
+    // The executor appends automation notes after actions are actually executed.
 
     limitedSupportReason := ocm.LimitedSupportReason{
         Summary: "Cluster is in Limited Support due to unsupported action",

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -472,9 +472,6 @@ func handleCADFailure(err error, rb investigation.ResourceBuilder, pdClient *pag
 }
 
 func updateMetrics(investigationName string, result *investigation.InvestigationResult) {
-	if result.ServiceLogSent.Performed {
-		metrics.Inc(metrics.ServicelogSent, append([]string{investigationName}, result.ServiceLogSent.Labels...)...)
-	}
 	if result.ServiceLogPrepared.Performed {
 		metrics.Inc(metrics.ServicelogPrepared, append([]string{investigationName}, result.ServiceLogPrepared.Labels...)...)
 	}
@@ -520,7 +517,7 @@ func (c *investigationRunner) executeActions(
 	exec := c.executor
 	if resources.IsInfrastructureCluster {
 		logging.Infof("Infrastructure cluster detected for %s: wrapping executor to intercept LS/Silence/ServiceLog actions", investigationName)
-		exec = executor.NewInfraClusterExecutor(exec, c.logger)
+		exec = executor.NewInfraClusterExecutor(exec, c.logger, resources.IsInfrastructureClusterUncertain)
 	}
 
 	// Execute actions with default options using controller's executor

--- a/pkg/executor/actions.go
+++ b/pkg/executor/actions.go
@@ -81,7 +81,17 @@ func (a *ServiceLogAction) Execute(ctx context.Context, execCtx *ExecutionContex
 		}
 	}
 
-	return execCtx.OCMClient.PostServiceLog(execCtx.Cluster, a.ServiceLog)
+	if err := execCtx.OCMClient.PostServiceLog(execCtx.Cluster, a.ServiceLog); err != nil {
+		return err
+	}
+
+	// Append to notes after successful send so the PD note
+	// accurately reflects what happened.
+	if execCtx.Notes != nil {
+		execCtx.Notes.AppendAutomation("Sent SL: '%s'", a.ServiceLog.Summary)
+	}
+
+	return nil
 }
 
 // LimitedSupportAction sets a cluster into limited support
@@ -126,7 +136,15 @@ func (a *LimitedSupportAction) Execute(ctx context.Context, execCtx *ExecutionCo
 		a.Reason.Summary, a.Context)
 
 	// Note: OCM API handles duplicate checking internally
-	return execCtx.OCMClient.PostLimitedSupportReason(execCtx.Cluster, a.Reason)
+	if err := execCtx.OCMClient.PostLimitedSupportReason(execCtx.Cluster, a.Reason); err != nil {
+		return err
+	}
+
+	if execCtx.Notes != nil {
+		execCtx.Notes.AppendAutomation("Sent LS: '%s'", a.Reason.Summary)
+	}
+
+	return nil
 }
 
 // PagerDutyNoteAction adds a note to the current PagerDuty incident

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -464,7 +464,7 @@ func TestInfraClusterExecutor_InterceptsLimitedSupportAndSilence(t *testing.T) {
 	mockPDClient.EXPECT().EscalateIncident().Return(nil)
 
 	inner := NewWebhookExecutor(mockOCMClient, mockPDClient, mockBPClient, logger)
-	exec := NewInfraClusterExecutor(inner, logger)
+	exec := NewInfraClusterExecutor(inner, logger, false)
 
 	limitedSupportExecuted := false
 	silenceExecuted := false
@@ -507,7 +507,7 @@ func TestInfraClusterExecutor_InterceptsServiceLog(t *testing.T) {
 	mockPDClient.EXPECT().EscalateIncident().Return(nil)
 
 	inner := NewWebhookExecutor(mockOCMClient, mockPDClient, mockBPClient, logger)
-	exec := NewInfraClusterExecutor(inner, logger)
+	exec := NewInfraClusterExecutor(inner, logger, false)
 
 	serviceLogExecuted := false
 	pdNoteExecuted := false
@@ -544,7 +544,7 @@ func TestInfraClusterExecutor_PassesThroughNonInterceptedActions(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 
 	inner := NewWebhookExecutor(mockOCMClient, mockPDClient, mockBPClient, logger)
-	exec := NewInfraClusterExecutor(inner, logger)
+	exec := NewInfraClusterExecutor(inner, logger, false)
 
 	pdNoteExecuted := false
 	escalateExecuted := false
@@ -585,7 +585,7 @@ func TestInfraClusterExecutor_NoActionsToIntercept(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 
 	inner := NewWebhookExecutor(mockOCMClient, mockPDClient, mockBPClient, logger)
-	exec := NewInfraClusterExecutor(inner, logger)
+	exec := NewInfraClusterExecutor(inner, logger, false)
 
 	escalateExecuted := false
 
@@ -620,7 +620,7 @@ func TestInfraClusterExecutor_NilInput(t *testing.T) {
 	mockBPClient := &bpmock.MockClient{}
 
 	inner := NewWebhookExecutor(mockOCMClient, mockPDClient, mockBPClient, logger)
-	exec := NewInfraClusterExecutor(inner, logger)
+	exec := NewInfraClusterExecutor(inner, logger, false)
 
 	err := exec.Execute(context.Background(), nil)
 
@@ -641,7 +641,7 @@ func TestInfraClusterExecutor_IntegrationAllIntercepted(t *testing.T) {
 	mockPDClient.EXPECT().EscalateIncident().Return(nil)
 
 	inner := NewWebhookExecutor(mockOCMClient, mockPDClient, mockBPClient, logger)
-	exec := NewInfraClusterExecutor(inner, logger)
+	exec := NewInfraClusterExecutor(inner, logger, false)
 
 	limitedSupportExecuted := false
 	silenceExecuted := false
@@ -672,6 +672,92 @@ func TestInfraClusterExecutor_IntegrationAllIntercepted(t *testing.T) {
 	assert.False(t, serviceLogExecuted, "ServiceLog should be intercepted")
 	assert.False(t, silenceExecuted, "Silence should be intercepted")
 	assert.True(t, backplaneExecuted, "Backplane report should pass through")
+}
+
+func TestInfraClusterExecutor_UncertainUsesAlternateNote(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOCMClient := ocmmock.NewMockClient(ctrl)
+	mockPDClient := pdmock.NewMockClient(ctrl)
+	mockBPClient := &bpmock.MockClient{}
+	logger := zap.NewNop().Sugar()
+
+	var capturedNote string
+	mockPDClient.EXPECT().AddNote(gomock.Any()).DoAndReturn(func(note string) error {
+		capturedNote = note
+		return nil
+	})
+	mockPDClient.EXPECT().EscalateIncident().Return(nil)
+
+	inner := NewWebhookExecutor(mockOCMClient, mockPDClient, mockBPClient, logger)
+	exec := NewInfraClusterExecutor(inner, logger, true)
+
+	serviceLogExecuted := false
+
+	actions := []Action{
+		&mockAction{actionType: ActionTypeServiceLog, executed: &serviceLogExecuted},
+	}
+
+	cluster, _ := cmv1.NewCluster().ID("test-cluster").Build()
+	input := &ExecutorInput{
+		InvestigationName: "test-investigation",
+		Actions:           actions,
+		Cluster:           cluster,
+		Options: ExecutionOptions{
+			ConcurrentActions: false,
+		},
+	}
+
+	err := exec.Execute(context.Background(), input)
+
+	assert.NoError(t, err)
+	assert.False(t, serviceLogExecuted, "ServiceLog should be intercepted")
+	assert.Contains(t, capturedNote, "Unable to determine cluster infrastructure status")
+	assert.NotContains(t, capturedNote, "Infra cluster detected")
+}
+
+func TestInfraClusterExecutor_ConfirmedUsesInfraNote(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOCMClient := ocmmock.NewMockClient(ctrl)
+	mockPDClient := pdmock.NewMockClient(ctrl)
+	mockBPClient := &bpmock.MockClient{}
+	logger := zap.NewNop().Sugar()
+
+	var capturedNote string
+	mockPDClient.EXPECT().AddNote(gomock.Any()).DoAndReturn(func(note string) error {
+		capturedNote = note
+		return nil
+	})
+	mockPDClient.EXPECT().EscalateIncident().Return(nil)
+
+	inner := NewWebhookExecutor(mockOCMClient, mockPDClient, mockBPClient, logger)
+	exec := NewInfraClusterExecutor(inner, logger, false)
+
+	serviceLogExecuted := false
+
+	actions := []Action{
+		&mockAction{actionType: ActionTypeServiceLog, executed: &serviceLogExecuted},
+	}
+
+	cluster, _ := cmv1.NewCluster().ID("test-cluster").Build()
+	input := &ExecutorInput{
+		InvestigationName: "test-investigation",
+		Actions:           actions,
+		Cluster:           cluster,
+		Options: ExecutionOptions{
+			ConcurrentActions: false,
+		},
+	}
+
+	err := exec.Execute(context.Background(), input)
+
+	assert.NoError(t, err)
+	assert.False(t, serviceLogExecuted, "ServiceLog should be intercepted")
+	assert.Contains(t, capturedNote, "Infra cluster detected")
+	assert.NotContains(t, capturedNote, "Unable to determine")
 }
 
 func TestJoinDescriptions(t *testing.T) {

--- a/pkg/executor/reporter.go
+++ b/pkg/executor/reporter.go
@@ -157,14 +157,16 @@ func isPagerDutyAction(action Action) bool {
 // Limited Support, Silence, and SL actions are replaced with an escalation and
 // a PagerDuty note explaining the substitution.
 type InfraClusterExecutor struct {
-	inner  Executor
-	logger *zap.SugaredLogger
+	inner     Executor
+	logger    *zap.SugaredLogger
+	uncertain bool
 }
 
 // NewInfraClusterExecutor creates an executor that intercepts unsuitable actions
-// for infrastructure clusters.
-func NewInfraClusterExecutor(inner Executor, logger *zap.SugaredLogger) Executor {
-	return &InfraClusterExecutor{inner: inner, logger: logger}
+// for infrastructure clusters. When uncertain is true, the infra status could not
+// be confirmed (e.g. OCM API error) and the note will reflect this.
+func NewInfraClusterExecutor(inner Executor, logger *zap.SugaredLogger, uncertain bool) Executor {
+	return &InfraClusterExecutor{inner: inner, logger: logger, uncertain: uncertain}
 }
 
 func (e *InfraClusterExecutor) Execute(ctx context.Context, input *ExecutorInput) error {
@@ -207,14 +209,25 @@ func (e *InfraClusterExecutor) Execute(ctx context.Context, input *ExecutorInput
 	}
 
 	if needsEscalation {
-		noteContent := fmt.Sprintf(
-			"⚠️ Infra cluster detected: the following action(s) were not executed and replaced with escalation: %s. "+
-				"Please investigate and take appropriate action manually.",
-			joinDescriptions(interceptedDescriptions),
-		)
+		var noteContent string
+		if e.uncertain {
+			noteContent = fmt.Sprintf(
+				"⚠️ Unable to determine cluster infrastructure status (OCM API error). "+
+					"Erring on the side of caution, the following action(s) were not executed and replaced with escalation: %s. "+
+					"Please verify whether this is an infrastructure cluster and take appropriate action manually.",
+				joinDescriptions(interceptedDescriptions),
+			)
+		} else {
+			noteContent = fmt.Sprintf(
+				"⚠️ Infra cluster detected: the following action(s) were not executed and replaced with escalation: %s. "+
+					"Please investigate and take appropriate action manually.",
+				joinDescriptions(interceptedDescriptions),
+			)
+		}
 		transformedActions = append(transformedActions, &PagerDutyNoteAction{Content: noteContent})
 		if !hasEscalation {
-			transformedActions = append(transformedActions,
+			transformedActions = append(
+				transformedActions,
 				&EscalateIncidentAction{Reason: "Infra cluster: actions intercepted"},
 			)
 		}
@@ -239,7 +252,8 @@ func joinDescriptions(descriptions []string) string {
 	if len(unique) == 1 {
 		return unique[0]
 	}
-	return fmt.Sprintf("%s and %s",
+	return fmt.Sprintf(
+		"%s and %s",
 		joinWithComma(unique[:len(unique)-1]),
 		unique[len(unique)-1],
 	)

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -73,7 +73,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	if !res.UserAuthorized {
 		logging.Infof("Instances were stopped by unauthorized user: %s / arn: %s", res.User.UserName, res.User.IssuerUserName)
-		r.Notes.AppendAutomation("Customer stopped instances. Sent LS and silencing alert.")
+		r.Notes.AppendWarning("Customer stopped instances.")
 
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
@@ -113,7 +113,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		logging.Infof("Network verifier reported failure: %s", failureReason)
 
 		if strings.Contains(failureReason, "nosnch.in") {
-			r.Notes.AppendAutomation("Egress `nosnch.in` blocked, sent limited support.")
+			r.Notes.AppendWarning("Egress `nosnch.in` blocked.")
 
 			result.Actions = append(
 				executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
@@ -127,7 +127,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		docLink := ocm.DocumentationLink(product, ocm.DocumentationTopicPrivatelinkFirewall)
 		egressSL := createEgressSL(failureReason, docLink)
 
-		r.Notes.AppendWarning("NetworkVerifier found unreachable targets and sent the SL, but deadmanssnitch is not blocked! \n⚠️ Please investigate this cluster.\nUnreachable: \n%s", failureReason)
+		r.Notes.AppendWarning("NetworkVerifier found unreachable targets, but deadmanssnitch is not blocked! \n⚠️ Please investigate this cluster.\nUnreachable: \n%s", failureReason)
 
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -106,7 +106,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (result investigat
 	// Check if the UWM configmap is invalid
 	// If it is, send a service log and silence the alert.
 	if isUWMConfigInvalid(&monitoringCo) {
-		notes.AppendAutomation("Customer misconfigured the UWM configmap, sending service log and silencing the alert")
+		notes.AppendWarning("Customer misconfigured the UWM configmap")
 		configMapSL := newUwmConfigMapMisconfiguredSL(monitoringDocLink)
 
 		result.Actions = append(
@@ -121,7 +121,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (result investigat
 	}
 
 	if isUWMAlertManagerBroken(&monitoringCo) {
-		notes.AppendAutomation("Customer misconfigured the UWM (UpdatingUserWorkloadAlertmanager), sending service log and silencing the alert")
+		notes.AppendWarning("Customer misconfigured the UWM (UpdatingUserWorkloadAlertmanager)")
 		alertManagerSL := newUwmAMMisconfiguredSL(monitoringDocLink)
 
 		result.Actions = append(
@@ -136,7 +136,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (result investigat
 	}
 
 	if isUWMPrometheusBroken(&monitoringCo) {
-		notes.AppendAutomation("Customer misconfigured the UWM (UpdatingUserWorkloadPrometheus), sending service log and silencing the alert")
+		notes.AppendWarning("Customer misconfigured the UWM (UpdatingUserWorkloadPrometheus)")
 		genericSL := newUwmGenericMisconfiguredSL(monitoringDocLink)
 
 		result.Actions = append(

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -100,11 +100,6 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 				notes.AppendWarning("subnet %s does not have a default route to 0.0.0.0/0", subnet)
 				byovpcRoutingSL := newBYOVPCRoutingSL(docLink)
 
-				// XXX: metrics.Inc(metrics.ServicelogSent, investigationName)
-				result.ServiceLogSent = investigation.InvestigationStep{Performed: true, Labels: nil}
-
-				notes.AppendAutomation("Sent SL: '%s'", byovpcRoutingSL.Summary)
-
 				result.Actions = append(
 					executor.NoteAndReportFrom(notes, r.Cluster.ID(), c.Name()),
 					executor.NewServiceLogAction(byovpcRoutingSL.Severity, byovpcRoutingSL.Summary).

--- a/pkg/investigations/investigation/investigation.go
+++ b/pkg/investigations/investigation/investigation.go
@@ -33,7 +33,6 @@ type InvestigationResult struct {
 	// EXISTING: Legacy fields (deprecated, maintained for backwards compatibility)
 	LimitedSupportSet    InvestigationStep
 	ServiceLogPrepared   InvestigationStep
-	ServiceLogSent       InvestigationStep
 	MustGatherPerformed  InvestigationStep
 	EtcdDatabaseAnalysis InvestigationStep
 
@@ -80,27 +79,28 @@ type Investigation interface {
 
 // Resources holds all resources/tools required for alert investigations
 type Resources struct {
-	Name                          string
-	Cluster                       *cmv1.Cluster
-	ClusterDeployment             *hivev1.ClusterDeployment
-	AwsClient                     aws.Client
-	BpClient                      backplane.Client
-	RestConfig                    *backplane.RestConfig
-	K8sClient                     k8sclient.Client
-	OcmClient                     ocm.Client
-	PdClient                      pagerduty.Client
-	Notes                         *notewriter.NoteWriter
-	OCClient                      oc.Client
-	ManagementRestConfig          *backplane.RestConfig
-	ManagementK8sClient           k8sclient.Client
-	ManagementOCClient            oc.Client
-	HCPNamespace                  string
-	HCNamespace                   string
-	IsHCP                         bool
-	IsInfrastructureCluster       bool
-	ManagementClusterName         string
-	DynatraceManagementClusterURL string
-	Params                        map[string]string
+	Name                             string
+	Cluster                          *cmv1.Cluster
+	ClusterDeployment                *hivev1.ClusterDeployment
+	AwsClient                        aws.Client
+	BpClient                         backplane.Client
+	RestConfig                       *backplane.RestConfig
+	K8sClient                        k8sclient.Client
+	OcmClient                        ocm.Client
+	PdClient                         pagerduty.Client
+	Notes                            *notewriter.NoteWriter
+	OCClient                         oc.Client
+	ManagementRestConfig             *backplane.RestConfig
+	ManagementK8sClient              k8sclient.Client
+	ManagementOCClient               oc.Client
+	HCPNamespace                     string
+	HCNamespace                      string
+	IsHCP                            bool
+	IsInfrastructureCluster          bool
+	IsInfrastructureClusterUncertain bool
+	ManagementClusterName            string
+	DynatraceManagementClusterURL    string
+	Params                           map[string]string
 }
 
 type ResourceBuilder interface {
@@ -231,6 +231,7 @@ func (r *ResourceBuilderT) Build() (*Resources, error) {
 		if err != nil {
 			logging.Warnf("Failed to check if cluster %s is a managing cluster: %v. Assuming it IS a managing cluster (fail-closed).", internalID, err)
 			r.builtResources.IsInfrastructureCluster = true
+			r.builtResources.IsInfrastructureClusterUncertain = true
 		} else {
 			r.builtResources.IsInfrastructureCluster = isManaging
 			if isManaging {


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [x] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved infrastructure-cluster handling during API failures, including correct PagerDuty wording and escalation behavior.
  * Service log and limited-support actions now surface posting errors and add follow-up notes only after success.
  * Investigation notes now consistently use warning-style, customer-focused text (with automation wording removed).
* **Documentation**
  * Refreshed investigation-writing guidelines to reflect the updated note patterns.
* **Tests**
  * Added coverage for infra-cluster “uncertain” vs “detected” note content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->