### PR TITLE
Assume cora invoker role

### DIFF
--- a/docs/investigation-filter-config.example.yaml
+++ b/docs/investigation-filter-config.example.yaml
@@ -91,18 +91,14 @@
 # AI investigation is enabled.
 #
 # ai_agent:
-#   runtime_arn: "arn:aws:bedrock:us-east-1:123456789012:agent-runtime/EXAMPLE"
-#   user_id: "cad-agent"
+#   runtime_arn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/rosasreai_stage-abc123"
+#   user_id: "cad-service-account"
 #   region: "us-east-1"
+#   invoker_role_arn: "arn:aws:iam::123456789012:role/rosasreai_stage-invoker"
 #   timeout_seconds: 900              # Optional, defaults to 900 (15 min)
 #   version: "v1.0.0"                 # Optional, audit trail only
 #   ops_sop_version: "v2.0.0"         # Optional, audit trail only
 #   rosa_plugins_version: "v3.0.0"    # Optional, audit trail only
-# ai_agent:
-#   runtime_arn: "arn:aws:bedrock:us-east-1:123456789012:agent-runtime/EXAMPLE"
-#   user_id: "cad-agent"
-#   region: "us-east-1"
-#   timeout_seconds: 900
 
 filters:
   # Enable AI investigation for specific clusters or organizations.

--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -271,6 +271,7 @@ ai_agent:
   runtime_arn: "arn:test"
   user_id: "test"
   region: "us-east-1"
+  invoker_role_arn: "arn:aws:iam::123456789012:role/test"
 filters:
   - investigation: aiassisted
     when:
@@ -288,6 +289,7 @@ ai_agent:
   runtime_arn: "arn:test"
   user_id: "test"
   region: "us-east-1"
+  invoker_role_arn: "arn:aws:iam::123456789012:role/test"
 filters:
   - investigation: aiassisted
 `,

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -113,6 +113,16 @@ func GetAIClient(ctx context.Context, roleArn, region, sessionIdentifier string)
 		return nil, fmt.Errorf("failed to assume IAM role: %w", err)
 	}
 
+	// Defensive nil-check for assumed role credentials
+	if assumeRoleOutput.Credentials == nil {
+		return nil, fmt.Errorf("STS AssumeRole returned nil credentials")
+	}
+	if assumeRoleOutput.Credentials.AccessKeyId == nil ||
+		assumeRoleOutput.Credentials.SecretAccessKey == nil ||
+		assumeRoleOutput.Credentials.SessionToken == nil {
+		return nil, fmt.Errorf("STS AssumeRole returned incomplete credentials")
+	}
+
 	// Create new AWS config with the assumed role credentials
 	awsCfg.Credentials = credentialsv2.NewStaticCredentialsProvider(
 		*assumeRoleOutput.Credentials.AccessKeyId,

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -11,6 +11,8 @@ import (
 
 	// V2 SDK
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awssdk "github.com/aws/aws-sdk-go-v2/config"
+	credentialsv2 "github.com/aws/aws-sdk-go-v2/credentials"
 	bedrockagentcore "github.com/aws/aws-sdk-go-v2/service/bedrockagentcore"
 	cloudtrailv2 "github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	cloudtrailv2types "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
@@ -83,6 +85,43 @@ func NewClient(config awsv2.Config) (*SdkClient, error) {
 // runtime lives (not customer account credentials).
 func NewAgentCoreClient(config awsv2.Config) AgentCoreAPI {
 	return bedrockagentcore.NewFromConfig(config)
+}
+
+// GetAIClient creates an AgentCore client by assuming the specified IAM role.
+// This function handles the role assumption and returns a configured AgentCore client.
+// The roleArn parameter is the IAM role to assume for invoking AgentCore.
+// The region parameter specifies the AWS region where the AgentCore runtime is deployed.
+// The sessionIdentifier is included in the session name for audit trail purposes.
+func GetAIClient(ctx context.Context, roleArn, region, sessionIdentifier string) (AgentCoreAPI, error) {
+	// Load default AWS config. CAD's deployment credentials have permission to assume the invoker role.
+	awsCfg, err := awssdk.LoadDefaultConfig(ctx, awssdk.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	// Set up STS client for role assumption
+	stsClient := stsv2.NewFromConfig(awsCfg)
+
+	// Include session identifier for audit trail in CloudTrail logs
+	sessionName := fmt.Sprintf("CAD-AI-Investigation-%s", sessionIdentifier)
+	assumeRoleOutput, err := stsClient.AssumeRole(ctx, &stsv2.AssumeRoleInput{
+		RoleArn:         awsv2.String(roleArn),
+		RoleSessionName: awsv2.String(sessionName),
+		DurationSeconds: awsv2.Int32(3600), // 1 hour
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to assume IAM role: %w", err)
+	}
+
+	// Create new AWS config with the assumed role credentials
+	awsCfg.Credentials = credentialsv2.NewStaticCredentialsProvider(
+		*assumeRoleOutput.Credentials.AccessKeyId,
+		*assumeRoleOutput.Credentials.SecretAccessKey,
+		*assumeRoleOutput.Credentials.SessionToken,
+	)
+
+	// Create and return AgentCore client
+	return NewAgentCoreClient(awsCfg), nil
 }
 
 // GetAWSCredentials gets the AWS credentials

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,9 +23,10 @@ const (
 
 // AIAgentConfig holds runtime configuration for AgentCore AI investigations.
 type AIAgentConfig struct {
-	RuntimeARN string `yaml:"runtime_arn"` // AWS ARN of the agent runtime to invoke
-	UserID     string `yaml:"user_id"`     // Used for audit trail only
-	Region     string `yaml:"region"`
+	RuntimeARN     string `yaml:"runtime_arn"`      // AWS ARN of the agent runtime to invoke
+	UserID         string `yaml:"user_id"`          // Used for audit trail only
+	Region         string `yaml:"region"`           // AWS region where the agent runtime is deployed
+	InvokerRoleArn string `yaml:"invoker_role_arn"` // IAM role ARN to assume for invoking the agent runtime
 
 	// Version Metadata (for audit trail in notes/reports)
 	Version            string `yaml:"version,omitempty"`              // Agent runtime version to validate
@@ -82,6 +83,7 @@ type legacyAIAgentConfig struct {
 	RuntimeARN         string   `json:"runtime_arn"`
 	UserID             string   `json:"user_id"`
 	Region             string   `json:"region"`
+	InvokerRoleArn     string   `json:"invoker_role_arn,omitempty"`
 	Version            string   `json:"version,omitempty"`
 	OpsSopVersion      string   `json:"ops_sop_version,omitempty"`
 	RosaPluginsVersion string   `json:"rosa_plugins_version,omitempty"`
@@ -127,6 +129,7 @@ func loadLegacyAIConfig() (*Config, error) {
 			RuntimeARN:         legacy.RuntimeARN,
 			UserID:             legacy.UserID,
 			Region:             legacy.Region,
+			InvokerRoleArn:     legacy.InvokerRoleArn,
 			Version:            legacy.Version,
 			OpsSopVersion:      legacy.OpsSopVersion,
 			RosaPluginsVersion: legacy.RosaPluginsVersion,
@@ -212,6 +215,9 @@ func (c *Config) Validate(validInvestigations []string) error {
 		}
 		if c.AIAgent.UserID == "" {
 			return fmt.Errorf("ai_agent: user_id must not be empty")
+		}
+		if c.AIAgent.InvokerRoleArn == "" {
+			return fmt.Errorf("ai_agent: invoker_role_arn must not be empty")
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,8 +25,8 @@ const (
 type AIAgentConfig struct {
 	RuntimeARN     string `yaml:"runtime_arn"`      // AWS ARN of the agent runtime to invoke
 	UserID         string `yaml:"user_id"`          // Used for audit trail only
-	Region         string `yaml:"region"`           // AWS region where the agent runtime is deployed
-	InvokerRoleArn string `yaml:"invoker_role_arn"` // IAM role ARN to assume for invoking the agent runtime
+	Region         string `yaml:"region"`           // AWS region where AgentCore is deployed
+	InvokerRoleArn string `yaml:"invoker_role_arn"` // IAM role ARN to assume for invoking AgentCore
 
 	// Version Metadata (for audit trail in notes/reports)
 	Version            string `yaml:"version,omitempty"`              // Agent runtime version to validate

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -350,6 +350,17 @@ filters: []
 			wantErr: true,
 		},
 		{
+			name: "ai_agent missing invoker_role_arn",
+			yaml: `
+ai_agent:
+  runtime_arn: "arn:test"
+  user_id: "user"
+  region: "us-east-1"
+filters: []
+`,
+			wantErr: true,
+		},
+		{
 			name: "config without ai_agent is valid",
 			yaml: testMustgatherFilterYAML,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -262,6 +262,7 @@ ai_agent:
   runtime_arn: "arn:aws:bedrock:us-east-1:123456789012:agent-runtime/test"
   user_id: "cad-agent"
   region: "us-east-1"
+  invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
   timeout_seconds: 600
   version: "v1.0.0"
   ops_sop_version: "v2.0.0"
@@ -301,6 +302,7 @@ ai_agent:
   runtime_arn: "arn:test"
   user_id: "user"
   region: "us-east-1"
+  invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
 filters:
   - investigation: aiassisted
     when:

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -68,7 +68,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	aiConfig := c.AIConfig
 
 	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), aiConfig.GetTimeout())
+	ctx, cancel := context.WithTimeout(context.TODO(), aiConfig.GetTimeout())
 	defer cancel()
 
 	// Get PagerDuty incident details

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -11,11 +11,7 @@ import (
 	"strings"
 	"time"
 
-	awsconfig "github.com/aws/aws-sdk-go-v2/aws"
-	awssdk "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	"github.com/openshift/configuration-anomaly-detection/pkg/config"
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
@@ -69,67 +65,11 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		return result, nil
 	}
 
-	config := c.AIConfig
+	aiConfig := c.AIConfig
 
 	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), config.GetTimeout())
+	ctx, cancel := context.WithTimeout(context.Background(), aiConfig.GetTimeout())
 	defer cancel()
-
-	// Load default AWS config (uses default credential chain)
-	awsCfg, err := awssdk.LoadDefaultConfig(ctx, awssdk.WithRegion(config.Region))
-	if err != nil {
-		notes.AppendWarning("Failed to load AWS config: %v", err)
-		result.Actions = append(
-			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
-			executor.Escalate("Failed to load AWS config"),
-		)
-		return result, nil
-	}
-
-	// Assume the CORA invoker IAM role with permissions to call AgentCore
-	roleArnToAssume := config.InvokerRoleArn
-
-	// Create STS client to assume the role
-	stsClient := sts.NewFromConfig(awsCfg)
-
-	// Get and log the identity of the original caller
-	callerIdentity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-	if err != nil {
-		logging.Warnf("Failed to get original caller identity: %v", err)
-	} else {
-		logging.Infof("Original Caller: %s", *callerIdentity.Arn)
-	}
-
-	// Assume the role
-	assumeRoleOutput, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
-		RoleArn:         &roleArnToAssume,
-		RoleSessionName: awsconfig.String("CAD-AI-Investigation"),
-		DurationSeconds: awsconfig.Int32(3600), // 1 hour
-	})
-	if err != nil {
-		notes.AppendWarning("Failed to assume IAM role: %v", err)
-		result.Actions = append(
-			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
-			executor.Escalate("Failed to assume IAM role"),
-		)
-		return result, nil
-	}
-
-	// Create new AWS config with the assumed role credentials
-	awsCfg.Credentials = credentials.NewStaticCredentialsProvider(
-		*assumeRoleOutput.Credentials.AccessKeyId,
-		*assumeRoleOutput.Credentials.SecretAccessKey,
-		*assumeRoleOutput.Credentials.SessionToken,
-	)
-
-	// Verify the assumed role identity
-	stsClient2 := sts.NewFromConfig(awsCfg)
-	callerIdentity2, err := stsClient2.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-	if err != nil {
-		logging.Warnf("Failed to get assumed role caller identity: %v", err)
-	} else {
-		logging.Infof("AssumedRole Caller: %s", *callerIdentity2.Arn)
-	}
 
 	// Get PagerDuty incident details
 	pdClient, ok := r.PdClient.(*pagerduty.SdkClient)
@@ -164,8 +104,17 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		return result, nil
 	}
 
-	// Create AgentCore client
-	agentClient := aws.NewAgentCoreClient(awsCfg)
+	// Get AI client (handles role assumption and client creation)
+	// Use incident ID as session identifier for audit trail
+	agentClient, err := aws.GetAIClient(ctx, aiConfig.InvokerRoleArn, aiConfig.Region, incidentID)
+	if err != nil {
+		notes.AppendWarning("Failed to create AI client: %v", err)
+		result.Actions = append(
+			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
+			executor.Escalate("Failed to create AI client"),
+		)
+		return result, nil
+	}
 
 	// TODO: Move session ID generation outside of AI investigation so all investigations have unique IDs
 	// This will require adapting this code to use the externally-generated ID instead
@@ -179,10 +128,10 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	// Request streaming response format
 	acceptHeader := "text/event-stream"
 	input := &bedrockagentcore.InvokeAgentRuntimeInput{
-		AgentRuntimeArn:  &config.RuntimeARN,
+		AgentRuntimeArn:  &aiConfig.RuntimeARN,
 		RuntimeSessionId: &sessionID,
 		Payload:          payloadJSON,
-		RuntimeUserId:    &config.UserID,
+		RuntimeUserId:    &aiConfig.UserID,
 		Accept:           &acceptHeader, // Force streaming response
 	}
 
@@ -206,15 +155,15 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	var aiResponse strings.Builder
 	aiResponse.WriteString("🤖 AI Investigation Results 🤖\n")
 	fmt.Fprintf(&aiResponse, "Session ID: %s\n", sessionID)
-	fmt.Fprintf(&aiResponse, "Runtime: %s\n", config.RuntimeARN)
-	if config.Version != "" {
-		fmt.Fprintf(&aiResponse, "Agent Version: %s\n", config.Version)
+	fmt.Fprintf(&aiResponse, "Runtime: %s\n", aiConfig.RuntimeARN)
+	if aiConfig.Version != "" {
+		fmt.Fprintf(&aiResponse, "Agent Version: %s\n", aiConfig.Version)
 	}
-	if config.OpsSopVersion != "" {
-		fmt.Fprintf(&aiResponse, "ops-sop Version: %s\n", config.OpsSopVersion)
+	if aiConfig.OpsSopVersion != "" {
+		fmt.Fprintf(&aiResponse, "ops-sop Version: %s\n", aiConfig.OpsSopVersion)
 	}
-	if config.RosaPluginsVersion != "" {
-		fmt.Fprintf(&aiResponse, "rosa-plugins Version: %s\n", config.RosaPluginsVersion)
+	if aiConfig.RosaPluginsVersion != "" {
+		fmt.Fprintf(&aiResponse, "rosa-plugins Version: %s\n", aiConfig.RosaPluginsVersion)
 	}
 	aiResponse.WriteString("\n")
 

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -8,13 +8,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/aws"
+	awssdk "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	"github.com/openshift/configuration-anomaly-detection/pkg/config"
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
@@ -70,34 +71,64 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	config := c.AIConfig
 
-	awsAccessKeyID := os.Getenv("AGENTCORE_AWS_ACCESS_KEY_ID")
-	if awsAccessKeyID == "" {
-		notes.AppendWarning("Failed to get AGENTCORE_AWS_ACCESS_KEY_ID")
-		result.Actions = append(
-			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
-			executor.Escalate("Failed to get AGENTCORE_AWS_ACCESS_KEY_ID"),
-		)
-		return result, nil
-	}
-	awsSecretAccessKey := os.Getenv("AGENTCORE_AWS_SECRET_ACCESS_KEY")
-	if awsSecretAccessKey == "" {
-		notes.AppendWarning("Failed to get AGENTCORE_AWS_SECRET_ACCESS_KEY")
-		result.Actions = append(
-			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
-			executor.Escalate("Failed to get AGENTCORE_AWS_SECRET_ACCESS_KEY"),
-		)
-		return result, nil
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), config.GetTimeout())
 	defer cancel()
 
-	// Create AWS config directly without LoadDefaultConfig
-	// This bypasses all default credential chain logic
-	awsCfg := awsconfig.Config{
-		Region:      config.Region,
-		Credentials: credentials.NewStaticCredentialsProvider(awsAccessKeyID, awsSecretAccessKey, ""),
+	// Load default AWS config (uses default credential chain)
+	awsCfg, err := awssdk.LoadDefaultConfig(ctx, awssdk.WithRegion(config.Region))
+	if err != nil {
+		notes.AppendWarning("Failed to load AWS config: %v", err)
+		result.Actions = append(
+			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
+			executor.Escalate("Failed to load AWS config"),
+		)
+		return result, nil
+	}
+
+	// Assume the CORA invoker IAM role with permissions to call AgentCore
+	roleArnToAssume := config.InvokerRoleArn
+
+	// Create STS client to assume the role
+	stsClient := sts.NewFromConfig(awsCfg)
+
+	// Get and log the identity of the original caller
+	callerIdentity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		logging.Warnf("Failed to get original caller identity: %v", err)
+	} else {
+		logging.Infof("Original Caller: %s", *callerIdentity.Arn)
+	}
+
+	// Assume the role
+	assumeRoleOutput, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         &roleArnToAssume,
+		RoleSessionName: awsconfig.String("CAD-AI-Investigation"),
+		DurationSeconds: awsconfig.Int32(3600), // 1 hour
+	})
+	if err != nil {
+		notes.AppendWarning("Failed to assume IAM role: %v", err)
+		result.Actions = append(
+			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
+			executor.Escalate("Failed to assume IAM role"),
+		)
+		return result, nil
+	}
+
+	// Create new AWS config with the assumed role credentials
+	awsCfg.Credentials = credentials.NewStaticCredentialsProvider(
+		*assumeRoleOutput.Credentials.AccessKeyId,
+		*assumeRoleOutput.Credentials.SecretAccessKey,
+		*assumeRoleOutput.Credentials.SessionToken,
+	)
+
+	// Verify the assumed role identity
+	stsClient2 := sts.NewFromConfig(awsCfg)
+	callerIdentity2, err := stsClient2.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		logging.Warnf("Failed to get assumed role caller identity: %v", err)
+	} else {
+		logging.Infof("AssumedRole Caller: %s", *callerIdentity2.Arn)
 	}
 
 	// Get PagerDuty incident details

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -111,7 +111,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		notes.AppendWarning("Failed to create AI client: %v", err)
 		result.Actions = append(
 			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
-			executor.Escalate("Failed to create AI client"),
+			executor.Escalate(fmt.Sprintf("Failed to create AI client: %v", err)),
 		)
 		return result, nil
 	}


### PR DESCRIPTION
### What type of PR is this?
(feature)

### What this PR does / Why we need it?
This PR enables the CAD to assume the [CORA invoker role](https://github.com/eth1030/rosa-cora-agent/blob/main/deploy/modules/rosa-cora-agent/main.tf#L469) instead of using static credentials so it can invoke the CORA to run an investigation.

Depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/189292 which adds the ai agent invoker role to cad configmap 

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [x] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI agent configuration now requires an invoker role ARN; example config updated and validation enforces it.
  * AI runtimes now obtain temporary role-based credentials for safer, role-scoped access.

* **Bug Fixes**
  * AI-assisted investigations report clearer warnings/errors when the AI client cannot be created.

* **Tests**
  * Fixtures updated and a negative test added for missing invoker role ARN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->