### PR TITLE
SREP-4517: Add consoleerrorbudgetburn investigation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentcore v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.300.0
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.32.0
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.49.0
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
 	github.com/onsi/gomega v1.40.0
 	github.com/openshift-online/ocm-common v0.0.40

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,16 @@ github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11 h1:3IDx7ybn7pyrLgVShEfG
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11/go.mod h1:iSArc5uhvz1S3EICNNvRzPksb6HPAUhltzMvoCrGyfM=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.300.0 h1:HgOfUy9Sm2Q9UQAyj9I/7NZhIaymTEakGA/FnLw65lw=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.300.0/go.mod h1:Y95W0Hm6FYLPa6o0hbnJ+sWgmdc4ifcLFjGkdobWVhY=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.32.0 h1:FO6LzHczDXByBf8+WJ5cswxaGy1EOjDVXA3NQa97Bh8=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.32.0/go.mod h1:q2K5uszrJv1SBxKYp5M9KUf7XR/Xnu38vSCiQ/wwhfI=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.49.0 h1:2VJj7fSoDawAjQ91u/DtrrUDOGsuMaWxcbe9Ok/O27w=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.49.0/go.mod h1:vJgvNz01VmSuXKzoUwQxQCzYklI/f09wXCWoj6TBGJE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9/go.mod h1:w7wZ/s9qK7c8g4al+UyoF1Sp/Z45UwMGcqIzLWVQHWk=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 h1:pbrxO/kuIwgEsOPLkaHu0O+m4fNgLU8B3vxQ+72jTPw=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23/go.mod h1:/CMNUqoj46HpS3MNRDEDIwcgEnrtZlKRaHNaHxIFpNA=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7 h1:twRRMmtSITnt/rrp+D7UDLzE5pKMZe759aalkUdN+OY=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7/go.mod h1:ztM1lr+sRoCAI8336ZUvlRPbToue0d3gE/wd6jomSJ8=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11/go.mod h1:R82ZRExE/nheo0N+T8zHPcLRTcH8MGsnR3BiVGX0TwI=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.5 h1:TY5Vh7uXQgJVuc6ahI6toLcRajG1aYSDCP3a0xsPvmo=

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -16,6 +16,11 @@ import (
 	cloudtrailv2types "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 	ec2v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2v2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv1 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	route53v2 "github.com/aws/aws-sdk-go-v2/service/route53"
+	route53v2types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
@@ -36,6 +41,8 @@ type EC2API interface {
 	DescribeSecurityGroups(ctx context.Context, in *ec2v2.DescribeSecurityGroupsInput, optFns ...func(*ec2v2.Options)) (*ec2v2.DescribeSecurityGroupsOutput, error)
 	DescribeSubnets(ctx context.Context, in *ec2v2.DescribeSubnetsInput, optFns ...func(*ec2v2.Options)) (*ec2v2.DescribeSubnetsOutput, error)
 	DescribeRouteTables(ctx context.Context, in *ec2v2.DescribeRouteTablesInput, optFns ...func(*ec2v2.Options)) (*ec2v2.DescribeRouteTablesOutput, error)
+	DescribeVpcs(ctx context.Context, in *ec2v2.DescribeVpcsInput, optFns ...func(*ec2v2.Options)) (*ec2v2.DescribeVpcsOutput, error)
+	DescribeDhcpOptions(ctx context.Context, in *ec2v2.DescribeDhcpOptionsInput, optFns ...func(*ec2v2.Options)) (*ec2v2.DescribeDhcpOptionsOutput, error)
 }
 
 type CloudTrailAPI interface {
@@ -50,6 +57,38 @@ type AgentCoreAPI interface {
 	InvokeAgentRuntime(ctx context.Context, in *bedrockagentcore.InvokeAgentRuntimeInput, optFns ...func(*bedrockagentcore.Options)) (*bedrockagentcore.InvokeAgentRuntimeOutput, error)
 }
 
+type Route53API interface {
+	ListHostedZonesByName(ctx context.Context, in *route53v2.ListHostedZonesByNameInput, optFns ...func(*route53v2.Options)) (*route53v2.ListHostedZonesByNameOutput, error)
+	ListResourceRecordSets(ctx context.Context, in *route53v2.ListResourceRecordSetsInput, optFns ...func(*route53v2.Options)) (*route53v2.ListResourceRecordSetsOutput, error)
+}
+
+type ELBV2API interface {
+	DescribeLoadBalancers(ctx context.Context, in *elbv2.DescribeLoadBalancersInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeLoadBalancersOutput, error)
+	DescribeTargetGroups(ctx context.Context, in *elbv2.DescribeTargetGroupsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetGroupsOutput, error)
+	DescribeTargetHealth(ctx context.Context, in *elbv2.DescribeTargetHealthInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetHealthOutput, error)
+}
+
+type ELBAPI interface {
+	DescribeLoadBalancers(ctx context.Context, in *elbv1.DescribeLoadBalancersInput, optFns ...func(*elbv1.Options)) (*elbv1.DescribeLoadBalancersOutput, error)
+	DescribeInstanceHealth(ctx context.Context, in *elbv1.DescribeInstanceHealthInput, optFns ...func(*elbv1.Options)) (*elbv1.DescribeInstanceHealthOutput, error)
+}
+
+// NLBTargetHealth represents one target's health in an NLB target group.
+type NLBTargetHealth struct {
+	TargetID string
+	Port     int32
+	State    string // "healthy", "unhealthy", "initial", "draining", etc.
+	Reason   string // empty if healthy
+}
+
+// CLBInstanceHealth represents one instance's health in a CLB.
+type CLBInstanceHealth struct {
+	InstanceID  string
+	State       string // "InService", "OutOfService", "Unknown"
+	Reason      string // "ELB", "Instance", "N/A"
+	Description string
+}
+
 type Client interface {
 	ListRunningInstances(infraID string) ([]ec2v2types.Instance, error)
 	ListNonRunningInstances(infraID string) ([]ec2v2types.Instance, error)
@@ -59,6 +98,13 @@ type Client interface {
 	GetSubnetID(infraID string) ([]string, error)
 	IsSubnetPrivate(subnet string) (bool, error)
 	GetRouteTableForSubnet(subnetID string) (ec2v2types.RouteTable, error)
+	FindHostedZone(dnsName string, private bool) (string, error)
+	HasResourceRecordSet(hostedZoneID, recordName, recordType string) (bool, error)
+	GetVpcDhcpConfiguration(infraID string) ([]string, error)
+	FindNLBByDNSName(dnsName string) (arn string, name string, err error)
+	FindCLBByDNSName(dnsName string) (name string, err error)
+	GetNLBTargetHealth(lbARN string) ([]NLBTargetHealth, error)
+	GetCLBInstanceHealth(lbName string) ([]CLBInstanceHealth, error)
 }
 
 type SdkClient struct {
@@ -67,6 +113,9 @@ type SdkClient struct {
 	CloudtrailClient CloudTrailAPI
 	Ec2Client        EC2API
 	StsClient        StsAPI
+	Route53Client    Route53API
+	Elbv2Client      ELBV2API
+	ElbClient        ELBAPI
 }
 
 func NewClient(config awsv2.Config) (*SdkClient, error) {
@@ -75,6 +124,9 @@ func NewClient(config awsv2.Config) (*SdkClient, error) {
 		CloudtrailClient: cloudtrailv2.NewFromConfig(config),
 		Ec2Client:        ec2v2.NewFromConfig(config),
 		StsClient:        stsv2.NewFromConfig(config),
+		Route53Client:    route53v2.NewFromConfig(config),
+		Elbv2Client:      elbv2.NewFromConfig(config),
+		ElbClient:        elbv1.NewFromConfig(config),
 	}, nil
 }
 
@@ -132,7 +184,7 @@ func (c *SdkClient) ListNonRunningInstances(infraID string) ([]ec2v2types.Instan
 	filters := []ec2v2types.Filter{
 		{
 			Name:   awsv2.String("tag:kubernetes.io/cluster/" + infraID),
-			Values: []string{("owned")},
+			Values: []string{"owned"},
 		},
 		{
 			Name: awsv2.String("instance-state-name"),
@@ -527,6 +579,205 @@ func (c *SdkClient) getRouteTable(routeTableID string) (ec2v2types.RouteTable, e
 		return ec2v2types.RouteTable{}, fmt.Errorf("no route tables found for route table id %v", routeTableID)
 	}
 	return describeRouteTablesOutput.RouteTables[0], nil
+}
+
+// FindHostedZone finds a hosted zone by DNS name and returns its ID.
+// If private is true, only private hosted zones are matched; otherwise only public zones.
+func (c *SdkClient) FindHostedZone(dnsName string, private bool) (string, error) {
+	normalizedName := dnsName
+	if !strings.HasSuffix(normalizedName, ".") {
+		normalizedName += "."
+	}
+
+	out, err := c.Route53Client.ListHostedZonesByName(context.TODO(), &route53v2.ListHostedZonesByNameInput{
+		DNSName: awsv2.String(normalizedName),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list hosted zones for %s: %w", dnsName, err)
+	}
+
+	for _, zone := range out.HostedZones {
+		// Treat nil Config as public (PrivateZone defaults to false).
+		isPrivate := zone.Config != nil && zone.Config.PrivateZone
+		if awsv2.ToString(zone.Name) == normalizedName && isPrivate == private {
+			// Zone IDs come as "/hostedzone/Z1234...", strip the prefix.
+			zoneID := awsv2.ToString(zone.Id)
+			zoneID = strings.TrimPrefix(zoneID, "/hostedzone/")
+			return zoneID, nil
+		}
+	}
+
+	return "", nil
+}
+
+// HasResourceRecordSet checks whether a specific DNS record exists in a hosted zone.
+// recordName should be fully qualified with a trailing dot (e.g., "\\052.apps.example.com.").
+// recordType is the DNS record type (e.g., "A", "CNAME").
+func (c *SdkClient) HasResourceRecordSet(hostedZoneID, recordName, recordType string) (bool, error) {
+	out, err := c.Route53Client.ListResourceRecordSets(context.TODO(), &route53v2.ListResourceRecordSetsInput{
+		HostedZoneId:    awsv2.String(hostedZoneID),
+		StartRecordName: awsv2.String(recordName),
+		StartRecordType: route53v2types.RRType(recordType),
+		MaxItems:        awsv2.Int32(1),
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to list record sets in zone %s: %w", hostedZoneID, err)
+	}
+
+	if len(out.ResourceRecordSets) == 0 {
+		return false, nil
+	}
+
+	rrs := out.ResourceRecordSets[0]
+	return awsv2.ToString(rrs.Name) == recordName && rrs.Type == route53v2types.RRType(recordType), nil
+}
+
+// GetVpcDhcpConfiguration returns the domain-name-servers values from the DHCP option set
+// associated with the cluster's VPC.
+func (c *SdkClient) GetVpcDhcpConfiguration(infraID string) ([]string, error) {
+	// Find VPC by infra ID tag
+	vpcOut, err := c.Ec2Client.DescribeVpcs(context.TODO(), &ec2v2.DescribeVpcsInput{
+		Filters: []ec2v2types.Filter{
+			{
+				Name:   awsv2.String("tag-key"),
+				Values: []string{fmt.Sprintf("kubernetes.io/cluster/%s", infraID)},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe VPCs for infra ID %s: %w", infraID, err)
+	}
+	if len(vpcOut.Vpcs) == 0 {
+		return nil, fmt.Errorf("no VPC found with kubernetes.io/cluster/%s tag", infraID)
+	}
+
+	dhcpOptionsID := awsv2.ToString(vpcOut.Vpcs[0].DhcpOptionsId)
+	if dhcpOptionsID == "" {
+		return nil, fmt.Errorf("VPC %s has no DHCP options set", awsv2.ToString(vpcOut.Vpcs[0].VpcId))
+	}
+
+	dhcpOut, err := c.Ec2Client.DescribeDhcpOptions(context.TODO(), &ec2v2.DescribeDhcpOptionsInput{
+		DhcpOptionsIds: []string{dhcpOptionsID},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe DHCP options %s: %w", dhcpOptionsID, err)
+	}
+	if len(dhcpOut.DhcpOptions) == 0 {
+		return nil, fmt.Errorf("DHCP options set %s not found", dhcpOptionsID)
+	}
+
+	var servers []string
+	for _, cfg := range dhcpOut.DhcpOptions[0].DhcpConfigurations {
+		if awsv2.ToString(cfg.Key) == "domain-name-servers" {
+			for _, v := range cfg.Values {
+				servers = append(servers, awsv2.ToString(v.Value))
+			}
+			break
+		}
+	}
+
+	return servers, nil
+}
+
+func (c *SdkClient) FindNLBByDNSName(dnsName string) (string, string, error) {
+	var marker *string
+	for {
+		out, err := c.Elbv2Client.DescribeLoadBalancers(context.TODO(), &elbv2.DescribeLoadBalancersInput{
+			Marker: marker,
+		})
+		if err != nil {
+			return "", "", fmt.Errorf("failed to describe NLBs: %w", err)
+		}
+		for _, lb := range out.LoadBalancers {
+			if lb.Type == elbv2types.LoadBalancerTypeEnumNetwork && awsv2.ToString(lb.DNSName) == dnsName {
+				return awsv2.ToString(lb.LoadBalancerArn), awsv2.ToString(lb.LoadBalancerName), nil
+			}
+		}
+		if out.NextMarker == nil {
+			break
+		}
+		marker = out.NextMarker
+	}
+	return "", "", nil
+}
+
+func (c *SdkClient) FindCLBByDNSName(dnsName string) (string, error) {
+	var marker *string
+	for {
+		out, err := c.ElbClient.DescribeLoadBalancers(context.TODO(), &elbv1.DescribeLoadBalancersInput{
+			Marker: marker,
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to describe CLBs: %w", err)
+		}
+		for _, lb := range out.LoadBalancerDescriptions {
+			if awsv2.ToString(lb.DNSName) == dnsName {
+				return awsv2.ToString(lb.LoadBalancerName), nil
+			}
+		}
+		if out.NextMarker == nil {
+			break
+		}
+		marker = out.NextMarker
+	}
+	return "", nil
+}
+
+func (c *SdkClient) GetNLBTargetHealth(lbARN string) ([]NLBTargetHealth, error) {
+	tgOut, err := c.Elbv2Client.DescribeTargetGroups(context.TODO(), &elbv2.DescribeTargetGroupsInput{
+		LoadBalancerArn: awsv2.String(lbARN),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe target groups for %s: %w", lbARN, err)
+	}
+
+	var results []NLBTargetHealth
+	for _, tg := range tgOut.TargetGroups {
+		thOut, err := c.Elbv2Client.DescribeTargetHealth(context.TODO(), &elbv2.DescribeTargetHealthInput{
+			TargetGroupArn: tg.TargetGroupArn,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe target health for %s: %w", awsv2.ToString(tg.TargetGroupArn), err)
+		}
+		for _, th := range thOut.TargetHealthDescriptions {
+			entry := NLBTargetHealth{
+				State: string(th.TargetHealth.State),
+			}
+			if th.Target != nil {
+				entry.TargetID = awsv2.ToString(th.Target.Id)
+				if th.Target.Port != nil {
+					entry.Port = *th.Target.Port
+				}
+			}
+			if th.TargetHealth.State != elbv2types.TargetHealthStateEnumHealthy {
+				entry.Reason = string(th.TargetHealth.Reason)
+			}
+			results = append(results, entry)
+		}
+	}
+
+	return results, nil
+}
+
+func (c *SdkClient) GetCLBInstanceHealth(lbName string) ([]CLBInstanceHealth, error) {
+	out, err := c.ElbClient.DescribeInstanceHealth(context.TODO(), &elbv1.DescribeInstanceHealthInput{
+		LoadBalancerName: awsv2.String(lbName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe instance health for CLB %s: %w", lbName, err)
+	}
+
+	results := make([]CLBInstanceHealth, 0, len(out.InstanceStates))
+	for _, is := range out.InstanceStates {
+		results = append(results, CLBInstanceHealth{
+			InstanceID:  awsv2.ToString(is.InstanceId),
+			State:       awsv2.ToString(is.State),
+			Reason:      awsv2.ToString(is.ReasonCode),
+			Description: awsv2.ToString(is.Description),
+		})
+	}
+
+	return results, nil
 }
 
 func populateStopTime(instances []ec2v2types.Instance) (map[string]time.Time, error) {

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -98,13 +98,13 @@ type Client interface {
 	GetSubnetID(infraID string) ([]string, error)
 	IsSubnetPrivate(subnet string) (bool, error)
 	GetRouteTableForSubnet(subnetID string) (ec2v2types.RouteTable, error)
-	FindHostedZone(dnsName string, private bool) (string, error)
-	HasResourceRecordSet(hostedZoneID, recordName, recordType string) (bool, error)
-	GetVpcDhcpConfiguration(infraID string) ([]string, error)
-	FindNLBByDNSName(dnsName string) (arn string, name string, err error)
-	FindCLBByDNSName(dnsName string) (name string, err error)
-	GetNLBTargetHealth(lbARN string) ([]NLBTargetHealth, error)
-	GetCLBInstanceHealth(lbName string) ([]CLBInstanceHealth, error)
+	FindHostedZone(ctx context.Context, dnsName string, private bool) (string, error)
+	HasResourceRecordSet(ctx context.Context, hostedZoneID, recordName, recordType string) (bool, error)
+	GetVpcDhcpConfiguration(ctx context.Context, infraID string) ([]string, error)
+	FindNLBByDNSName(ctx context.Context, dnsName string) (arn string, name string, err error)
+	FindCLBByDNSName(ctx context.Context, dnsName string) (name string, err error)
+	GetNLBTargetHealth(ctx context.Context, lbARN string) ([]NLBTargetHealth, error)
+	GetCLBInstanceHealth(ctx context.Context, lbName string) ([]CLBInstanceHealth, error)
 }
 
 type SdkClient struct {
@@ -583,13 +583,13 @@ func (c *SdkClient) getRouteTable(routeTableID string) (ec2v2types.RouteTable, e
 
 // FindHostedZone finds a hosted zone by DNS name and returns its ID.
 // If private is true, only private hosted zones are matched; otherwise only public zones.
-func (c *SdkClient) FindHostedZone(dnsName string, private bool) (string, error) {
+func (c *SdkClient) FindHostedZone(ctx context.Context, dnsName string, private bool) (string, error) {
 	normalizedName := dnsName
 	if !strings.HasSuffix(normalizedName, ".") {
 		normalizedName += "."
 	}
 
-	out, err := c.Route53Client.ListHostedZonesByName(context.TODO(), &route53v2.ListHostedZonesByNameInput{
+	out, err := c.Route53Client.ListHostedZonesByName(ctx, &route53v2.ListHostedZonesByNameInput{
 		DNSName: awsv2.String(normalizedName),
 	})
 	if err != nil {
@@ -613,8 +613,8 @@ func (c *SdkClient) FindHostedZone(dnsName string, private bool) (string, error)
 // HasResourceRecordSet checks whether a specific DNS record exists in a hosted zone.
 // recordName should be fully qualified with a trailing dot (e.g., "\\052.apps.example.com.").
 // recordType is the DNS record type (e.g., "A", "CNAME").
-func (c *SdkClient) HasResourceRecordSet(hostedZoneID, recordName, recordType string) (bool, error) {
-	out, err := c.Route53Client.ListResourceRecordSets(context.TODO(), &route53v2.ListResourceRecordSetsInput{
+func (c *SdkClient) HasResourceRecordSet(ctx context.Context, hostedZoneID, recordName, recordType string) (bool, error) {
+	out, err := c.Route53Client.ListResourceRecordSets(ctx, &route53v2.ListResourceRecordSetsInput{
 		HostedZoneId:    awsv2.String(hostedZoneID),
 		StartRecordName: awsv2.String(recordName),
 		StartRecordType: route53v2types.RRType(recordType),
@@ -634,9 +634,9 @@ func (c *SdkClient) HasResourceRecordSet(hostedZoneID, recordName, recordType st
 
 // GetVpcDhcpConfiguration returns the domain-name-servers values from the DHCP option set
 // associated with the cluster's VPC.
-func (c *SdkClient) GetVpcDhcpConfiguration(infraID string) ([]string, error) {
+func (c *SdkClient) GetVpcDhcpConfiguration(ctx context.Context, infraID string) ([]string, error) {
 	// Find VPC by infra ID tag
-	vpcOut, err := c.Ec2Client.DescribeVpcs(context.TODO(), &ec2v2.DescribeVpcsInput{
+	vpcOut, err := c.Ec2Client.DescribeVpcs(ctx, &ec2v2.DescribeVpcsInput{
 		Filters: []ec2v2types.Filter{
 			{
 				Name:   awsv2.String("tag-key"),
@@ -656,7 +656,7 @@ func (c *SdkClient) GetVpcDhcpConfiguration(infraID string) ([]string, error) {
 		return nil, fmt.Errorf("VPC %s has no DHCP options set", awsv2.ToString(vpcOut.Vpcs[0].VpcId))
 	}
 
-	dhcpOut, err := c.Ec2Client.DescribeDhcpOptions(context.TODO(), &ec2v2.DescribeDhcpOptionsInput{
+	dhcpOut, err := c.Ec2Client.DescribeDhcpOptions(ctx, &ec2v2.DescribeDhcpOptionsInput{
 		DhcpOptionsIds: []string{dhcpOptionsID},
 	})
 	if err != nil {
@@ -679,10 +679,10 @@ func (c *SdkClient) GetVpcDhcpConfiguration(infraID string) ([]string, error) {
 	return servers, nil
 }
 
-func (c *SdkClient) FindNLBByDNSName(dnsName string) (string, string, error) {
+func (c *SdkClient) FindNLBByDNSName(ctx context.Context, dnsName string) (string, string, error) {
 	var marker *string
 	for {
-		out, err := c.Elbv2Client.DescribeLoadBalancers(context.TODO(), &elbv2.DescribeLoadBalancersInput{
+		out, err := c.Elbv2Client.DescribeLoadBalancers(ctx, &elbv2.DescribeLoadBalancersInput{
 			Marker: marker,
 		})
 		if err != nil {
@@ -701,10 +701,10 @@ func (c *SdkClient) FindNLBByDNSName(dnsName string) (string, string, error) {
 	return "", "", nil
 }
 
-func (c *SdkClient) FindCLBByDNSName(dnsName string) (string, error) {
+func (c *SdkClient) FindCLBByDNSName(ctx context.Context, dnsName string) (string, error) {
 	var marker *string
 	for {
-		out, err := c.ElbClient.DescribeLoadBalancers(context.TODO(), &elbv1.DescribeLoadBalancersInput{
+		out, err := c.ElbClient.DescribeLoadBalancers(ctx, &elbv1.DescribeLoadBalancersInput{
 			Marker: marker,
 		})
 		if err != nil {
@@ -723,8 +723,8 @@ func (c *SdkClient) FindCLBByDNSName(dnsName string) (string, error) {
 	return "", nil
 }
 
-func (c *SdkClient) GetNLBTargetHealth(lbARN string) ([]NLBTargetHealth, error) {
-	tgOut, err := c.Elbv2Client.DescribeTargetGroups(context.TODO(), &elbv2.DescribeTargetGroupsInput{
+func (c *SdkClient) GetNLBTargetHealth(ctx context.Context, lbARN string) ([]NLBTargetHealth, error) {
+	tgOut, err := c.Elbv2Client.DescribeTargetGroups(ctx, &elbv2.DescribeTargetGroupsInput{
 		LoadBalancerArn: awsv2.String(lbARN),
 	})
 	if err != nil {
@@ -733,7 +733,7 @@ func (c *SdkClient) GetNLBTargetHealth(lbARN string) ([]NLBTargetHealth, error) 
 
 	var results []NLBTargetHealth
 	for _, tg := range tgOut.TargetGroups {
-		thOut, err := c.Elbv2Client.DescribeTargetHealth(context.TODO(), &elbv2.DescribeTargetHealthInput{
+		thOut, err := c.Elbv2Client.DescribeTargetHealth(ctx, &elbv2.DescribeTargetHealthInput{
 			TargetGroupArn: tg.TargetGroupArn,
 		})
 		if err != nil {
@@ -759,8 +759,8 @@ func (c *SdkClient) GetNLBTargetHealth(lbARN string) ([]NLBTargetHealth, error) 
 	return results, nil
 }
 
-func (c *SdkClient) GetCLBInstanceHealth(lbName string) ([]CLBInstanceHealth, error) {
-	out, err := c.ElbClient.DescribeInstanceHealth(context.TODO(), &elbv1.DescribeInstanceHealthInput{
+func (c *SdkClient) GetCLBInstanceHealth(ctx context.Context, lbName string) ([]CLBInstanceHealth, error) {
+	out, err := c.ElbClient.DescribeInstanceHealth(ctx, &elbv1.DescribeInstanceHealthInput{
 		LoadBalancerName: awsv2.String(lbName),
 	})
 	if err != nil {

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -1,5 +1,4 @@
-// Package aws contains functions related to aws sdk
-package aws
+package aws_test
 
 import (
 	"testing"
@@ -9,10 +8,11 @@ import (
 	ec2v2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"go.uber.org/mock/gomock"
 
+	cadaws "github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	awsmock "github.com/openshift/configuration-anomaly-detection/pkg/aws/mock"
 )
 
-func setupSubnetMock(t *testing.T, gatewayId *string, mapPublicIps bool) EC2API {
+func setupSubnetMock(t *testing.T, gatewayId *string, mapPublicIps bool) cadaws.EC2API {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	rtb := []ec2v2types.Route{
@@ -43,9 +43,9 @@ func setupSubnetMock(t *testing.T, gatewayId *string, mapPublicIps bool) EC2API 
 func TestSdkClient_IsSubnetPrivate(t *testing.T) {
 	type fields struct {
 		Region           string
-		StsClient        StsAPI
-		Ec2Client        EC2API
-		CloudTrailClient CloudTrailAPI
+		StsClient        cadaws.StsAPI
+		Ec2Client        cadaws.EC2API
+		CloudTrailClient cadaws.CloudTrailAPI
 		BaseConfig       awsv2.Config
 	}
 	type args struct {
@@ -106,7 +106,7 @@ func TestSdkClient_IsSubnetPrivate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &SdkClient{
+			c := &cadaws.SdkClient{
 				Region:           tt.fields.Region,
 				StsClient:        tt.fields.StsClient,
 				Ec2Client:        tt.fields.Ec2Client,

--- a/pkg/aws/mock/aws.go
+++ b/pkg/aws/mock/aws.go
@@ -540,39 +540,39 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // FindCLBByDNSName mocks base method.
-func (m *MockClient) FindCLBByDNSName(dnsName string) (string, error) {
+func (m *MockClient) FindCLBByDNSName(ctx context.Context, dnsName string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindCLBByDNSName", dnsName)
+	ret := m.ctrl.Call(m, "FindCLBByDNSName", ctx, dnsName)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindCLBByDNSName indicates an expected call of FindCLBByDNSName.
-func (mr *MockClientMockRecorder) FindCLBByDNSName(dnsName any) *gomock.Call {
+func (mr *MockClientMockRecorder) FindCLBByDNSName(ctx, dnsName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCLBByDNSName", reflect.TypeOf((*MockClient)(nil).FindCLBByDNSName), dnsName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCLBByDNSName", reflect.TypeOf((*MockClient)(nil).FindCLBByDNSName), ctx, dnsName)
 }
 
 // FindHostedZone mocks base method.
-func (m *MockClient) FindHostedZone(dnsName string, private bool) (string, error) {
+func (m *MockClient) FindHostedZone(ctx context.Context, dnsName string, private bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindHostedZone", dnsName, private)
+	ret := m.ctrl.Call(m, "FindHostedZone", ctx, dnsName, private)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindHostedZone indicates an expected call of FindHostedZone.
-func (mr *MockClientMockRecorder) FindHostedZone(dnsName, private any) *gomock.Call {
+func (mr *MockClientMockRecorder) FindHostedZone(ctx, dnsName, private any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindHostedZone", reflect.TypeOf((*MockClient)(nil).FindHostedZone), dnsName, private)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindHostedZone", reflect.TypeOf((*MockClient)(nil).FindHostedZone), ctx, dnsName, private)
 }
 
 // FindNLBByDNSName mocks base method.
-func (m *MockClient) FindNLBByDNSName(dnsName string) (string, string, error) {
+func (m *MockClient) FindNLBByDNSName(ctx context.Context, dnsName string) (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindNLBByDNSName", dnsName)
+	ret := m.ctrl.Call(m, "FindNLBByDNSName", ctx, dnsName)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -580,9 +580,9 @@ func (m *MockClient) FindNLBByDNSName(dnsName string) (string, string, error) {
 }
 
 // FindNLBByDNSName indicates an expected call of FindNLBByDNSName.
-func (mr *MockClientMockRecorder) FindNLBByDNSName(dnsName any) *gomock.Call {
+func (mr *MockClientMockRecorder) FindNLBByDNSName(ctx, dnsName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNLBByDNSName", reflect.TypeOf((*MockClient)(nil).FindNLBByDNSName), dnsName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNLBByDNSName", reflect.TypeOf((*MockClient)(nil).FindNLBByDNSName), ctx, dnsName)
 }
 
 // GetBaseConfig mocks base method.
@@ -600,33 +600,33 @@ func (mr *MockClientMockRecorder) GetBaseConfig() *gomock.Call {
 }
 
 // GetCLBInstanceHealth mocks base method.
-func (m *MockClient) GetCLBInstanceHealth(lbName string) ([]aws0.CLBInstanceHealth, error) {
+func (m *MockClient) GetCLBInstanceHealth(ctx context.Context, lbName string) ([]aws0.CLBInstanceHealth, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCLBInstanceHealth", lbName)
+	ret := m.ctrl.Call(m, "GetCLBInstanceHealth", ctx, lbName)
 	ret0, _ := ret[0].([]aws0.CLBInstanceHealth)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCLBInstanceHealth indicates an expected call of GetCLBInstanceHealth.
-func (mr *MockClientMockRecorder) GetCLBInstanceHealth(lbName any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetCLBInstanceHealth(ctx, lbName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCLBInstanceHealth", reflect.TypeOf((*MockClient)(nil).GetCLBInstanceHealth), lbName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCLBInstanceHealth", reflect.TypeOf((*MockClient)(nil).GetCLBInstanceHealth), ctx, lbName)
 }
 
 // GetNLBTargetHealth mocks base method.
-func (m *MockClient) GetNLBTargetHealth(lbARN string) ([]aws0.NLBTargetHealth, error) {
+func (m *MockClient) GetNLBTargetHealth(ctx context.Context, lbARN string) ([]aws0.NLBTargetHealth, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNLBTargetHealth", lbARN)
+	ret := m.ctrl.Call(m, "GetNLBTargetHealth", ctx, lbARN)
 	ret0, _ := ret[0].([]aws0.NLBTargetHealth)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNLBTargetHealth indicates an expected call of GetNLBTargetHealth.
-func (mr *MockClientMockRecorder) GetNLBTargetHealth(lbARN any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetNLBTargetHealth(ctx, lbARN any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNLBTargetHealth", reflect.TypeOf((*MockClient)(nil).GetNLBTargetHealth), lbARN)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNLBTargetHealth", reflect.TypeOf((*MockClient)(nil).GetNLBTargetHealth), ctx, lbARN)
 }
 
 // GetRouteTableForSubnet mocks base method.
@@ -675,33 +675,33 @@ func (mr *MockClientMockRecorder) GetSubnetID(infraID any) *gomock.Call {
 }
 
 // GetVpcDhcpConfiguration mocks base method.
-func (m *MockClient) GetVpcDhcpConfiguration(infraID string) ([]string, error) {
+func (m *MockClient) GetVpcDhcpConfiguration(ctx context.Context, infraID string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVpcDhcpConfiguration", infraID)
+	ret := m.ctrl.Call(m, "GetVpcDhcpConfiguration", ctx, infraID)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetVpcDhcpConfiguration indicates an expected call of GetVpcDhcpConfiguration.
-func (mr *MockClientMockRecorder) GetVpcDhcpConfiguration(infraID any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetVpcDhcpConfiguration(ctx, infraID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVpcDhcpConfiguration", reflect.TypeOf((*MockClient)(nil).GetVpcDhcpConfiguration), infraID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVpcDhcpConfiguration", reflect.TypeOf((*MockClient)(nil).GetVpcDhcpConfiguration), ctx, infraID)
 }
 
 // HasResourceRecordSet mocks base method.
-func (m *MockClient) HasResourceRecordSet(hostedZoneID, recordName, recordType string) (bool, error) {
+func (m *MockClient) HasResourceRecordSet(ctx context.Context, hostedZoneID, recordName, recordType string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasResourceRecordSet", hostedZoneID, recordName, recordType)
+	ret := m.ctrl.Call(m, "HasResourceRecordSet", ctx, hostedZoneID, recordName, recordType)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HasResourceRecordSet indicates an expected call of HasResourceRecordSet.
-func (mr *MockClientMockRecorder) HasResourceRecordSet(hostedZoneID, recordName, recordType any) *gomock.Call {
+func (mr *MockClientMockRecorder) HasResourceRecordSet(ctx, hostedZoneID, recordName, recordType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasResourceRecordSet", reflect.TypeOf((*MockClient)(nil).HasResourceRecordSet), hostedZoneID, recordName, recordType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasResourceRecordSet", reflect.TypeOf((*MockClient)(nil).HasResourceRecordSet), ctx, hostedZoneID, recordName, recordType)
 }
 
 // IsSubnetPrivate mocks base method.

--- a/pkg/aws/mock/aws.go
+++ b/pkg/aws/mock/aws.go
@@ -19,7 +19,11 @@ import (
 	types "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 	ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	types0 "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elasticloadbalancing "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
+	elasticloadbalancingv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	route53 "github.com/aws/aws-sdk-go-v2/service/route53"
 	sts "github.com/aws/aws-sdk-go-v2/service/sts"
+	aws0 "github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -45,6 +49,26 @@ func NewMockEC2API(ctrl *gomock.Controller) *MockEC2API {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEC2API) EXPECT() *MockEC2APIMockRecorder {
 	return m.recorder
+}
+
+// DescribeDhcpOptions mocks base method.
+func (m *MockEC2API) DescribeDhcpOptions(ctx context.Context, in *ec2.DescribeDhcpOptionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeDhcpOptionsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeDhcpOptions", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeDhcpOptionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeDhcpOptions indicates an expected call of DescribeDhcpOptions.
+func (mr *MockEC2APIMockRecorder) DescribeDhcpOptions(ctx, in any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDhcpOptions", reflect.TypeOf((*MockEC2API)(nil).DescribeDhcpOptions), varargs...)
 }
 
 // DescribeInstances mocks base method.
@@ -125,6 +149,26 @@ func (mr *MockEC2APIMockRecorder) DescribeSubnets(ctx, in any, optFns ...any) *g
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, in}, optFns...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockEC2API)(nil).DescribeSubnets), varargs...)
+}
+
+// DescribeVpcs mocks base method.
+func (m *MockEC2API) DescribeVpcs(ctx context.Context, in *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeVpcs", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeVpcsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeVpcs indicates an expected call of DescribeVpcs.
+func (mr *MockEC2APIMockRecorder) DescribeVpcs(ctx, in any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcs", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcs), varargs...)
 }
 
 // MockCloudTrailAPI is a mock of CloudTrailAPI interface.
@@ -259,6 +303,218 @@ func (mr *MockAgentCoreAPIMockRecorder) InvokeAgentRuntime(ctx, in any, optFns .
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvokeAgentRuntime", reflect.TypeOf((*MockAgentCoreAPI)(nil).InvokeAgentRuntime), varargs...)
 }
 
+// MockRoute53API is a mock of Route53API interface.
+type MockRoute53API struct {
+	ctrl     *gomock.Controller
+	recorder *MockRoute53APIMockRecorder
+	isgomock struct{}
+}
+
+// MockRoute53APIMockRecorder is the mock recorder for MockRoute53API.
+type MockRoute53APIMockRecorder struct {
+	mock *MockRoute53API
+}
+
+// NewMockRoute53API creates a new mock instance.
+func NewMockRoute53API(ctrl *gomock.Controller) *MockRoute53API {
+	mock := &MockRoute53API{ctrl: ctrl}
+	mock.recorder = &MockRoute53APIMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRoute53API) EXPECT() *MockRoute53APIMockRecorder {
+	return m.recorder
+}
+
+// ListHostedZonesByName mocks base method.
+func (m *MockRoute53API) ListHostedZonesByName(ctx context.Context, in *route53.ListHostedZonesByNameInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesByNameOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListHostedZonesByName", varargs...)
+	ret0, _ := ret[0].(*route53.ListHostedZonesByNameOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListHostedZonesByName indicates an expected call of ListHostedZonesByName.
+func (mr *MockRoute53APIMockRecorder) ListHostedZonesByName(ctx, in any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListHostedZonesByName", reflect.TypeOf((*MockRoute53API)(nil).ListHostedZonesByName), varargs...)
+}
+
+// ListResourceRecordSets mocks base method.
+func (m *MockRoute53API) ListResourceRecordSets(ctx context.Context, in *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListResourceRecordSets", varargs...)
+	ret0, _ := ret[0].(*route53.ListResourceRecordSetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListResourceRecordSets indicates an expected call of ListResourceRecordSets.
+func (mr *MockRoute53APIMockRecorder) ListResourceRecordSets(ctx, in any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceRecordSets", reflect.TypeOf((*MockRoute53API)(nil).ListResourceRecordSets), varargs...)
+}
+
+// MockELBV2API is a mock of ELBV2API interface.
+type MockELBV2API struct {
+	ctrl     *gomock.Controller
+	recorder *MockELBV2APIMockRecorder
+	isgomock struct{}
+}
+
+// MockELBV2APIMockRecorder is the mock recorder for MockELBV2API.
+type MockELBV2APIMockRecorder struct {
+	mock *MockELBV2API
+}
+
+// NewMockELBV2API creates a new mock instance.
+func NewMockELBV2API(ctrl *gomock.Controller) *MockELBV2API {
+	mock := &MockELBV2API{ctrl: ctrl}
+	mock.recorder = &MockELBV2APIMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockELBV2API) EXPECT() *MockELBV2APIMockRecorder {
+	return m.recorder
+}
+
+// DescribeLoadBalancers mocks base method.
+func (m *MockELBV2API) DescribeLoadBalancers(ctx context.Context, in *elasticloadbalancingv2.DescribeLoadBalancersInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeLoadBalancers", varargs...)
+	ret0, _ := ret[0].(*elasticloadbalancingv2.DescribeLoadBalancersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeLoadBalancers indicates an expected call of DescribeLoadBalancers.
+func (mr *MockELBV2APIMockRecorder) DescribeLoadBalancers(ctx, in any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLoadBalancers", reflect.TypeOf((*MockELBV2API)(nil).DescribeLoadBalancers), varargs...)
+}
+
+// DescribeTargetGroups mocks base method.
+func (m *MockELBV2API) DescribeTargetGroups(ctx context.Context, in *elasticloadbalancingv2.DescribeTargetGroupsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetGroupsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTargetGroups", varargs...)
+	ret0, _ := ret[0].(*elasticloadbalancingv2.DescribeTargetGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTargetGroups indicates an expected call of DescribeTargetGroups.
+func (mr *MockELBV2APIMockRecorder) DescribeTargetGroups(ctx, in any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTargetGroups", reflect.TypeOf((*MockELBV2API)(nil).DescribeTargetGroups), varargs...)
+}
+
+// DescribeTargetHealth mocks base method.
+func (m *MockELBV2API) DescribeTargetHealth(ctx context.Context, in *elasticloadbalancingv2.DescribeTargetHealthInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetHealthOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTargetHealth", varargs...)
+	ret0, _ := ret[0].(*elasticloadbalancingv2.DescribeTargetHealthOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTargetHealth indicates an expected call of DescribeTargetHealth.
+func (mr *MockELBV2APIMockRecorder) DescribeTargetHealth(ctx, in any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTargetHealth", reflect.TypeOf((*MockELBV2API)(nil).DescribeTargetHealth), varargs...)
+}
+
+// MockELBAPI is a mock of ELBAPI interface.
+type MockELBAPI struct {
+	ctrl     *gomock.Controller
+	recorder *MockELBAPIMockRecorder
+	isgomock struct{}
+}
+
+// MockELBAPIMockRecorder is the mock recorder for MockELBAPI.
+type MockELBAPIMockRecorder struct {
+	mock *MockELBAPI
+}
+
+// NewMockELBAPI creates a new mock instance.
+func NewMockELBAPI(ctrl *gomock.Controller) *MockELBAPI {
+	mock := &MockELBAPI{ctrl: ctrl}
+	mock.recorder = &MockELBAPIMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockELBAPI) EXPECT() *MockELBAPIMockRecorder {
+	return m.recorder
+}
+
+// DescribeInstanceHealth mocks base method.
+func (m *MockELBAPI) DescribeInstanceHealth(ctx context.Context, in *elasticloadbalancing.DescribeInstanceHealthInput, optFns ...func(*elasticloadbalancing.Options)) (*elasticloadbalancing.DescribeInstanceHealthOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeInstanceHealth", varargs...)
+	ret0, _ := ret[0].(*elasticloadbalancing.DescribeInstanceHealthOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeInstanceHealth indicates an expected call of DescribeInstanceHealth.
+func (mr *MockELBAPIMockRecorder) DescribeInstanceHealth(ctx, in any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceHealth", reflect.TypeOf((*MockELBAPI)(nil).DescribeInstanceHealth), varargs...)
+}
+
+// DescribeLoadBalancers mocks base method.
+func (m *MockELBAPI) DescribeLoadBalancers(ctx context.Context, in *elasticloadbalancing.DescribeLoadBalancersInput, optFns ...func(*elasticloadbalancing.Options)) (*elasticloadbalancing.DescribeLoadBalancersOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeLoadBalancers", varargs...)
+	ret0, _ := ret[0].(*elasticloadbalancing.DescribeLoadBalancersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeLoadBalancers indicates an expected call of DescribeLoadBalancers.
+func (mr *MockELBAPIMockRecorder) DescribeLoadBalancers(ctx, in any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLoadBalancers", reflect.TypeOf((*MockELBAPI)(nil).DescribeLoadBalancers), varargs...)
+}
+
 // MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
@@ -283,6 +539,52 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// FindCLBByDNSName mocks base method.
+func (m *MockClient) FindCLBByDNSName(dnsName string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindCLBByDNSName", dnsName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindCLBByDNSName indicates an expected call of FindCLBByDNSName.
+func (mr *MockClientMockRecorder) FindCLBByDNSName(dnsName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCLBByDNSName", reflect.TypeOf((*MockClient)(nil).FindCLBByDNSName), dnsName)
+}
+
+// FindHostedZone mocks base method.
+func (m *MockClient) FindHostedZone(dnsName string, private bool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindHostedZone", dnsName, private)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindHostedZone indicates an expected call of FindHostedZone.
+func (mr *MockClientMockRecorder) FindHostedZone(dnsName, private any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindHostedZone", reflect.TypeOf((*MockClient)(nil).FindHostedZone), dnsName, private)
+}
+
+// FindNLBByDNSName mocks base method.
+func (m *MockClient) FindNLBByDNSName(dnsName string) (string, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindNLBByDNSName", dnsName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// FindNLBByDNSName indicates an expected call of FindNLBByDNSName.
+func (mr *MockClientMockRecorder) FindNLBByDNSName(dnsName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNLBByDNSName", reflect.TypeOf((*MockClient)(nil).FindNLBByDNSName), dnsName)
+}
+
 // GetBaseConfig mocks base method.
 func (m *MockClient) GetBaseConfig() *aws.Config {
 	m.ctrl.T.Helper()
@@ -295,6 +597,36 @@ func (m *MockClient) GetBaseConfig() *aws.Config {
 func (mr *MockClientMockRecorder) GetBaseConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBaseConfig", reflect.TypeOf((*MockClient)(nil).GetBaseConfig))
+}
+
+// GetCLBInstanceHealth mocks base method.
+func (m *MockClient) GetCLBInstanceHealth(lbName string) ([]aws0.CLBInstanceHealth, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCLBInstanceHealth", lbName)
+	ret0, _ := ret[0].([]aws0.CLBInstanceHealth)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCLBInstanceHealth indicates an expected call of GetCLBInstanceHealth.
+func (mr *MockClientMockRecorder) GetCLBInstanceHealth(lbName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCLBInstanceHealth", reflect.TypeOf((*MockClient)(nil).GetCLBInstanceHealth), lbName)
+}
+
+// GetNLBTargetHealth mocks base method.
+func (m *MockClient) GetNLBTargetHealth(lbARN string) ([]aws0.NLBTargetHealth, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNLBTargetHealth", lbARN)
+	ret0, _ := ret[0].([]aws0.NLBTargetHealth)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNLBTargetHealth indicates an expected call of GetNLBTargetHealth.
+func (mr *MockClientMockRecorder) GetNLBTargetHealth(lbARN any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNLBTargetHealth", reflect.TypeOf((*MockClient)(nil).GetNLBTargetHealth), lbARN)
 }
 
 // GetRouteTableForSubnet mocks base method.
@@ -340,6 +672,36 @@ func (m *MockClient) GetSubnetID(infraID string) ([]string, error) {
 func (mr *MockClientMockRecorder) GetSubnetID(infraID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetID", reflect.TypeOf((*MockClient)(nil).GetSubnetID), infraID)
+}
+
+// GetVpcDhcpConfiguration mocks base method.
+func (m *MockClient) GetVpcDhcpConfiguration(infraID string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVpcDhcpConfiguration", infraID)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVpcDhcpConfiguration indicates an expected call of GetVpcDhcpConfiguration.
+func (mr *MockClientMockRecorder) GetVpcDhcpConfiguration(infraID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVpcDhcpConfiguration", reflect.TypeOf((*MockClient)(nil).GetVpcDhcpConfiguration), infraID)
+}
+
+// HasResourceRecordSet mocks base method.
+func (m *MockClient) HasResourceRecordSet(hostedZoneID, recordName, recordType string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasResourceRecordSet", hostedZoneID, recordName, recordType)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasResourceRecordSet indicates an expected call of HasResourceRecordSet.
+func (mr *MockClientMockRecorder) HasResourceRecordSet(hostedZoneID, recordName, recordType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasResourceRecordSet", reflect.TypeOf((*MockClient)(nil).HasResourceRecordSet), hostedZoneID, recordName, recordType)
 }
 
 // IsSubnetPrivate mocks base method.

--- a/pkg/investigations/consoleerrorbudgetburn/README.md
+++ b/pkg/investigations/consoleerrorbudgetburn/README.md
@@ -1,0 +1,7 @@
+# consoleerrorbudgetburn Investigation
+
+Investigation to analyze a console-ErrorBudgetBurn alert.
+
+## Testing
+
+Refer to the [testing README](./testing/README.md) for instructions on testing this investigation

--- a/pkg/investigations/consoleerrorbudgetburn/README.md
+++ b/pkg/investigations/consoleerrorbudgetburn/README.md
@@ -1,7 +1,48 @@
 # consoleerrorbudgetburn Investigation
 
-Investigation to analyze a console-ErrorBudgetBurn alert.
+Automates the console-ErrorBudgetBurn alert investigation by systematically checking every
+layer of the network path: blackbox probes, DNS resolution, VPC egress, load balancer health,
+OpenShift router pods, and the console service itself.
 
-## Testing
+The investigation collects diagnostic findings and posts them to PagerDuty. Two checks
+(allowedSourceRanges and Route53 DNS) can resolve the alert automatically by sending a
+service log and silencing the alert. All other checks are informational -- they collect
+context to help SREs triage faster.
 
-Refer to the [testing README](./testing/README.md) for instructions on testing this investigation
+## Investigation Flow
+
+The checks run in this order:
+
+| # | Check | Scope | Type |
+|---|-------|-------|------|
+| 1 | **Blackbox probe analysis** -- execs into blackbox-exporter, classifies failure mode (dns/timeout/tls/connection_refused/server_error) | All clusters | Informational |
+| 2 | **AllowedSourceRanges** -- detects if the IngressController's allowedSourceRanges excludes the machine CIDR | Classic only | Actioning -- sends service log + silences |
+| 3 | **Upstream DNS** -- detects customer-configured upstreamResolvers in dns.operator.openshift.io | All clusters | Informational |
+| 4 | **Router pod health** -- checks pod status, restarts, readiness, and warning events in openshift-ingress | All clusters | Informational |
+| 5 | **Console service** -- execs into cluster-monitoring-operator pod, curls the console service, reports HTTP response | All clusters | Informational |
+| 6 | **Console pod health** -- checks pod status, restarts, readiness, and warning events in openshift-console | All clusters | Informational |
+| 7 | **Node health** -- checks node conditions (NotReady, DiskPressure, MemoryPressure) for nodes running console pods | All clusters | Informational |
+| 8 | **Route53 DNS** -- verifies *.apps records exist in private and public hosted zones | AWS only (classic + HCP) | Actioning -- sends service log + silences |
+| 9 | **DHCP option set** -- verifies the VPC's DHCP option set includes AmazonProvidedDNS | AWS classic only | Informational |
+| 10 | **Load balancer health** -- identifies CLB/NLB type, checks target health | AWS classic only | Informational |
+| 11 | **VPC egress** -- runs the osd-network-verifier to test outbound connectivity | AWS classic, public only | Informational |
+
+If no automated root cause is found, the investigation escalates to SRE with all collected findings.
+
+## Architecture
+
+The investigation uses a multi-phase resource Build pattern:
+
+1. **Phase 1 (K8s)**: `rb.WithCluster().WithK8sClient().Build()` -- runs all K8s-based checks (1-7).
+2. **Phase 2 (AWS)**: `rb.WithAwsClient().Build()` -- runs AWS-specific checks (8-10). Graceful degradation if the AWS client cannot be initialized.
+3. **Phase 3 (Egress)**: `rb.WithClusterDeployment().Build()` -- fetches the ClusterDeployment for the network verifier (check 11). Only for public classic clusters.
+
+Interface-based dependency injection is used for three operations that require pod exec or external calls:
+- `consoleServiceChecker` -- curling the console service from within the cluster
+- `blackboxProber` -- running the blackbox probe via exec into blackbox-exporter
+- `egressVerifier` -- wrapping the network verifier (launches a temporary EC2 instance)
+
+## SOP Reference
+
+- Classic: [console-ErrorBudgetBurn.md](../../../../ops-sop/v4/alerts/console-ErrorBudgetBurn.md)
+- HCP: [console-ErrorBudgetBurn.md](../../../../ops-sop/v4/alerts/hypershift/console-ErrorBudgetBurn.md)

--- a/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
+++ b/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
@@ -12,11 +12,13 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	nodeutils "github.com/openshift/configuration-anomaly-detection/pkg/investigations/utils/node"
 	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/networkverifier"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
@@ -35,9 +37,20 @@ type blackboxProber interface {
 	runProbe(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config, consoleURL string) (string, error)
 }
 
+type egressVerifier interface {
+	run(r *investigation.Resources) (networkverifier.VerifierResult, string, error)
+}
+
+type defaultEgressVerifier struct{}
+
+func (d *defaultEgressVerifier) run(r *investigation.Resources) (networkverifier.VerifierResult, string, error) {
+	return networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
+}
+
 type Investigation struct {
 	consoleChecker consoleServiceChecker
 	blackboxProber blackboxProber
+	egressVerifier egressVerifier
 }
 
 func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
@@ -46,6 +59,9 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 	if i.blackboxProber == nil {
 		i.blackboxProber = &defaultBlackboxProber{}
+	}
+	if i.egressVerifier == nil {
+		i.egressVerifier = &defaultEgressVerifier{}
 	}
 
 	ctx := context.Background()
@@ -109,6 +125,56 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	// Check health of nodes running console pods.
 	// Applies to: Classic + HCP.
 	i.checkNodeHealth(ctx, r.K8sClient, notes)
+
+	// AWS-specific checks.
+	// Applies to: AWS clusters only.
+	if r.Cluster.CloudProvider() != nil && r.Cluster.CloudProvider().ID() == "aws" {
+		r, err = rb.WithAwsClient().Build()
+		if err != nil {
+			notes.AppendWarning("AWS: unable to initialize AWS client — %v", err)
+		}
+	}
+
+	if r.AwsClient != nil {
+		// Route53 DNS check (classic + HCP, early return on missing records).
+		if i.checkRoute53DNS(ctx, r, notes) {
+			clusterDomain := r.Cluster.DomainPrefix() + "." + r.Cluster.DNS().BaseDomain()
+			sl := newNetworkMisconfigurationSL(
+				fmt.Sprintf("The *.apps.%s DNS record is missing from Route53 hosted zones", clusterDomain),
+			)
+			notes.AppendAutomation("Sent NetworkMisconfiguration service log and silenced alert")
+			result.Actions = append(
+				executor.NoteAndReportFrom(notes, r.Cluster.ID(), i.Name()),
+				executor.NewServiceLogAction(sl.Severity, sl.Summary).
+					WithDescription(sl.Description).
+					WithServiceName(sl.ServiceName).
+					Build(),
+				executor.Silence("Missing *.apps DNS records in Route53"),
+			)
+			return result, nil
+		}
+		// DHCP option set check (classic only).
+		if !r.IsHCP {
+			i.checkDHCPOptions(ctx, r, notes)
+		}
+		// Load balancer health check (classic only).
+		if !r.IsHCP {
+			i.checkLoadBalancerHealth(ctx, r, notes)
+		}
+		// VPC egress check (classic, public only).
+		// PrivateLink clusters are excluded because the network verifier's probe
+		// methodology (launching an instance to test internet-bound egress) does not
+		// apply to PrivateLink clusters, which use AWS PrivateLink endpoints instead
+		// of public internet egress.
+		if !r.IsHCP && r.Cluster.AWS() != nil && !r.Cluster.AWS().PrivateLink() {
+			r, err = rb.WithClusterDeployment().Build()
+			if err != nil {
+				notes.AppendWarning("VPC Egress: unable to fetch ClusterDeployment — %v", err)
+			} else {
+				i.checkVPCEgress(r, notes)
+			}
+		}
+	}
 
 	// No automated root cause identified — escalate for manual investigation.
 	result.Actions = append(
@@ -181,6 +247,318 @@ func newAllowedSourceRangesSL(machineCIDR string) *ocm.ServiceLog {
 		Summary:      "Action required: Incorrect Default IngressController Configuration",
 		Description:  fmt.Sprintf("Your cluster requires you to take action. Your default ingresscontroller is misconfigured, generating alerts for Red Hat SRE and degrading cluster health. The Machine CIDR for the cluster, '%s', needs to be added to the allowlist.", machineCIDR),
 		InternalOnly: false,
+	}
+}
+
+// newNetworkMisconfigurationSL returns the service log for a network misconfiguration
+func newNetworkMisconfigurationSL(change string) *ocm.ServiceLog {
+	return &ocm.ServiceLog{
+		Severity:     "Critical",
+		ServiceName:  "SREManualAction",
+		Summary:      "Action required: Network misconfiguration",
+		Description:  fmt.Sprintf("Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: %s.", change),
+		InternalOnly: false,
+	}
+}
+
+// checkRoute53DNS verifies that *.apps DNS records exist in the cluster's Route53 hosted zones.
+// For non-PrivateLink, check both private and public hosted zones.
+// For PrivateLink clusters, only the private hosted zone is checked.
+func (i *Investigation) checkRoute53DNS(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) bool {
+	baseDomain := r.Cluster.DNS().BaseDomain()
+	domainPrefix := r.Cluster.DomainPrefix()
+	if baseDomain == "" || domainPrefix == "" {
+		notes.AppendWarning("Route53: unable to determine cluster domain (missing base domain or domain prefix)")
+		return false
+	}
+
+	clusterDomain := domainPrefix + "." + baseDomain
+	appsRecordName := "\\052.apps." + clusterDomain + "."
+
+	privateZoneID, err := r.AwsClient.FindHostedZone(clusterDomain, true)
+	if err != nil {
+		notes.AppendWarning("Route53: error looking up private hosted zone for %s — %v", clusterDomain, err)
+		return false
+	}
+
+	var missingPrivate, missingPublic bool
+
+	if privateZoneID == "" {
+		notes.AppendWarning("Route53: no private hosted zone found for %s", clusterDomain)
+		return false
+	}
+
+	hasPrivateRecord, err := r.AwsClient.HasResourceRecordSet(privateZoneID, appsRecordName, "A")
+	if err != nil {
+		notes.AppendWarning("Route53: error checking *.apps record in private zone for %s — %v", clusterDomain, err)
+		return false
+	}
+	missingPrivate = !hasPrivateRecord
+
+	isPrivateLink := r.Cluster.AWS() != nil && r.Cluster.AWS().PrivateLink()
+	if !isPrivateLink {
+		publicZoneID, err := r.AwsClient.FindHostedZone(baseDomain, false)
+		if err != nil {
+			notes.AppendWarning("Route53: error looking up public hosted zone for %s — %v", baseDomain, err)
+			return false
+		}
+		if publicZoneID == "" {
+			notes.AppendWarning("Route53: no public hosted zone found for %s", baseDomain)
+			return false
+		}
+
+		hasPublicRecord, err := r.AwsClient.HasResourceRecordSet(publicZoneID, appsRecordName, "A")
+		if err != nil {
+			notes.AppendWarning("Route53: error checking *.apps record in public zone for %s — %v", clusterDomain, err)
+			return false
+		}
+		missingPublic = !hasPublicRecord
+	}
+
+	if missingPrivate && missingPublic {
+		notes.AppendWarning("Route53: *.apps DNS record missing from BOTH private and public hosted zones for %s", clusterDomain)
+		return true
+	}
+	if missingPrivate {
+		notes.AppendWarning("Route53: *.apps DNS record missing from private hosted zone for %s", clusterDomain)
+		return true
+	}
+	if missingPublic {
+		notes.AppendWarning("Route53: *.apps DNS record missing from public hosted zone for %s", clusterDomain)
+		return true
+	}
+
+	if isPrivateLink {
+		notes.AppendSuccess("Route53: *.apps DNS record verified in private hosted zone for %s", clusterDomain)
+	} else {
+		notes.AppendSuccess("Route53: *.apps DNS records verified in private and public hosted zones for %s", clusterDomain)
+	}
+	return false
+}
+
+// checkDHCPOptions checks whether the VPC's DHCP option set includes AmazonProvidedDNS.
+//
+// Classic only, informational check.
+func (i *Investigation) checkDHCPOptions(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
+	infraID := r.Cluster.InfraID()
+	if infraID == "" {
+		notes.AppendWarning("DHCP: unable to determine cluster infrastructure ID")
+		return
+	}
+
+	servers, err := r.AwsClient.GetVpcDhcpConfiguration(infraID)
+	if err != nil {
+		notes.AppendWarning("DHCP: unable to check VPC DHCP options — %v", err)
+		return
+	}
+
+	if len(servers) == 0 {
+		notes.AppendSuccess("DHCP: VPC DHCP option set uses AWS default DNS (AmazonProvidedDNS)")
+		return
+	}
+
+	hasAmazonDNS := false
+	for _, s := range servers {
+		if s == "AmazonProvidedDNS" {
+			hasAmazonDNS = true
+			break
+		}
+	}
+
+	if !hasAmazonDNS {
+		notes.AppendWarning("DHCP: VPC DHCP option set uses custom DNS servers %v instead of AmazonProvidedDNS — this may prevent in-VPC DNS resolution", servers)
+		return
+	}
+
+	if len(servers) > 1 {
+		notes.AppendSuccess("DHCP: VPC DHCP option set includes AmazonProvidedDNS alongside custom servers %v", servers)
+		return
+	}
+
+	notes.AppendSuccess("DHCP: VPC DHCP option set uses AmazonProvidedDNS")
+}
+
+// determineLBType extracts the AWS load balancer type from the IngressController.
+// Returns "NLB" or "Classic". Defaults to "Classic" if the provider parameters are not set
+func determineLBType(ic *operatorv1.IngressController) string {
+	// check Spec first, fall back to status
+	for _, eps := range []*operatorv1.EndpointPublishingStrategy{
+		ic.Spec.EndpointPublishingStrategy,
+		ic.Status.EndpointPublishingStrategy,
+	} {
+		if eps != nil &&
+			eps.LoadBalancer != nil &&
+			eps.LoadBalancer.ProviderParameters != nil &&
+			eps.LoadBalancer.ProviderParameters.AWS != nil {
+			if eps.LoadBalancer.ProviderParameters.AWS.Type == operatorv1.AWSNetworkLoadBalancer {
+				return "NLB"
+			}
+			return "Classic"
+		}
+	}
+	return "Classic"
+}
+
+// checkLoadBalancerHealth checks the health of the cluster's ingress load balancer targets.
+// Identifies the LB type (CLB vs NLB) from the IngressController, reads the router-default
+// Service to find the LB hostname, then queries AWS for target health status.
+//
+// Classic only (not applicable to HCP). Informational-only check.
+func (i *Investigation) checkLoadBalancerHealth(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
+	// Get IngressController to determine LB type.
+	ic := &operatorv1.IngressController{}
+	if err := r.K8sClient.Get(ctx, ktypes.NamespacedName{
+		Namespace: "openshift-ingress-operator",
+		Name:      "default",
+	}, ic); err != nil {
+		notes.AppendWarning("LB Health: failed to get default IngressController — %v", err)
+		return
+	}
+	lbType := determineLBType(ic)
+
+	svc := &corev1.Service{}
+	if err := r.K8sClient.Get(ctx, ktypes.NamespacedName{
+		Namespace: "openshift-ingress",
+		Name:      "router-default",
+	}, svc); err != nil {
+		notes.AppendWarning("LB Health: failed to get router-default Service — %v", err)
+		return
+	}
+	if len(svc.Status.LoadBalancer.Ingress) == 0 || svc.Status.LoadBalancer.Ingress[0].Hostname == "" {
+		notes.AppendWarning("LB Health: router-default Service has no LoadBalancer hostname assigned")
+		return
+	}
+	hostname := svc.Status.LoadBalancer.Ingress[0].Hostname
+
+	switch lbType {
+	case "NLB":
+		i.checkNLBHealth(r, hostname, notes)
+	default:
+		i.checkCLBHealth(r, hostname, notes)
+	}
+}
+
+// checkNLBHealth finds an NLB by DNS name and reports target health.
+func (i *Investigation) checkNLBHealth(r *investigation.Resources, hostname string, notes *notewriter.NoteWriter) {
+	arn, name, err := r.AwsClient.FindNLBByDNSName(hostname)
+	if err != nil {
+		notes.AppendWarning("LB Health: failed to look up NLB — %v", err)
+		return
+	}
+	if arn == "" {
+		notes.AppendWarning("LB Health: no NLB found matching DNS name %s", hostname)
+		return
+	}
+
+	targets, err := r.AwsClient.GetNLBTargetHealth(arn)
+	if err != nil {
+		notes.AppendWarning("LB Health: failed to get NLB target health for %s — %v", name, err)
+		return
+	}
+	if len(targets) == 0 {
+		notes.AppendWarning("LB Health: NLB %s has no registered targets", name)
+		return
+	}
+
+	reportNLBTargetHealth(name, targets, notes)
+}
+
+// reportNLBTargetHealth formats and appends NLB target health to the notewriter.
+func reportNLBTargetHealth(lbName string, targets []aws.NLBTargetHealth, notes *notewriter.NoteWriter) {
+	var unhealthy []aws.NLBTargetHealth
+	for _, t := range targets {
+		if t.State != "healthy" {
+			unhealthy = append(unhealthy, t)
+		}
+	}
+
+	if len(unhealthy) == 0 {
+		notes.AppendSuccess("LB Health: NLB %s — all %d target(s) healthy", lbName, len(targets))
+		return
+	}
+
+	details := make([]string, 0, len(unhealthy))
+	for _, t := range unhealthy {
+		detail := fmt.Sprintf("%s (port %d): %s", t.TargetID, t.Port, t.State)
+		if t.Reason != "" {
+			detail += " — " + t.Reason
+		}
+		details = append(details, detail)
+	}
+	notes.AppendWarning("LB Health: NLB %s — %d/%d target(s) unhealthy:\n  %s",
+		lbName, len(unhealthy), len(targets), strings.Join(details, "\n  "))
+}
+
+// checkCLBHealth finds a CLB by DNS name and reports instance health.
+func (i *Investigation) checkCLBHealth(r *investigation.Resources, hostname string, notes *notewriter.NoteWriter) {
+	name, err := r.AwsClient.FindCLBByDNSName(hostname)
+	if err != nil {
+		notes.AppendWarning("LB Health: failed to look up CLB — %v", err)
+		return
+	}
+	if name == "" {
+		notes.AppendWarning("LB Health: no CLB found matching DNS name %s", hostname)
+		return
+	}
+
+	instances, err := r.AwsClient.GetCLBInstanceHealth(name)
+	if err != nil {
+		notes.AppendWarning("LB Health: failed to get CLB instance health for %s — %v", name, err)
+		return
+	}
+	if len(instances) == 0 {
+		notes.AppendWarning("LB Health: CLB %s has no registered instances", name)
+		return
+	}
+
+	reportCLBInstanceHealth(name, instances, notes)
+}
+
+// reportCLBInstanceHealth formats and appends CLB instance health to the notewriter.
+func reportCLBInstanceHealth(lbName string, instances []aws.CLBInstanceHealth, notes *notewriter.NoteWriter) {
+	var unhealthy []aws.CLBInstanceHealth
+	for _, inst := range instances {
+		if inst.State != "InService" {
+			unhealthy = append(unhealthy, inst)
+		}
+	}
+
+	if len(unhealthy) == 0 {
+		notes.AppendSuccess("LB Health: CLB %s — all %d instance(s) InService", lbName, len(instances))
+		return
+	}
+
+	details := make([]string, 0, len(unhealthy))
+	for _, inst := range unhealthy {
+		detail := fmt.Sprintf("%s: %s", inst.InstanceID, inst.State)
+		if inst.Description != "" {
+			detail += " — " + inst.Description
+		}
+		details = append(details, detail)
+	}
+	notes.AppendWarning("LB Health: CLB %s — %d/%d instance(s) not InService:\n  %s",
+		lbName, len(unhealthy), len(instances), strings.Join(details, "\n  "))
+}
+
+// checkVPCEgress runs the network verifier to validate VPC egress connectivity.
+// The network verifier launches a temporary t3.micro EC2 instance in a private subnet
+// to test outbound connectivity to required endpoints.
+//
+// Classic only, public only (not PrivateLink). Informational-only check.
+func (i *Investigation) checkVPCEgress(r *investigation.Resources, notes *notewriter.NoteWriter) {
+	verifierResult, failureReason, err := i.egressVerifier.run(r)
+	if err != nil {
+		notes.AppendWarning("VPC Egress: network verifier error — %v", err)
+		return
+	}
+
+	switch verifierResult {
+	case networkverifier.Failure:
+		notes.AppendWarning("VPC Egress: network verifier reported blocked egress — %s", failureReason)
+	case networkverifier.Success:
+		notes.AppendSuccess("VPC Egress: network verifier passed — all egress endpoints reachable")
+	default:
+		notes.AppendWarning("VPC Egress: network verifier returned undefined result")
 	}
 }
 

--- a/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
+++ b/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
@@ -1,0 +1,461 @@
+// Package consoleerrorbudgetburn investigates console-ErrorBudgetBurn alerts
+// by checking ingress configuration, DNS, router/console pod health, and node conditions.
+package consoleerrorbudgetburn
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	nodeutils "github.com/openshift/configuration-anomaly-detection/pkg/investigations/utils/node"
+	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	"github.com/openshift/configuration-anomaly-detection/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type consoleServiceChecker interface {
+	checkConsoleEndpoint(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config) (string, error)
+}
+
+type Investigation struct {
+	consoleChecker consoleServiceChecker
+}
+
+func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
+	if i.consoleChecker == nil {
+		i.consoleChecker = &defaultConsoleServiceChecker{}
+	}
+
+	ctx := context.Background()
+	result := investigation.InvestigationResult{}
+
+	r, err := rb.WithCluster().WithK8sClient().Build()
+	if err != nil {
+		if msg, ok := investigation.ClusterAccessErrorMessage(err); ok {
+			logging.Warnf("Cluster access error for %s: %v", i.Name(), err)
+			result.Actions = []types.Action{
+				executor.Note(msg),
+				executor.Escalate(msg),
+			}
+			return result, nil
+		}
+		return result, investigation.WrapInfrastructure(err, "failed to build resources for "+i.Name())
+	}
+
+	notes := notewriter.New(i.Name(), logging.RawLogger)
+
+	// Check allowedSourceRanges on the default IngressController.
+	// Applies to: classic
+	if !r.IsHCP {
+		if i.checkAllowedSourceRanges(ctx, r, notes) {
+			// Definitive root cause found;send SL, silence, return early.
+			machineCIDR := r.Cluster.Network().MachineCIDR()
+			sl := newAllowedSourceRangesSL(machineCIDR)
+			notes.AppendAutomation("Sent AllowedSourceRanges service log and silenced alert")
+			result.Actions = append(
+				executor.NoteAndReportFrom(notes, r.Cluster.ID(), i.Name()),
+				executor.NewServiceLogAction(sl.Severity, sl.Summary).
+					WithDescription(sl.Description).
+					WithServiceName(sl.ServiceName).
+					Build(),
+				executor.Silence("AllowedSourceRanges misconfiguration on default IngressController"),
+			)
+			return result, nil
+		}
+	}
+
+	// Check for customer-configured upstream DNS resolvers.
+	// Applies to: Classic + HCP.
+	i.checkUpstreamDNS(ctx, r.K8sClient, notes)
+
+	// Check router pod health in openshift-ingress.
+	// Applies to: Classic + HCP.
+	i.checkPodHealth(ctx, r.K8sClient, "openshift-ingress", "Router", notes)
+
+	// Check console service reachability from within the cluster.
+	// Applies to: Classic + HCP.
+	i.checkConsoleService(ctx, r, notes)
+
+	// Check console pod health in openshift-console.
+	// Applies to: Classic + HCP.
+	i.checkPodHealth(ctx, r.K8sClient, "openshift-console", "Console", notes)
+
+	// Check health of nodes running console pods.
+	// Applies to: Classic + HCP.
+	i.checkNodeHealth(ctx, r.K8sClient, notes)
+
+	// No automated root cause identified — escalate for manual investigation.
+	result.Actions = append(
+		executor.NoteAndReportFrom(notes, r.Cluster.ID(), i.Name()),
+		executor.Escalate("No automated root cause identified — manual investigation required"),
+	)
+	return result, nil
+}
+
+// checkAllowedSourceRanges checks whether the default IngressController's allowedSourceRanges
+// includes the cluster's machine CIDR.
+//
+// Return true if a misconfig was detected.
+func (i *Investigation) checkAllowedSourceRanges(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) bool {
+	machineCIDR := r.Cluster.Network().MachineCIDR()
+	if machineCIDR == "" {
+		notes.AppendWarning("AllowedSourceRanges: unable to determine machine CIDR from cluster info")
+		return false
+	}
+
+	machineIP, machineNet, err := net.ParseCIDR(machineCIDR)
+	if err != nil {
+		notes.AppendWarning("AllowedSourceRanges: failed to parse machine CIDR %q - %v", machineCIDR, err)
+		return false
+	}
+
+	ic := &operatorv1.IngressController{}
+	if err := r.K8sClient.Get(ctx, ktypes.NamespacedName{Namespace: "openshift-ingress-operator", Name: "default"}, ic); err != nil {
+		notes.AppendWarning("AllowedSourceRanges: failed to get default IngressController - %v", err)
+		return false
+	}
+
+	if ic.Spec.EndpointPublishingStrategy == nil || ic.Spec.EndpointPublishingStrategy.LoadBalancer == nil || len(ic.Spec.EndpointPublishingStrategy.LoadBalancer.AllowedSourceRanges) == 0 {
+		notes.AppendSuccess("AllowedSourceRanges: not configured on default IngressController")
+		return false
+	}
+
+	ranges := ic.Spec.EndpointPublishingStrategy.LoadBalancer.AllowedSourceRanges
+	for _, r := range ranges {
+		if cidrContains(string(r), machineIP, machineNet) {
+			notes.AppendSuccess("AllowedSourceRanges: machine CIDR %s is covered by allowedSourceRanges on default IngressController", machineCIDR)
+			return false
+		}
+	}
+
+	notes.AppendWarning("AllowedSourceRanges: machine CIDR %s is NOT included in allowedSourceRanges on default IngressController (ranges: %v)", machineCIDR, ranges)
+	return true
+}
+
+// cidrContains checks whether allowedCIDR is contained in (or equal to) machine CIDR.
+// This matches the semantics of the ops-sop check-allowed-source-ranges.py cidr_fit function.
+func cidrContains(allowedCIDR string, machineIP net.IP, machineNet *net.IPNet) bool {
+	_, allowedNet, err := net.ParseCIDR(allowedCIDR)
+	if err != nil {
+		return false
+	}
+
+	allowedOnes, _ := allowedNet.Mask.Size()
+	machineOnes, _ := machineNet.Mask.Size()
+
+	return allowedOnes <= machineOnes && allowedNet.Contains(machineIP)
+}
+
+// newAllowedSourceRangesSL returns the service log for an allowedSourceRanges misconfiguration.
+// Content matches the managed-notifications AllowedSourceRanges.json template.
+func newAllowedSourceRangesSL(machineCIDR string) *ocm.ServiceLog {
+	return &ocm.ServiceLog{
+		Severity:     "Critical",
+		ServiceName:  "SREManualAction",
+		Summary:      "Action required: Incorrect Default IngressController Configuration",
+		Description:  fmt.Sprintf("Your cluster requires you to take action. Your default ingresscontroller is misconfigured, generating alerts for Red Hat SRE and degrading cluster health. The Machine CIDR for the cluster, '%s', needs to be added to the allowlist.", machineCIDR),
+		InternalOnly: false,
+	}
+}
+
+// checkUpstreamDNS checks whether the cluster has customer-configured upstream DNS resolvers.
+// If upstreamResolvers with type "Network" are found on dns.operator.openshift.io/default,
+// this flags them as a potential cause of probe DNS resolution failures.
+//
+// Informational-only check.
+func (i *Investigation) checkUpstreamDNS(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	dns := &operatorv1.DNS{}
+	if err := k8sClient.Get(ctx, ktypes.NamespacedName{Name: "default"}, dns); err != nil {
+		notes.AppendWarning("DNS: failed to get dns.operator.openshift.io/default - %v", err)
+		return
+	}
+
+	var customUpstreams []string
+	for _, u := range dns.Spec.UpstreamResolvers.Upstreams {
+		if u.Type == operatorv1.NetworkResolverType {
+			customUpstreams = append(customUpstreams, fmt.Sprintf("%s:%d", u.Address, u.Port))
+		}
+	}
+
+	if len(customUpstreams) == 0 {
+		notes.AppendSuccess("DNS: no custom upstream resolvers configured")
+		return
+	}
+
+	notes.AppendWarning("DNS: customer-configured upstream resolvers detected (may prevent *.apps domain resolution): %s", strings.Join(customUpstreams, ", "))
+}
+
+// checkPodHealth checks the health of pods in the given namespace, reporting any
+// failed, pending, crashlooping, or not-ready pods as well as warning events.
+//
+// Informational-only check.
+func (i *Investigation) checkPodHealth(ctx context.Context, k8sClient k8sclient.Client, namespace, label string, notes *notewriter.NoteWriter) {
+	const restartThreshold int32 = 3
+
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(ctx, podList, client.InNamespace(namespace)); err != nil {
+		notes.AppendWarning("%s: failed to list pods in %s - %v", label, namespace, err)
+		return
+	}
+
+	if len(podList.Items) == 0 {
+		notes.AppendWarning("%s: no pods found in %s", label, namespace)
+		return
+	}
+
+	type podIssue struct {
+		name   string
+		reason string
+	}
+
+	var issues []podIssue
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodSucceeded {
+			continue
+		}
+		if pod.Status.Phase == corev1.PodFailed {
+			reason := pod.Status.Reason
+			if reason == "" {
+				reason = "Failed"
+			}
+			issues = append(issues, podIssue{name: pod.Name, reason: reason})
+			continue
+		}
+		if pod.Status.Phase == corev1.PodPending {
+			issues = append(issues, podIssue{name: pod.Name, reason: "Pending"})
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.RestartCount > restartThreshold {
+				issues = append(issues, podIssue{
+					name:   pod.Name,
+					reason: fmt.Sprintf("container %s has %d restarts", cs.Name, cs.RestartCount),
+				})
+			}
+			if cs.State.Waiting != nil && (cs.State.Waiting.Reason == "CrashLoopBackOff" ||
+				cs.State.Waiting.Reason == "Error" ||
+				cs.State.Waiting.Reason == "ImagePullBackOff" ||
+				cs.State.Waiting.Reason == "ErrImagePull") {
+				issues = append(issues, podIssue{
+					name:   pod.Name,
+					reason: fmt.Sprintf("container %s: %s", cs.Name, cs.State.Waiting.Reason),
+				})
+			}
+			if !cs.Ready && pod.Status.Phase == corev1.PodRunning {
+				issues = append(issues, podIssue{
+					name:   pod.Name,
+					reason: fmt.Sprintf("container %s not ready", cs.Name),
+				})
+			}
+		}
+	}
+
+	// Check for warning events in the namespace.
+	eventList := &corev1.EventList{}
+	var warningEvents []string
+	if err := k8sClient.List(ctx, eventList, client.InNamespace(namespace)); err != nil {
+		notes.AppendWarning("%s: failed to list events in %s - %v", label, namespace, err)
+	} else {
+		for _, event := range eventList.Items {
+			if event.Type != corev1.EventTypeNormal {
+				msg := event.Message
+				if len(msg) > 120 {
+					msg = msg[:120] + "..."
+				}
+				countStr := ""
+				if event.Count > 1 {
+					countStr = fmt.Sprintf(" (x%d)", event.Count)
+				}
+				warningEvents = append(warningEvents, fmt.Sprintf("  %s/%s: %s%s - %s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, countStr, msg))
+			}
+		}
+	}
+
+	if len(issues) == 0 && len(warningEvents) == 0 {
+		notes.AppendSuccess("%s: all %d pod(s) in %s are running and ready", label, len(podList.Items), namespace)
+		return
+	}
+
+	var sb strings.Builder
+	if len(issues) > 0 {
+		sb.WriteString(fmt.Sprintf("%d pod issue(s):\n", len(issues)))
+		for _, issue := range issues {
+			sb.WriteString(fmt.Sprintf("  %s: %s\n", issue.name, issue.reason))
+		}
+	}
+	if len(warningEvents) > 0 {
+		sb.WriteString(fmt.Sprintf("%d warning event(s):\n", len(warningEvents)))
+		for _, e := range warningEvents {
+			sb.WriteString(e + "\n")
+		}
+	}
+	notes.AppendWarning("%s: %s", label, sb.String())
+}
+
+// checkConsoleService tests whether the console service is reachable from within the cluster
+// by exec'ing into a CMO pod and curling the console ClusterIP service.
+//
+// informational-only check.
+func (i *Investigation) checkConsoleService(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
+	restConfig, err := getRestConfig(r)
+	if err != nil {
+		notes.AppendWarning("Console Service: unable to get REST config - %v", err)
+		return
+	}
+
+	output, err := i.consoleChecker.checkConsoleEndpoint(ctx, r.K8sClient, restConfig)
+	if err != nil {
+		notes.AppendWarning("Console Service: unable to reach console service - %v", err)
+		return
+	}
+
+	if output == "200" {
+		notes.AppendSuccess("Console Service: console is responding (HTTP 200) from within the cluster")
+	} else {
+		notes.AppendWarning("Console Service: console returned HTTP %s from within the cluster", output)
+	}
+}
+
+// defaultConsoleServiceChecker implements consoleServiceChecker by exec'ing curl
+// into a cluster-monitoring-operator pod in openshift-monitoring.
+type defaultConsoleServiceChecker struct{}
+
+func (d *defaultConsoleServiceChecker) checkConsoleEndpoint(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config) (string, error) {
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(
+		ctx, podList,
+		client.InNamespace("openshift-monitoring"),
+		client.MatchingLabels{"app.kubernetes.io/name": "cluster-monitoring-operator"},
+	); err != nil {
+		return "", fmt.Errorf("failed to list cluster-monitoring-operator pods: %w", err)
+	}
+
+	var cmoPod *corev1.Pod
+	for idx := range podList.Items {
+		if podList.Items[idx].Status.Phase == corev1.PodRunning {
+			cmoPod = &podList.Items[idx]
+			break
+		}
+	}
+	if cmoPod == nil {
+		return "", fmt.Errorf("no running cluster-monitoring-operator pod found in openshift-monitoring")
+	}
+
+	output, err := k8sclient.ExecInPod(ctx, restConfig, cmoPod, "cluster-monitoring-operator", []string{
+		"curl", "-sk", "-o", "/dev/null", "-w", "%{http_code}",
+		"https://console.openshift-console.svc.cluster.local",
+	})
+	if err != nil {
+		return output, fmt.Errorf("exec failed: %w", err)
+	}
+	return strings.TrimSpace(output), nil
+}
+
+// checkNodeHealth checks the health of nodes that run console pods.
+// It looks for NotReady, MemoryPressure, DiskPressure, PIDPressure conditions
+// and Unschedulable status.
+//
+// Informational-only check.
+func (i *Investigation) checkNodeHealth(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	// find which nodes run console pods
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(ctx, podList, client.InNamespace("openshift-console")); err != nil {
+		notes.AppendWarning("Node Health: failed to list console pods - %v", err)
+		return
+	}
+
+	nodeNames := make(map[string]struct{})
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName != "" {
+			nodeNames[pod.Spec.NodeName] = struct{}{}
+		}
+	}
+
+	if len(nodeNames) == 0 {
+		notes.AppendWarning("Node Health: no console pods found to determine nodes")
+		return
+	}
+
+	var issues []string
+	nodeCount := 0
+	for nodeName := range nodeNames {
+		node := &corev1.Node{}
+		if err := k8sClient.Get(ctx, ktypes.NamespacedName{Name: nodeName}, node); err != nil {
+			issues = append(issues, fmt.Sprintf("%s: failed to get node - %v", nodeName, err))
+			continue
+		}
+		nodeCount++
+
+		// Check NodeReady condition using the utils helper.
+		if readyCond, found := nodeutils.FindReadyCondition(*node); found {
+			if readyCond.Status != corev1.ConditionTrue {
+				issues = append(issues, fmt.Sprintf("%s: NotReady (status: %s, reason: %s)", nodeName, readyCond.Status, readyCond.Reason))
+			}
+		} else {
+			issues = append(issues, fmt.Sprintf("%s: NodeReady condition not found", nodeName))
+		}
+
+		for _, cond := range node.Status.Conditions {
+			switch cond.Type {
+			case corev1.NodeMemoryPressure:
+				if cond.Status == corev1.ConditionTrue {
+					issues = append(issues, fmt.Sprintf("%s: MemoryPressure", nodeName))
+				}
+			case corev1.NodeDiskPressure:
+				if cond.Status == corev1.ConditionTrue {
+					issues = append(issues, fmt.Sprintf("%s: DiskPressure", nodeName))
+				}
+			case corev1.NodePIDPressure:
+				if cond.Status == corev1.ConditionTrue {
+					issues = append(issues, fmt.Sprintf("%s: PIDPressure", nodeName))
+				}
+			}
+		}
+
+		if node.Spec.Unschedulable {
+			issues = append(issues, fmt.Sprintf("%s: Unschedulable (cordoned)", nodeName))
+		}
+	}
+
+	if len(issues) == 0 {
+		notes.AppendSuccess("Node Health: all %d node(s) running console pods are healthy", nodeCount)
+	} else {
+		notes.AppendWarning("Node Health: %d issue(s) on nodes running console pods:\n  %s", len(issues), strings.Join(issues, "\n  "))
+	}
+}
+
+// getRestConfig extracts the *rest.Config from the investigation resources.
+func getRestConfig(r *investigation.Resources) (*rest.Config, error) {
+	if r.RestConfig != nil {
+		return &r.RestConfig.Config, nil
+	}
+	return k8sclient.GetRestConfig(r.K8sClient)
+}
+
+func (i *Investigation) Name() string {
+	return "consoleerrorbudgetburn"
+}
+
+func (i *Investigation) AlertTitle() string {
+	return "console-errorbudgetburn"
+}
+
+func (i *Investigation) Description() string {
+	return "Investigation to analyze a console-ErrorBudgetBurn alert"
+}
+
+func (i *Investigation) IsExperimental() bool {
+	return true
+}

--- a/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
+++ b/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
+	"strconv"
 	"strings"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -29,13 +31,21 @@ type consoleServiceChecker interface {
 	checkConsoleEndpoint(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config) (string, error)
 }
 
+type blackboxProber interface {
+	runProbe(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config, consoleURL string) (string, error)
+}
+
 type Investigation struct {
 	consoleChecker consoleServiceChecker
+	blackboxProber blackboxProber
 }
 
 func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
 	if i.consoleChecker == nil {
 		i.consoleChecker = &defaultConsoleServiceChecker{}
+	}
+	if i.blackboxProber == nil {
+		i.blackboxProber = &defaultBlackboxProber{}
 	}
 
 	ctx := context.Background()
@@ -55,6 +65,10 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 
 	notes := notewriter.New(i.Name(), logging.RawLogger)
+
+	// Check blackbox probe
+	// Applies to: Classic + HCP.
+	i.checkBlackboxProbe(ctx, r, notes)
 
 	// Check allowedSourceRanges on the default IngressController.
 	// Applies to: classic
@@ -433,6 +447,172 @@ func (i *Investigation) checkNodeHealth(ctx context.Context, k8sClient k8sclient
 		notes.AppendSuccess("Node Health: all %d node(s) running console pods are healthy", nodeCount)
 	} else {
 		notes.AppendWarning("Node Health: %d issue(s) on nodes running console pods:\n  %s", len(issues), strings.Join(issues, "\n  "))
+	}
+}
+
+// defaultBlackboxProber implements blackboxProber by exec'ing wget into the
+// blackbox-exporter pod in openshift-route-monitor-operator.
+type defaultBlackboxProber struct{}
+
+func (d *defaultBlackboxProber) runProbe(ctx context.Context, k8sClient k8sclient.Client, restConfig *rest.Config, consoleURL string) (string, error) {
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(
+		ctx, podList,
+		client.InNamespace("openshift-route-monitor-operator"),
+		client.MatchingLabels{"app": "blackbox-exporter"},
+	); err != nil {
+		return "", fmt.Errorf("failed to list blackbox-exporter pods: %w", err)
+	}
+
+	var bbPod *corev1.Pod
+	for idx := range podList.Items {
+		if podList.Items[idx].Status.Phase == corev1.PodRunning {
+			bbPod = &podList.Items[idx]
+			break
+		}
+	}
+	if bbPod == nil {
+		return "", fmt.Errorf("no running blackbox-exporter pod found in openshift-route-monitor-operator")
+	}
+
+	probeURL := fmt.Sprintf("http://localhost:9115/probe?target=%s&module=http_2xx&debug=true", consoleURL)
+	output, err := k8sclient.ExecInPod(ctx, restConfig, bbPod, "blackbox-exporter", []string{
+		"wget", "-qO-", probeURL,
+	})
+	if err != nil {
+		return output, fmt.Errorf("exec failed: %w", err)
+	}
+	return strings.TrimSpace(output), nil
+}
+
+type probeResult struct {
+	success       bool
+	httpStatus    int
+	failureMode   string // "dns", "timeout", "tls", "connection_refused", "server_error", "unknown"
+	failureDetail string // human-readable detail extracted from logs
+	duration      float64
+}
+
+var (
+	probeSuccessRe    = regexp.MustCompile(`probe_success\s+([01])`)
+	probeHTTPStatusRe = regexp.MustCompile(`probe_http_status_code\s+(\d+)`)
+	probeDurationRe   = regexp.MustCompile(`probe_duration_seconds\s+([\d.]+)`)
+)
+
+func parseProbeResponse(body string) probeResult {
+	result := probeResult{}
+
+	const metricsSeparator = "Metrics that would have been returned:"
+	logSection := body
+	metricsSection := ""
+	if idx := strings.Index(body, metricsSeparator); idx >= 0 {
+		logSection = body[:idx]
+		metricsSection = body[idx+len(metricsSeparator):]
+	}
+
+	if m := probeSuccessRe.FindStringSubmatch(metricsSection); len(m) > 1 {
+		result.success = m[1] == "1"
+	}
+	if m := probeHTTPStatusRe.FindStringSubmatch(metricsSection); len(m) > 1 {
+		result.httpStatus, _ = strconv.Atoi(m[1])
+	}
+	if m := probeDurationRe.FindStringSubmatch(metricsSection); len(m) > 1 {
+		result.duration, _ = strconv.ParseFloat(m[1], 64)
+	}
+
+	if result.success {
+		return result
+	}
+
+	logLower := strings.ToLower(logSection)
+
+	type pattern struct {
+		needles []string
+		mode    string
+	}
+	patterns := []pattern{
+		{needles: []string{"no such host", "server misbehaving"}, mode: "dns"},
+		{needles: []string{"context deadline exceeded", "i/o timeout"}, mode: "timeout"},
+		{needles: []string{"x509", "certificate"}, mode: "tls"},
+		{needles: []string{"connection refused"}, mode: "connection_refused"},
+	}
+
+	for _, p := range patterns {
+		for _, needle := range p.needles {
+			if strings.Contains(logLower, needle) {
+				result.failureMode = p.mode
+				result.failureDetail = extractDetail(logSection, needle)
+				return result
+			}
+		}
+	}
+
+	// Check for server error (5xx) from the HTTP status code.
+	if result.httpStatus >= 500 && result.httpStatus < 600 {
+		result.failureMode = "server_error"
+		result.failureDetail = fmt.Sprintf("HTTP %d", result.httpStatus)
+		return result
+	}
+
+	result.failureMode = "unknown"
+	result.failureDetail = "probe failed with no recognized error pattern"
+	return result
+}
+
+func extractDetail(logSection, needle string) string {
+	needleLower := strings.ToLower(needle)
+	for _, line := range strings.Split(logSection, "\n") {
+		if strings.Contains(strings.ToLower(line), needleLower) {
+			line = strings.TrimSpace(line)
+
+			// Try to extract just the err= or msg= value for concise detail.
+			for _, prefix := range []string{"err=", "msg="} {
+				if idx := strings.Index(line, prefix); idx >= 0 {
+					snippet := line[idx:]
+					if len(snippet) > 200 {
+						snippet = snippet[:200] + "..."
+					}
+					return snippet
+				}
+			}
+
+			if len(line) > 200 {
+				line = line[:200] + "..."
+			}
+			return line
+		}
+	}
+	return needle
+}
+
+// checkBlackboxProbe queries the blackbox exporter's /probe endpoint by exec'ing
+// into the blackbox-exporter pod and classifies the result.
+//
+// Informational-only check.
+func (i *Investigation) checkBlackboxProbe(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
+	consoleURL := r.Cluster.Console().URL()
+	if consoleURL == "" {
+		notes.AppendWarning("Blackbox Probe: unable to determine console URL from cluster info")
+		return
+	}
+
+	restConfig, err := getRestConfig(r)
+	if err != nil {
+		notes.AppendWarning("Blackbox Probe: unable to get REST config - %v", err)
+		return
+	}
+
+	output, err := i.blackboxProber.runProbe(ctx, r.K8sClient, restConfig, consoleURL)
+	if err != nil {
+		notes.AppendWarning("Blackbox Probe: failed to query blackbox exporter - %v", err)
+		return
+	}
+
+	pr := parseProbeResponse(output)
+	if pr.success {
+		notes.AppendSuccess("Blackbox Probe: probe succeeded (HTTP %d, %.2fs) for %s", pr.httpStatus, pr.duration, consoleURL)
+	} else {
+		notes.AppendWarning("Blackbox Probe: probe FAILED for %s — failure mode: %s — %s", consoleURL, pr.failureMode, pr.failureDetail)
 	}
 }
 

--- a/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
+++ b/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
@@ -4,11 +4,14 @@ package consoleerrorbudgetburn
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
@@ -24,7 +27,9 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -112,7 +117,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	// Check router pod health in openshift-ingress.
 	// Applies to: Classic + HCP.
-	i.checkPodHealth(ctx, r.K8sClient, "openshift-ingress", "Router", notes)
+	i.checkPodHealth(ctx, r.K8sClient, "openshift-ingress", "Router", client.MatchingLabels{"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}, notes)
 
 	// Check console service reachability from within the cluster.
 	// Applies to: Classic + HCP.
@@ -120,11 +125,11 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	// Check console pod health in openshift-console.
 	// Applies to: Classic + HCP.
-	i.checkPodHealth(ctx, r.K8sClient, "openshift-console", "Console", notes)
+	i.checkPodHealth(ctx, r.K8sClient, "openshift-console", "Console", client.MatchingLabels{"app": "console", "component": "ui"}, notes)
 
 	// Check health of nodes running console pods.
 	// Applies to: Classic + HCP.
-	i.checkNodeHealth(ctx, r.K8sClient, notes)
+	i.checkNodeHealth(ctx, r, notes)
 
 	// AWS-specific checks.
 	// Applies to: AWS clusters only.
@@ -275,7 +280,7 @@ func (i *Investigation) checkRoute53DNS(ctx context.Context, r *investigation.Re
 	clusterDomain := domainPrefix + "." + baseDomain
 	appsRecordName := "\\052.apps." + clusterDomain + "."
 
-	privateZoneID, err := r.AwsClient.FindHostedZone(clusterDomain, true)
+	privateZoneID, err := r.AwsClient.FindHostedZone(ctx, clusterDomain, true)
 	if err != nil {
 		notes.AppendWarning("Route53: error looking up private hosted zone for %s — %v", clusterDomain, err)
 		return false
@@ -288,7 +293,7 @@ func (i *Investigation) checkRoute53DNS(ctx context.Context, r *investigation.Re
 		return false
 	}
 
-	hasPrivateRecord, err := r.AwsClient.HasResourceRecordSet(privateZoneID, appsRecordName, "A")
+	hasPrivateRecord, err := r.AwsClient.HasResourceRecordSet(ctx, privateZoneID, appsRecordName, "A")
 	if err != nil {
 		notes.AppendWarning("Route53: error checking *.apps record in private zone for %s — %v", clusterDomain, err)
 		return false
@@ -297,7 +302,7 @@ func (i *Investigation) checkRoute53DNS(ctx context.Context, r *investigation.Re
 
 	isPrivateLink := r.Cluster.AWS() != nil && r.Cluster.AWS().PrivateLink()
 	if !isPrivateLink {
-		publicZoneID, err := r.AwsClient.FindHostedZone(baseDomain, false)
+		publicZoneID, err := r.AwsClient.FindHostedZone(ctx, baseDomain, false)
 		if err != nil {
 			notes.AppendWarning("Route53: error looking up public hosted zone for %s — %v", baseDomain, err)
 			return false
@@ -307,7 +312,7 @@ func (i *Investigation) checkRoute53DNS(ctx context.Context, r *investigation.Re
 			return false
 		}
 
-		hasPublicRecord, err := r.AwsClient.HasResourceRecordSet(publicZoneID, appsRecordName, "A")
+		hasPublicRecord, err := r.AwsClient.HasResourceRecordSet(ctx, publicZoneID, appsRecordName, "A")
 		if err != nil {
 			notes.AppendWarning("Route53: error checking *.apps record in public zone for %s — %v", clusterDomain, err)
 			return false
@@ -346,7 +351,7 @@ func (i *Investigation) checkDHCPOptions(ctx context.Context, r *investigation.R
 		return
 	}
 
-	servers, err := r.AwsClient.GetVpcDhcpConfiguration(infraID)
+	servers, err := r.AwsClient.GetVpcDhcpConfiguration(ctx, infraID)
 	if err != nil {
 		notes.AppendWarning("DHCP: unable to check VPC DHCP options — %v", err)
 		return
@@ -432,15 +437,15 @@ func (i *Investigation) checkLoadBalancerHealth(ctx context.Context, r *investig
 
 	switch lbType {
 	case "NLB":
-		i.checkNLBHealth(r, hostname, notes)
+		i.checkNLBHealth(ctx, r, hostname, notes)
 	default:
-		i.checkCLBHealth(r, hostname, notes)
+		i.checkCLBHealth(ctx, r, hostname, notes)
 	}
 }
 
 // checkNLBHealth finds an NLB by DNS name and reports target health.
-func (i *Investigation) checkNLBHealth(r *investigation.Resources, hostname string, notes *notewriter.NoteWriter) {
-	arn, name, err := r.AwsClient.FindNLBByDNSName(hostname)
+func (i *Investigation) checkNLBHealth(ctx context.Context, r *investigation.Resources, hostname string, notes *notewriter.NoteWriter) {
+	arn, name, err := r.AwsClient.FindNLBByDNSName(ctx, hostname)
 	if err != nil {
 		notes.AppendWarning("LB Health: failed to look up NLB — %v", err)
 		return
@@ -450,7 +455,7 @@ func (i *Investigation) checkNLBHealth(r *investigation.Resources, hostname stri
 		return
 	}
 
-	targets, err := r.AwsClient.GetNLBTargetHealth(arn)
+	targets, err := r.AwsClient.GetNLBTargetHealth(ctx, arn)
 	if err != nil {
 		notes.AppendWarning("LB Health: failed to get NLB target health for %s — %v", name, err)
 		return
@@ -490,8 +495,8 @@ func reportNLBTargetHealth(lbName string, targets []aws.NLBTargetHealth, notes *
 }
 
 // checkCLBHealth finds a CLB by DNS name and reports instance health.
-func (i *Investigation) checkCLBHealth(r *investigation.Resources, hostname string, notes *notewriter.NoteWriter) {
-	name, err := r.AwsClient.FindCLBByDNSName(hostname)
+func (i *Investigation) checkCLBHealth(ctx context.Context, r *investigation.Resources, hostname string, notes *notewriter.NoteWriter) {
+	name, err := r.AwsClient.FindCLBByDNSName(ctx, hostname)
 	if err != nil {
 		notes.AppendWarning("LB Health: failed to look up CLB — %v", err)
 		return
@@ -501,7 +506,7 @@ func (i *Investigation) checkCLBHealth(r *investigation.Resources, hostname stri
 		return
 	}
 
-	instances, err := r.AwsClient.GetCLBInstanceHealth(name)
+	instances, err := r.AwsClient.GetCLBInstanceHealth(ctx, name)
 	if err != nil {
 		notes.AppendWarning("LB Health: failed to get CLB instance health for %s — %v", name, err)
 		return
@@ -593,11 +598,11 @@ func (i *Investigation) checkUpstreamDNS(ctx context.Context, k8sClient k8sclien
 // failed, pending, crashlooping, or not-ready pods as well as warning events.
 //
 // Informational-only check.
-func (i *Investigation) checkPodHealth(ctx context.Context, k8sClient k8sclient.Client, namespace, label string, notes *notewriter.NoteWriter) {
+func (i *Investigation) checkPodHealth(ctx context.Context, k8sClient k8sclient.Client, namespace, label string, matchLabels client.MatchingLabels, notes *notewriter.NoteWriter) {
 	const restartThreshold int32 = 3
 
 	podList := &corev1.PodList{}
-	if err := k8sClient.List(ctx, podList, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.List(ctx, podList, client.InNamespace(namespace), matchLabels); err != nil {
 		notes.AppendWarning("%s: failed to list pods in %s - %v", label, namespace, err)
 		return
 	}
@@ -654,26 +659,24 @@ func (i *Investigation) checkPodHealth(ctx context.Context, k8sClient k8sclient.
 		}
 	}
 
-	// Check for warning events in the namespace.
-	eventList := &corev1.EventList{}
-	var warningEvents []string
-	if err := k8sClient.List(ctx, eventList, client.InNamespace(namespace)); err != nil {
-		notes.AppendWarning("%s: failed to list events in %s - %v", label, namespace, err)
-	} else {
-		for _, event := range eventList.Items {
-			if event.Type != corev1.EventTypeNormal {
-				msg := event.Message
-				if len(msg) > 120 {
-					msg = msg[:120] + "..."
-				}
-				countStr := ""
-				if event.Count > 1 {
-					countStr = fmt.Sprintf(" (x%d)", event.Count)
-				}
-				warningEvents = append(warningEvents, fmt.Sprintf("  %s/%s: %s%s - %s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, countStr, msg))
+	// if all router pods are unhealthy suggest a restart
+	if label == "Router" && len(issues) > 0 {
+		unhealthyPods := make(map[string]bool, len(issues))
+		for _, issue := range issues {
+			unhealthyPods[issue.name] = true
+		}
+		activePods := 0
+		for _, pod := range podList.Items {
+			if pod.Status.Phase != corev1.PodSucceeded {
+				activePods++
 			}
 		}
+		if len(unhealthyPods) >= activePods {
+			notes.AppendWarning("%s: no healthy router pods present; consider restarting: `oc -n openshift-ingress rollout restart deploy/router-default`", label)
+		}
 	}
+
+	warningEvents := collectWarningEvents(ctx, k8sClient, namespace, label, podList.Items, notes)
 
 	if len(issues) == 0 && len(warningEvents) == 0 {
 		notes.AppendSuccess("%s: all %d pod(s) in %s are running and ready", label, len(podList.Items), namespace)
@@ -696,18 +699,58 @@ func (i *Investigation) checkPodHealth(ctx context.Context, k8sClient k8sclient.
 	notes.AppendWarning("%s: %s", label, sb.String())
 }
 
+// collectWarningEvents returns recent warning events for pods matched by the label selector.
+func collectWarningEvents(ctx context.Context, k8sClient k8sclient.Client, namespace, label string, pods []corev1.Pod, notes *notewriter.NoteWriter) []string {
+	podNames := make(map[string]bool, len(pods))
+	for _, pod := range pods {
+		podNames[pod.Name] = true
+	}
+
+	eventList := &corev1.EventList{}
+	if err := k8sClient.List(ctx, eventList, client.InNamespace(namespace)); err != nil {
+		notes.AppendWarning("%s: failed to list events in %s - %v", label, namespace, err)
+		return nil
+	}
+
+	const maxWarningEvents = 5
+	warningEvents := make([]string, 0, maxWarningEvents)
+	recentCutoff := time.Now().Add(-30 * time.Minute)
+	for _, event := range eventList.Items {
+		if event.Type == corev1.EventTypeNormal {
+			continue
+		}
+		if event.InvolvedObject.Kind != "Pod" || !podNames[event.InvolvedObject.Name] {
+			continue
+		}
+		eventTime := event.LastTimestamp.Time
+		if eventTime.IsZero() {
+			eventTime = event.CreationTimestamp.Time
+		}
+		if eventTime.Before(recentCutoff) {
+			continue
+		}
+		msg := event.Message
+		if len(msg) > 120 {
+			msg = msg[:120] + "..."
+		}
+		countStr := ""
+		if event.Count > 1 {
+			countStr = fmt.Sprintf(" (x%d)", event.Count)
+		}
+		warningEvents = append(warningEvents, fmt.Sprintf("  %s/%s: %s%s - %s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, countStr, msg))
+		if len(warningEvents) >= maxWarningEvents {
+			break
+		}
+	}
+	return warningEvents
+}
+
 // checkConsoleService tests whether the console service is reachable from within the cluster
 // by exec'ing into a CMO pod and curling the console ClusterIP service.
 //
 // informational-only check.
 func (i *Investigation) checkConsoleService(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
-	restConfig, err := getRestConfig(r)
-	if err != nil {
-		notes.AppendWarning("Console Service: unable to get REST config - %v", err)
-		return
-	}
-
-	output, err := i.consoleChecker.checkConsoleEndpoint(ctx, r.K8sClient, restConfig)
+	output, err := i.consoleChecker.checkConsoleEndpoint(ctx, r.K8sClient, &r.RestConfig.Config)
 	if err != nil {
 		notes.AppendWarning("Console Service: unable to reach console service - %v", err)
 		return
@@ -760,10 +803,10 @@ func (d *defaultConsoleServiceChecker) checkConsoleEndpoint(ctx context.Context,
 // and Unschedulable status.
 //
 // Informational-only check.
-func (i *Investigation) checkNodeHealth(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+func (i *Investigation) checkNodeHealth(ctx context.Context, r *investigation.Resources, notes *notewriter.NoteWriter) {
 	// find which nodes run console pods
 	podList := &corev1.PodList{}
-	if err := k8sClient.List(ctx, podList, client.InNamespace("openshift-console")); err != nil {
+	if err := r.K8sClient.List(ctx, podList, client.InNamespace("openshift-console"), client.MatchingLabels{"app": "console", "component": "ui"}); err != nil {
 		notes.AppendWarning("Node Health: failed to list console pods - %v", err)
 		return
 	}
@@ -782,13 +825,15 @@ func (i *Investigation) checkNodeHealth(ctx context.Context, k8sClient k8sclient
 
 	var issues []string
 	nodeCount := 0
+	nodeCapacity := make(map[string]corev1.ResourceList, len(nodeNames))
 	for nodeName := range nodeNames {
 		node := &corev1.Node{}
-		if err := k8sClient.Get(ctx, ktypes.NamespacedName{Name: nodeName}, node); err != nil {
+		if err := r.K8sClient.Get(ctx, ktypes.NamespacedName{Name: nodeName}, node); err != nil {
 			issues = append(issues, fmt.Sprintf("%s: failed to get node - %v", nodeName, err))
 			continue
 		}
 		nodeCount++
+		nodeCapacity[nodeName] = node.Status.Capacity
 
 		// Check NodeReady condition using the utils helper.
 		if readyCond, found := nodeutils.FindReadyCondition(*node); found {
@@ -826,6 +871,92 @@ func (i *Investigation) checkNodeHealth(ctx context.Context, k8sClient k8sclient
 	} else {
 		notes.AppendWarning("Node Health: %d issue(s) on nodes running console pods:\n  %s", len(issues), strings.Join(issues, "\n  "))
 	}
+
+	i.checkNodeUtilization(ctx, r, nodeNames, nodeCapacity, notes)
+}
+
+type nodeMetricsList struct {
+	Items []nodeMetrics `json:"items"`
+}
+
+type nodeMetrics struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Usage map[string]string `json:"usage"`
+}
+
+// checkNodeUtilization queries for current CPU/mem usage on nodes running console
+// pods. Warn if usage is above 80%
+func (i *Investigation) checkNodeUtilization(ctx context.Context, r *investigation.Resources, nodeNames map[string]struct{}, nodeCapacity map[string]corev1.ResourceList, notes *notewriter.NoteWriter) {
+	clientset, err := kubernetes.NewForConfig(&r.RestConfig.Config)
+	if err != nil {
+		notes.AppendWarning("Node Utilization: unable to create clientset - %v", err)
+		return
+	}
+
+	body, err := clientset.Discovery().RESTClient().Get().AbsPath("/apis/metrics.k8s.io/v1beta1/nodes").DoRaw(ctx)
+	if err != nil {
+		notes.AppendWarning("Node Utilization: unable to query metrics API - %v", err)
+		return
+	}
+
+	var metricsList nodeMetricsList
+	if err := json.Unmarshal(body, &metricsList); err != nil {
+		notes.AppendWarning("Node Utilization: failed to parse metrics response - %v", err)
+		return
+	}
+
+	const utilizationThreshold = 80
+	perNode := make([]string, 0, len(nodeNames))
+	var overThreshold []string
+
+	for _, nm := range metricsList.Items {
+		if _, ok := nodeNames[nm.Metadata.Name]; !ok {
+			continue
+		}
+		capacity, ok := nodeCapacity[nm.Metadata.Name]
+		if !ok {
+			continue
+		}
+
+		cpuUsage, err := resource.ParseQuantity(nm.Usage["cpu"])
+		if err != nil {
+			continue
+		}
+		memUsage, err := resource.ParseQuantity(nm.Usage["memory"])
+		if err != nil {
+			continue
+		}
+		cpuCap := capacity[corev1.ResourceCPU]
+		memCap := capacity[corev1.ResourceMemory]
+
+		cpuPct := 0
+		if cpuCap.MilliValue() > 0 {
+			cpuPct = int(math.Round(float64(cpuUsage.MilliValue()) * 100 / float64(cpuCap.MilliValue())))
+		}
+		memPct := 0
+		if memCap.Value() > 0 {
+			memPct = int(math.Round(float64(memUsage.Value()) * 100 / float64(memCap.Value())))
+		}
+
+		perNode = append(perNode, fmt.Sprintf("%s: CPU %d%%, Memory %d%%", nm.Metadata.Name, cpuPct, memPct))
+		if cpuPct >= utilizationThreshold || memPct >= utilizationThreshold {
+			overThreshold = append(overThreshold, fmt.Sprintf("%s (CPU: %d%%, Memory: %d%%)", nm.Metadata.Name, cpuPct, memPct))
+		}
+	}
+
+	if len(perNode) == 0 {
+		notes.AppendWarning("Node Utilization: no metrics available for console-pod nodes")
+		return
+	}
+
+	if len(overThreshold) > 0 {
+		notes.AppendWarning("Node Utilization: %d node(s) with >=80%% utilization — %s", len(overThreshold), strings.Join(overThreshold, "; "))
+	} else {
+		notes.AppendSuccess("Node Utilization: all console-pod nodes below 80%% CPU and Memory utilization")
+	}
+	notes.AppendSuccess("Node Utilization per-node:\n  %s", strings.Join(perNode, "\n  "))
 }
 
 // defaultBlackboxProber implements blackboxProber by exec'ing wget into the
@@ -857,10 +988,11 @@ func (d *defaultBlackboxProber) runProbe(ctx context.Context, k8sClient k8sclien
 	output, err := k8sclient.ExecInPod(ctx, restConfig, bbPod, "blackbox-exporter", []string{
 		"wget", "-qO-", probeURL,
 	})
+	output = strings.TrimSpace(output)
 	if err != nil {
 		return output, fmt.Errorf("exec failed: %w", err)
 	}
-	return strings.TrimSpace(output), nil
+	return output, nil
 }
 
 type probeResult struct {
@@ -974,13 +1106,7 @@ func (i *Investigation) checkBlackboxProbe(ctx context.Context, r *investigation
 		return
 	}
 
-	restConfig, err := getRestConfig(r)
-	if err != nil {
-		notes.AppendWarning("Blackbox Probe: unable to get REST config - %v", err)
-		return
-	}
-
-	output, err := i.blackboxProber.runProbe(ctx, r.K8sClient, restConfig, consoleURL)
+	output, err := i.blackboxProber.runProbe(ctx, r.K8sClient, &r.RestConfig.Config, consoleURL)
 	if err != nil {
 		notes.AppendWarning("Blackbox Probe: failed to query blackbox exporter - %v", err)
 		return
@@ -992,14 +1118,6 @@ func (i *Investigation) checkBlackboxProbe(ctx context.Context, r *investigation
 	} else {
 		notes.AppendWarning("Blackbox Probe: probe FAILED for %s — failure mode: %s — %s", consoleURL, pr.failureMode, pr.failureDetail)
 	}
-}
-
-// getRestConfig extracts the *rest.Config from the investigation resources.
-func getRestConfig(r *investigation.Resources) (*rest.Config, error) {
-	if r.RestConfig != nil {
-		return &r.RestConfig.Config, nil
-	}
-	return k8sclient.GetRestConfig(r.K8sClient)
 }
 
 func (i *Investigation) Name() string {

--- a/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn_test.go
+++ b/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn_test.go
@@ -34,11 +34,14 @@ func newFakeClient(objs ...client.Object) client.Client {
 	return fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(objs...).Build()
 }
 
-func newTestCluster(id, machineCIDR string) *cmv1.Cluster {
-	cluster, _ := cmv1.NewCluster().
+func newTestCluster(id, machineCIDR, consoleURL string) *cmv1.Cluster {
+	builder := cmv1.NewCluster().
 		ID(id).
-		Network(cmv1.NewNetwork().MachineCIDR(machineCIDR)).
-		Build()
+		Network(cmv1.NewNetwork().MachineCIDR(machineCIDR))
+	if consoleURL != "" {
+		builder = builder.Console(cmv1.NewClusterConsole().URL(consoleURL))
+	}
+	cluster, _ := builder.Build()
 	return cluster
 }
 
@@ -84,6 +87,135 @@ func testRestConfig() *backplane.RestConfig {
 	return &backplane.RestConfig{Config: rest.Config{Host: "https://test-cluster:6443"}}
 }
 
+// mockBlackboxProber implements blackboxProber for testing.
+type mockBlackboxProber struct {
+	output string
+	err    error
+}
+
+func (m *mockBlackboxProber) runProbe(_ context.Context, _ k8sclient.Client, _ *rest.Config, _ string) (string, error) {
+	return m.output, m.err
+}
+
+func healthyBlackboxProber() *mockBlackboxProber {
+	return &mockBlackboxProber{output: successfulProbeResponse}
+}
+
+const successfulProbeResponse = `Logs for the probe:
+ts=2024-01-01T00:00:00.000Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Beginning probe"
+ts=2024-01-01T00:00:00.001Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolving target address" ip_protocol=ip4
+ts=2024-01-01T00:00:00.002Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolved target address" ip=10.0.1.50
+ts=2024-01-01T00:00:00.003Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Making HTTP request" url=https://10.0.1.50 host=console-openshift-console.apps.test.example.com
+ts=2024-01-01T00:00:00.200Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Received HTTP response" status_code=200
+ts=2024-01-01T00:00:00.201Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Probe succeeded" duration_seconds=0.198
+
+Metrics that would have been returned:
+# HELP probe_success Displays whether or not the probe was a success
+# TYPE probe_success gauge
+probe_success 1
+# HELP probe_http_status_code Response HTTP status code
+# TYPE probe_http_status_code gauge
+probe_http_status_code 200
+# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
+# TYPE probe_duration_seconds gauge
+probe_duration_seconds 0.198
+`
+
+const dnsFailureProbeResponse = `Logs for the probe:
+ts=2024-01-01T00:00:00.000Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Beginning probe"
+ts=2024-01-01T00:00:00.001Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolving target address" ip_protocol=ip4
+ts=2024-01-01T00:00:00.002Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=error msg="Resolution failed" err="lookup console-openshift-console.apps.test.example.com: no such host"
+ts=2024-01-01T00:00:00.002Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Probe failed" duration_seconds=0.001
+
+Metrics that would have been returned:
+# HELP probe_success Displays whether or not the probe was a success
+# TYPE probe_success gauge
+probe_success 0
+# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
+# TYPE probe_duration_seconds gauge
+probe_duration_seconds 0.001
+`
+
+const timeoutProbeResponse = `Logs for the probe:
+ts=2024-01-01T00:00:00.000Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Beginning probe"
+ts=2024-01-01T00:00:00.001Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolving target address" ip_protocol=ip4
+ts=2024-01-01T00:00:00.002Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolved target address" ip=10.0.1.50
+ts=2024-01-01T00:02:00.000Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=error msg="Error making HTTP request" err="Get \"https://10.0.1.50\": context deadline exceeded"
+ts=2024-01-01T00:02:00.001Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Probe failed" duration_seconds=119.999
+
+Metrics that would have been returned:
+# HELP probe_success Displays whether or not the probe was a success
+# TYPE probe_success gauge
+probe_success 0
+# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
+# TYPE probe_duration_seconds gauge
+probe_duration_seconds 119.999
+`
+
+const tlsErrorProbeResponse = `Logs for the probe:
+ts=2024-01-01T00:00:00.000Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Beginning probe"
+ts=2024-01-01T00:00:00.001Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolving target address" ip_protocol=ip4
+ts=2024-01-01T00:00:00.002Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolved target address" ip=10.0.1.50
+ts=2024-01-01T00:00:00.100Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=error msg="Error making HTTP request" err="Get \"https://10.0.1.50\": x509: certificate signed by unknown authority"
+ts=2024-01-01T00:00:00.101Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Probe failed" duration_seconds=0.099
+
+Metrics that would have been returned:
+# HELP probe_success Displays whether or not the probe was a success
+# TYPE probe_success gauge
+probe_success 0
+# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
+# TYPE probe_duration_seconds gauge
+probe_duration_seconds 0.099
+`
+
+const connectionRefusedProbeResponse = `Logs for the probe:
+ts=2024-01-01T00:00:00.000Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Beginning probe"
+ts=2024-01-01T00:00:00.001Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolving target address" ip_protocol=ip4
+ts=2024-01-01T00:00:00.002Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolved target address" ip=10.0.1.50
+ts=2024-01-01T00:00:00.003Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=error msg="Error making HTTP request" err="Get \"https://10.0.1.50\": dial tcp 10.0.1.50:443: connect: connection refused"
+ts=2024-01-01T00:00:00.003Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Probe failed" duration_seconds=0.002
+
+Metrics that would have been returned:
+# HELP probe_success Displays whether or not the probe was a success
+# TYPE probe_success gauge
+probe_success 0
+# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
+# TYPE probe_duration_seconds gauge
+probe_duration_seconds 0.002
+`
+
+const serverErrorProbeResponse = `Logs for the probe:
+ts=2024-01-01T00:00:00.000Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Beginning probe"
+ts=2024-01-01T00:00:00.001Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolving target address" ip_protocol=ip4
+ts=2024-01-01T00:00:00.002Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Resolved target address" ip=10.0.1.50
+ts=2024-01-01T00:00:00.100Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Received HTTP response" status_code=503
+ts=2024-01-01T00:00:00.101Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Probe failed" duration_seconds=0.099
+
+Metrics that would have been returned:
+# HELP probe_success Displays whether or not the probe was a success
+# TYPE probe_success gauge
+probe_success 0
+# HELP probe_http_status_code Response HTTP status code
+# TYPE probe_http_status_code gauge
+probe_http_status_code 503
+# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
+# TYPE probe_duration_seconds gauge
+probe_duration_seconds 0.099
+`
+
+const unknownFailureProbeResponse = `Logs for the probe:
+ts=2024-01-01T00:00:00.000Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Beginning probe"
+ts=2024-01-01T00:00:00.100Z caller=handler.go:119 module=http_2xx target=https://console-openshift-console.apps.test.example.com level=debug msg="Probe failed" duration_seconds=0.099
+
+Metrics that would have been returned:
+# HELP probe_success Displays whether or not the probe was a success
+# TYPE probe_success gauge
+probe_success 0
+# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
+# TYPE probe_duration_seconds gauge
+probe_duration_seconds 0.099
+`
+
 func TestName(t *testing.T) {
 	inv := &Investigation{}
 	if inv.Name() != "consoleerrorbudgetburn" {
@@ -117,7 +249,7 @@ func TestIsExperimental(t *testing.T) {
 func TestCheckAllowedSourceRanges_NotConfigured(t *testing.T) {
 	ic := newDefaultIngressController(nil)
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -139,7 +271,7 @@ func TestCheckAllowedSourceRanges_MachineIncluded(t *testing.T) {
 	// CIDR 10.0.0.0/16 is contained within allowed range 10.0.0.0/8
 	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/8"})
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -161,7 +293,7 @@ func TestCheckAllowedSourceRanges_ExactMatch(t *testing.T) {
 	// Exact match: allowed 10.0.0.0/16 == machine CIDR 10.0.0.0/16
 	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/16"})
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -183,7 +315,7 @@ func TestCheckAllowedSourceRanges_SmallerRangeDoesNotContain(t *testing.T) {
 	// Allowed 10.0.0.0/24 does NOT contain 10.0.0.0/16
 	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/24"})
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -205,7 +337,7 @@ func TestCheckAllowedSourceRanges_MachineExcluded(t *testing.T) {
 	// CIDR 10.0.0.0/16 is not covered by 192.168.0.0/16
 	ic := newDefaultIngressController([]operatorv1.CIDR{"192.168.0.0/16"})
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -227,7 +359,7 @@ func TestCheckAllowedSourceRanges_MultipleRangesOneMatch(t *testing.T) {
 	// First range doesn't match, but second range covers the machine CIDR
 	ic := newDefaultIngressController([]operatorv1.CIDR{"192.168.0.0/16", "10.0.0.0/8"})
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -249,7 +381,7 @@ func TestCheckAllowedSourceRanges_EmptyMachineCIDR(t *testing.T) {
 	// CIDR empty; cluster info incomplete
 	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/8"})
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "")
+	cluster := newTestCluster("test-cluster", "", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -270,7 +402,7 @@ func TestCheckAllowedSourceRanges_EmptyMachineCIDR(t *testing.T) {
 func TestCheckAllowedSourceRanges_IngressControllerNotFound(t *testing.T) {
 	// No IngressController in the fake client
 	k8sClient := newFakeClient()
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -302,7 +434,7 @@ func TestCheckAllowedSourceRanges_NilLoadBalancer(t *testing.T) {
 		},
 	}
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -324,7 +456,7 @@ func TestCheckAllowedSourceRanges_EmptyAllowedSourceRanges(t *testing.T) {
 	// LoadBalancer exists but AllowedSourceRanges is empty slice
 	ic := newDefaultIngressController([]operatorv1.CIDR{})
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	notes := newTestNotes()
 	inv := &Investigation{}
 
@@ -604,7 +736,7 @@ func TestCheckPodHealth_Router_ExcessiveRestarts(t *testing.T) {
 // checkConsoleService unit tests
 
 func TestCheckConsoleService_Healthy(t *testing.T) {
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	k8sClient := newFakeClient()
 	notes := newTestNotes()
 	inv := &Investigation{consoleChecker: &mockConsoleServiceChecker{output: "200"}}
@@ -627,7 +759,7 @@ func TestCheckConsoleService_Healthy(t *testing.T) {
 }
 
 func TestCheckConsoleService_NonOK(t *testing.T) {
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	k8sClient := newFakeClient()
 	notes := newTestNotes()
 	inv := &Investigation{consoleChecker: &mockConsoleServiceChecker{output: "503"}}
@@ -647,7 +779,7 @@ func TestCheckConsoleService_NonOK(t *testing.T) {
 }
 
 func TestCheckConsoleService_ExecError(t *testing.T) {
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
 	k8sClient := newFakeClient()
 	notes := newTestNotes()
 	inv := &Investigation{consoleChecker: &mockConsoleServiceChecker{err: fmt.Errorf("connection refused")}}
@@ -856,7 +988,7 @@ func TestRun_HCP_SkipsAllowedSourceRanges(t *testing.T) {
 	consolePod := newConsolePod("console-abc", "node-1")
 	node := newTestNode("node-1", healthyNodeConditions(), false)
 	k8sClient := newFakeClient(ic, dns, routerPod, consolePod, node)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "https://console.test.example.com")
 
 	rb := &investigation.ResourceBuilderMock{
 		Resources: &investigation.Resources{
@@ -867,7 +999,7 @@ func TestRun_HCP_SkipsAllowedSourceRanges(t *testing.T) {
 		},
 	}
 
-	inv := &Investigation{consoleChecker: healthyConsoleChecker()}
+	inv := &Investigation{consoleChecker: healthyConsoleChecker(), blackboxProber: healthyBlackboxProber()}
 	result, err := inv.Run(rb)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -896,17 +1028,18 @@ func TestRun_AllowedSourceRangesMisconfigured(t *testing.T) {
 	// Classic cluster with machine CIDR excluded from allowedSourceRanges
 	ic := newDefaultIngressController([]operatorv1.CIDR{"192.168.0.0/16"})
 	k8sClient := newFakeClient(ic)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "https://console.test.example.com")
 
 	rb := &investigation.ResourceBuilderMock{
 		Resources: &investigation.Resources{
-			Cluster:   cluster,
-			K8sClient: k8sClient,
-			IsHCP:     false,
+			Cluster:    cluster,
+			K8sClient:  k8sClient,
+			IsHCP:      false,
+			RestConfig: testRestConfig(),
 		},
 	}
 
-	inv := &Investigation{consoleChecker: healthyConsoleChecker()}
+	inv := &Investigation{consoleChecker: healthyConsoleChecker(), blackboxProber: healthyBlackboxProber()}
 	result, err := inv.Run(rb)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -947,7 +1080,7 @@ func TestRun_AllowedSourceRangesOK(t *testing.T) {
 	consolePod := newConsolePod("console-abc", "node-1")
 	node := newTestNode("node-1", healthyNodeConditions(), false)
 	k8sClient := newFakeClient(ic, dns, routerPod, consolePod, node)
-	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "https://console.test.example.com")
 
 	rb := &investigation.ResourceBuilderMock{
 		Resources: &investigation.Resources{
@@ -958,7 +1091,7 @@ func TestRun_AllowedSourceRangesOK(t *testing.T) {
 		},
 	}
 
-	inv := &Investigation{consoleChecker: healthyConsoleChecker()}
+	inv := &Investigation{consoleChecker: healthyConsoleChecker(), blackboxProber: healthyBlackboxProber()}
 	result, err := inv.Run(rb)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1008,5 +1141,193 @@ func TestRun_ClusterAccessError(t *testing.T) {
 	}
 	if !hasEscalate {
 		t.Error("expected escalate action for cluster access error")
+	}
+}
+
+// parseProbeResponse unit tests
+
+func TestParseProbeResponse_Success(t *testing.T) {
+	pr := parseProbeResponse(successfulProbeResponse)
+	if !pr.success {
+		t.Error("expected success=true")
+	}
+	if pr.httpStatus != 200 {
+		t.Errorf("expected httpStatus=200, got %d", pr.httpStatus)
+	}
+	if pr.duration < 0.19 || pr.duration > 0.20 {
+		t.Errorf("expected duration≈0.198, got %f", pr.duration)
+	}
+}
+
+func TestParseProbeResponse_DNSError(t *testing.T) {
+	pr := parseProbeResponse(dnsFailureProbeResponse)
+	if pr.success {
+		t.Error("expected success=false")
+	}
+	if pr.failureMode != "dns" {
+		t.Errorf("expected failureMode='dns', got %q", pr.failureMode)
+	}
+	if !strings.Contains(pr.failureDetail, "no such host") {
+		t.Errorf("expected failureDetail to contain 'no such host', got %q", pr.failureDetail)
+	}
+}
+
+func TestParseProbeResponse_Timeout(t *testing.T) {
+	pr := parseProbeResponse(timeoutProbeResponse)
+	if pr.success {
+		t.Error("expected success=false")
+	}
+	if pr.failureMode != "timeout" {
+		t.Errorf("expected failureMode='timeout', got %q", pr.failureMode)
+	}
+	if !strings.Contains(pr.failureDetail, "context deadline exceeded") {
+		t.Errorf("expected failureDetail to contain 'context deadline exceeded', got %q", pr.failureDetail)
+	}
+}
+
+func TestParseProbeResponse_TLSError(t *testing.T) {
+	pr := parseProbeResponse(tlsErrorProbeResponse)
+	if pr.success {
+		t.Error("expected success=false")
+	}
+	if pr.failureMode != "tls" {
+		t.Errorf("expected failureMode='tls', got %q", pr.failureMode)
+	}
+	if !strings.Contains(pr.failureDetail, "x509") {
+		t.Errorf("expected failureDetail to contain 'x509', got %q", pr.failureDetail)
+	}
+}
+
+func TestParseProbeResponse_ConnectionRefused(t *testing.T) {
+	pr := parseProbeResponse(connectionRefusedProbeResponse)
+	if pr.success {
+		t.Error("expected success=false")
+	}
+	if pr.failureMode != "connection_refused" {
+		t.Errorf("expected failureMode='connection_refused', got %q", pr.failureMode)
+	}
+	if !strings.Contains(pr.failureDetail, "connection refused") {
+		t.Errorf("expected failureDetail to contain 'connection refused', got %q", pr.failureDetail)
+	}
+}
+
+func TestParseProbeResponse_ServerError(t *testing.T) {
+	pr := parseProbeResponse(serverErrorProbeResponse)
+	if pr.success {
+		t.Error("expected success=false")
+	}
+	if pr.failureMode != "server_error" {
+		t.Errorf("expected failureMode='server_error', got %q", pr.failureMode)
+	}
+	if pr.httpStatus != 503 {
+		t.Errorf("expected httpStatus=503, got %d", pr.httpStatus)
+	}
+}
+
+func TestParseProbeResponse_UnknownFailure(t *testing.T) {
+	pr := parseProbeResponse(unknownFailureProbeResponse)
+	if pr.success {
+		t.Error("expected success=false")
+	}
+	if pr.failureMode != "unknown" {
+		t.Errorf("expected failureMode='unknown', got %q", pr.failureMode)
+	}
+}
+
+func TestParseProbeResponse_EmptyResponse(t *testing.T) {
+	pr := parseProbeResponse("")
+	if pr.success {
+		t.Error("expected success=false for empty response")
+	}
+	if pr.failureMode != "unknown" {
+		t.Errorf("expected failureMode='unknown' for empty response, got %q", pr.failureMode)
+	}
+}
+
+// checkBlackboxProbe unit tests
+
+func TestCheckBlackboxProbe_Success(t *testing.T) {
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "https://console.test.example.com")
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{blackboxProber: healthyBlackboxProber()}
+
+	r := &investigation.Resources{
+		Cluster:    cluster,
+		K8sClient:  k8sClient,
+		RestConfig: testRestConfig(),
+	}
+
+	inv.checkBlackboxProbe(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "probe succeeded") {
+		t.Errorf("expected 'probe succeeded' in notes, got: %s", output)
+	}
+	if !strings.Contains(output, "HTTP 200") {
+		t.Errorf("expected 'HTTP 200' in notes, got: %s", output)
+	}
+}
+
+func TestCheckBlackboxProbe_DNSFailure(t *testing.T) {
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "https://console.test.example.com")
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{blackboxProber: &mockBlackboxProber{output: dnsFailureProbeResponse}}
+
+	r := &investigation.Resources{
+		Cluster:    cluster,
+		K8sClient:  k8sClient,
+		RestConfig: testRestConfig(),
+	}
+
+	inv.checkBlackboxProbe(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "probe FAILED") {
+		t.Errorf("expected 'probe FAILED' in notes, got: %s", output)
+	}
+	if !strings.Contains(output, "dns") {
+		t.Errorf("expected 'dns' in notes, got: %s", output)
+	}
+}
+
+func TestCheckBlackboxProbe_ProberError(t *testing.T) {
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "https://console.test.example.com")
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{blackboxProber: &mockBlackboxProber{err: fmt.Errorf("service not found")}}
+
+	r := &investigation.Resources{
+		Cluster:    cluster,
+		K8sClient:  k8sClient,
+		RestConfig: testRestConfig(),
+	}
+
+	inv.checkBlackboxProbe(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "failed to query blackbox exporter") {
+		t.Errorf("expected 'failed to query blackbox exporter' in notes, got: %s", output)
+	}
+}
+
+func TestCheckBlackboxProbe_EmptyConsoleURL(t *testing.T) {
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{blackboxProber: healthyBlackboxProber()}
+
+	r := &investigation.Resources{
+		Cluster:    cluster,
+		K8sClient:  k8sClient,
+		RestConfig: testRestConfig(),
+	}
+
+	inv.checkBlackboxProbe(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "unable to determine console URL") {
+		t.Errorf("expected 'unable to determine console URL' in notes, got: %s", output)
 	}
 }

--- a/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn_test.go
+++ b/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn_test.go
@@ -3,8 +3,11 @@ package consoleerrorbudgetburn
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -112,9 +115,13 @@ func healthyConsoleChecker() *mockConsoleServiceChecker {
 	return &mockConsoleServiceChecker{output: "200"}
 }
 
-// testRestConfig returns a dummy backplane.RestConfig for tests that need getRestConfig to succeed.
+var testServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	http.Error(w, "not found", http.StatusNotFound)
+}))
+
+// testRestConfig returns a dummy backplane.RestConfig for tests that need r.RestConfig to be set.
 func testRestConfig() *backplane.RestConfig {
-	return &backplane.RestConfig{Config: rest.Config{Host: "https://test-cluster:6443"}}
+	return &backplane.RestConfig{Config: rest.Config{Host: testServer.URL}}
 }
 
 // mockBlackboxProber implements blackboxProber for testing.
@@ -636,11 +643,17 @@ func TestCheckUpstreamDNS_GetError(t *testing.T) {
 
 // checkPodHealth unit tests (Router)
 
+var (
+	routerMatchLabels  = client.MatchingLabels{"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}
+	consoleMatchLabels = client.MatchingLabels{"app": "console", "component": "ui"}
+)
+
 func newRouterPod(name string, phase corev1.PodPhase, containers []corev1.ContainerStatus) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "openshift-ingress",
+			Labels:    map[string]string{"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"},
 		},
 		Status: corev1.PodStatus{
 			Phase:             phase,
@@ -660,7 +673,7 @@ func TestCheckPodHealth_Router_AllHealthy(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", routerMatchLabels, notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "2 pod(s)") {
@@ -681,7 +694,7 @@ func TestCheckPodHealth_Router_CrashLooping(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", routerMatchLabels, notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "CrashLoopBackOff") {
@@ -697,7 +710,7 @@ func TestCheckPodHealth_Router_PodNotReady(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", routerMatchLabels, notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "not ready") {
@@ -710,7 +723,7 @@ func TestCheckPodHealth_Router_NoPods(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", routerMatchLabels, notes)
 
 	if !strings.Contains(notes.String(), "no pods found") {
 		t.Errorf("expected 'no pods found' in notes, got: %s", notes.String())
@@ -731,12 +744,13 @@ func TestCheckPodHealth_Router_WarningEvents(t *testing.T) {
 		Reason:         "Unhealthy",
 		Message:        "Readiness probe failed",
 		Count:          3,
+		LastTimestamp:  metav1.NewTime(time.Now().Add(-5 * time.Minute)),
 	}
 	k8sClient := newFakeClient(pod, event)
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", routerMatchLabels, notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "Unhealthy") {
@@ -755,11 +769,50 @@ func TestCheckPodHealth_Router_ExcessiveRestarts(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", routerMatchLabels, notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "5 restarts") {
 		t.Errorf("expected '5 restarts' in notes, got: %s", output)
+	}
+}
+
+func TestCheckPodHealth_Router_AllUnhealthy_SuggestsRestart(t *testing.T) {
+	pod1 := newRouterPod("router-default-abc", corev1.PodFailed, nil)
+	pod2 := newRouterPod("router-default-def", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: false, RestartCount: 10, State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+		}},
+	})
+	k8sClient := newFakeClient(pod1, pod2)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", routerMatchLabels, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no healthy router pods present") {
+		t.Errorf("expected restart suggestion in notes, got: %s", output)
+	}
+	if !strings.Contains(output, "rollout restart deploy/router-default") {
+		t.Errorf("expected rollout restart command in notes, got: %s", output)
+	}
+}
+
+func TestCheckPodHealth_Router_SomeHealthy_NoRestartSuggestion(t *testing.T) {
+	pod1 := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 0},
+	})
+	pod2 := newRouterPod("router-default-def", corev1.PodFailed, nil)
+	k8sClient := newFakeClient(pod1, pod2)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", routerMatchLabels, notes)
+
+	output := notes.String()
+	if strings.Contains(output, "no healthy router pods present") {
+		t.Errorf("should not suggest restart when some pods are healthy, got: %s", output)
 	}
 }
 
@@ -835,6 +888,7 @@ func newConsolePod(name, nodeName string) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "openshift-console",
+			Labels:    map[string]string{"app": "console", "component": "ui"},
 		},
 		Spec: corev1.PodSpec{
 			NodeName: nodeName,
@@ -855,7 +909,7 @@ func TestCheckPodHealth_Console_AllHealthy(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkPodHealth(context.Background(), k8sClient, "openshift-console", "Console", notes)
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-console", "Console", consoleMatchLabels, notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "Console: all 2 pod(s)") {
@@ -888,6 +942,13 @@ func healthyNodeConditions() []corev1.NodeCondition {
 	}
 }
 
+func nodeHealthResources(k8sClient k8sclient.Client) *investigation.Resources {
+	return &investigation.Resources{
+		K8sClient:  k8sClient,
+		RestConfig: testRestConfig(),
+	}
+}
+
 func TestCheckNodeHealth_AllHealthy(t *testing.T) {
 	consolePod := newConsolePod("console-abc", "node-1")
 	node := newTestNode("node-1", healthyNodeConditions(), false)
@@ -895,7 +956,7 @@ func TestCheckNodeHealth_AllHealthy(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+	inv.checkNodeHealth(context.Background(), nodeHealthResources(k8sClient), notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "1 node(s) running console pods are healthy") {
@@ -912,7 +973,7 @@ func TestCheckNodeHealth_NodeNotReady(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+	inv.checkNodeHealth(context.Background(), nodeHealthResources(k8sClient), notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "NotReady") {
@@ -930,7 +991,7 @@ func TestCheckNodeHealth_DiskPressure(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+	inv.checkNodeHealth(context.Background(), nodeHealthResources(k8sClient), notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "DiskPressure") {
@@ -943,7 +1004,7 @@ func TestCheckNodeHealth_NoConsolePods(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+	inv.checkNodeHealth(context.Background(), nodeHealthResources(k8sClient), notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "no console pods found") {
@@ -961,7 +1022,7 @@ func TestCheckNodeHealth_PIDPressure(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+	inv.checkNodeHealth(context.Background(), nodeHealthResources(k8sClient), notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "PIDPressure") {
@@ -976,7 +1037,7 @@ func TestCheckNodeHealth_Unschedulable(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+	inv.checkNodeHealth(context.Background(), nodeHealthResources(k8sClient), notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "Unschedulable") {
@@ -996,7 +1057,7 @@ func TestCheckNodeHealth_MultipleNodesOneUnhealthy(t *testing.T) {
 	notes := newTestNotes()
 	inv := &Investigation{}
 
-	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+	inv.checkNodeHealth(context.Background(), nodeHealthResources(k8sClient), notes)
 
 	output := notes.String()
 	if !strings.Contains(output, "MemoryPressure") {
@@ -1004,6 +1065,26 @@ func TestCheckNodeHealth_MultipleNodesOneUnhealthy(t *testing.T) {
 	}
 	if !strings.Contains(output, "node-2") {
 		t.Errorf("expected 'node-2' in notes, got: %s", output)
+	}
+}
+
+func TestCheckNodeHealth_MetricsUnavailable(t *testing.T) {
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", healthyNodeConditions(), false)
+	k8sClient := newFakeClient(consolePod, node)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), nodeHealthResources(k8sClient), notes)
+
+	output := notes.String()
+	// Node health conditions should still be reported.
+	if !strings.Contains(output, "1 node(s) running console pods are healthy") {
+		t.Errorf("expected healthy node message, got: %s", output)
+	}
+	// Metrics API should fail gracefully.
+	if !strings.Contains(output, "Node Utilization: unable to query metrics API") {
+		t.Errorf("expected metrics API unavailable warning, got: %s", output)
 	}
 }
 
@@ -1218,17 +1299,17 @@ func TestRun_AWSCluster_AWSChecksRun(t *testing.T) {
 	mockAws := awsmock.NewMockClient(ctrl)
 
 	// Route53 check expects: FindHostedZone (private + public), HasResourceRecordSet (private + public)
-	mockAws.EXPECT().FindHostedZone("msaary-test.4t01.s1.devshift.org", true).Return("Z1234PRIVATE", nil)
-	mockAws.EXPECT().HasResourceRecordSet("Z1234PRIVATE", "\\052.apps.msaary-test.4t01.s1.devshift.org.", "A").Return(true, nil)
-	mockAws.EXPECT().FindHostedZone("4t01.s1.devshift.org", false).Return("Z5678PUBLIC", nil)
-	mockAws.EXPECT().HasResourceRecordSet("Z5678PUBLIC", "\\052.apps.msaary-test.4t01.s1.devshift.org.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "msaary-test.4t01.s1.devshift.org", true).Return("Z1234PRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "Z1234PRIVATE", "\\052.apps.msaary-test.4t01.s1.devshift.org.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "4t01.s1.devshift.org", false).Return("Z5678PUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "Z5678PUBLIC", "\\052.apps.msaary-test.4t01.s1.devshift.org.", "A").Return(true, nil)
 
 	// DHCP check expects: GetVpcDhcpConfiguration (classic cluster, not HCP)
-	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"AmazonProvidedDNS"}, nil)
+	mockAws.EXPECT().GetVpcDhcpConfiguration(gomock.Any(), "test-cluster-infra").Return([]string{"AmazonProvidedDNS"}, nil)
 
 	// LB health check expects: FindCLBByDNSName (IC has no ProviderParameters → defaults to Classic)
-	mockAws.EXPECT().FindCLBByDNSName("test-elb-123456.us-east-1.elb.amazonaws.com").Return("test-elb", nil)
-	mockAws.EXPECT().GetCLBInstanceHealth("test-elb").Return([]aws.CLBInstanceHealth{
+	mockAws.EXPECT().FindCLBByDNSName(gomock.Any(), "test-elb-123456.us-east-1.elb.amazonaws.com").Return("test-elb", nil)
+	mockAws.EXPECT().GetCLBInstanceHealth(gomock.Any(), "test-elb").Return([]aws.CLBInstanceHealth{
 		{InstanceID: "i-001", State: "InService"},
 		{InstanceID: "i-002", State: "InService"},
 	}, nil)
@@ -1472,10 +1553,10 @@ func TestCheckRoute53DNS_AllRecordsExist(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
-	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
-	mockAws.EXPECT().FindHostedZone("example.com", false).Return("ZPUBLIC", nil)
-	mockAws.EXPECT().HasResourceRecordSet("ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "example.com", false).Return("ZPUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1498,11 +1579,11 @@ func TestCheckRoute53DNS_MissingPrivateRecord(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
-	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
 	// Public zone is still checked (both zones are evaluated before reporting).
-	mockAws.EXPECT().FindHostedZone("example.com", false).Return("ZPUBLIC", nil)
-	mockAws.EXPECT().HasResourceRecordSet("ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "example.com", false).Return("ZPUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1525,10 +1606,10 @@ func TestCheckRoute53DNS_MissingPublicRecord(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
-	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
-	mockAws.EXPECT().FindHostedZone("example.com", false).Return("ZPUBLIC", nil)
-	mockAws.EXPECT().HasResourceRecordSet("ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "example.com", false).Return("ZPUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1551,10 +1632,10 @@ func TestCheckRoute53DNS_BothMissing(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
-	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
-	mockAws.EXPECT().FindHostedZone("example.com", false).Return("ZPUBLIC", nil)
-	mockAws.EXPECT().HasResourceRecordSet("ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "example.com", false).Return("ZPUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1578,8 +1659,8 @@ func TestCheckRoute53DNS_PrivateLink_SkipsPublic(t *testing.T) {
 	mockAws := awsmock.NewMockClient(ctrl)
 
 	// Only private zone should be checked... no public zone calls expected.
-	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
-	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", true)
 	notes := newTestNotes()
@@ -1602,7 +1683,7 @@ func TestCheckRoute53DNS_ZoneNotFound(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("", nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "myprefix.example.com", true).Return("", nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1625,7 +1706,7 @@ func TestCheckRoute53DNS_APIError(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("", fmt.Errorf("access denied"))
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "myprefix.example.com", true).Return("", fmt.Errorf("access denied"))
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1668,7 +1749,7 @@ func TestCheckDHCPOptions_AmazonDNSOnly(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"AmazonProvidedDNS"}, nil)
+	mockAws.EXPECT().GetVpcDhcpConfiguration(gomock.Any(), "test-cluster-infra").Return([]string{"AmazonProvidedDNS"}, nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1691,7 +1772,7 @@ func TestCheckDHCPOptions_CustomDNSOnly(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"10.0.0.2", "10.0.0.3"}, nil)
+	mockAws.EXPECT().GetVpcDhcpConfiguration(gomock.Any(), "test-cluster-infra").Return([]string{"10.0.0.2", "10.0.0.3"}, nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1714,7 +1795,7 @@ func TestCheckDHCPOptions_MixedDNS(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"AmazonProvidedDNS", "10.0.0.2"}, nil)
+	mockAws.EXPECT().GetVpcDhcpConfiguration(gomock.Any(), "test-cluster-infra").Return([]string{"AmazonProvidedDNS", "10.0.0.2"}, nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1737,7 +1818,7 @@ func TestCheckDHCPOptions_DefaultDHCPNoServersEntry(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{}, nil)
+	mockAws.EXPECT().GetVpcDhcpConfiguration(gomock.Any(), "test-cluster-infra").Return([]string{}, nil)
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1771,7 +1852,7 @@ func TestCheckDHCPOptions_APIError(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return(nil, fmt.Errorf("access denied"))
+	mockAws.EXPECT().GetVpcDhcpConfiguration(gomock.Any(), "test-cluster-infra").Return(nil, fmt.Errorf("access denied"))
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1794,7 +1875,7 @@ func TestCheckDHCPOptions_NoVPCFound(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return(nil, fmt.Errorf("no VPC found with kubernetes.io/cluster/test-cluster-infra tag"))
+	mockAws.EXPECT().GetVpcDhcpConfiguration(gomock.Any(), "test-cluster-infra").Return(nil, fmt.Errorf("no VPC found with kubernetes.io/cluster/test-cluster-infra tag"))
 
 	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
 	notes := newTestNotes()
@@ -1922,9 +2003,9 @@ func TestCheckLBHealth_NLB_AllHealthy(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindNLBByDNSName("test-nlb-abc123.elb.us-east-1.amazonaws.com").
+	mockAws.EXPECT().FindNLBByDNSName(gomock.Any(), "test-nlb-abc123.elb.us-east-1.amazonaws.com").
 		Return("arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/net/test-nlb/abc", "test-nlb", nil)
-	mockAws.EXPECT().GetNLBTargetHealth("arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/net/test-nlb/abc").
+	mockAws.EXPECT().GetNLBTargetHealth(gomock.Any(), "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/net/test-nlb/abc").
 		Return([]aws.NLBTargetHealth{
 			{TargetID: "i-001", Port: 443, State: "healthy"},
 			{TargetID: "i-002", Port: 443, State: "healthy"},
@@ -1951,9 +2032,9 @@ func TestCheckLBHealth_NLB_UnhealthyTarget(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindNLBByDNSName("test-nlb-abc123.elb.us-east-1.amazonaws.com").
+	mockAws.EXPECT().FindNLBByDNSName(gomock.Any(), "test-nlb-abc123.elb.us-east-1.amazonaws.com").
 		Return("arn:nlb", "test-nlb", nil)
-	mockAws.EXPECT().GetNLBTargetHealth("arn:nlb").
+	mockAws.EXPECT().GetNLBTargetHealth(gomock.Any(), "arn:nlb").
 		Return([]aws.NLBTargetHealth{
 			{TargetID: "i-001", Port: 443, State: "healthy"},
 			{TargetID: "i-002", Port: 443, State: "unhealthy", Reason: "Target.FailedHealthChecks"},
@@ -1983,9 +2064,9 @@ func TestCheckLBHealth_CLB_AllInService(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindCLBByDNSName("test-clb-123456.us-east-1.elb.amazonaws.com").
+	mockAws.EXPECT().FindCLBByDNSName(gomock.Any(), "test-clb-123456.us-east-1.elb.amazonaws.com").
 		Return("test-clb", nil)
-	mockAws.EXPECT().GetCLBInstanceHealth("test-clb").
+	mockAws.EXPECT().GetCLBInstanceHealth(gomock.Any(), "test-clb").
 		Return([]aws.CLBInstanceHealth{
 			{InstanceID: "i-001", State: "InService"},
 			{InstanceID: "i-002", State: "InService"},
@@ -2012,9 +2093,9 @@ func TestCheckLBHealth_CLB_OutOfService(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindCLBByDNSName("test-clb-123456.us-east-1.elb.amazonaws.com").
+	mockAws.EXPECT().FindCLBByDNSName(gomock.Any(), "test-clb-123456.us-east-1.elb.amazonaws.com").
 		Return("test-clb", nil)
-	mockAws.EXPECT().GetCLBInstanceHealth("test-clb").
+	mockAws.EXPECT().GetCLBInstanceHealth(gomock.Any(), "test-clb").
 		Return([]aws.CLBInstanceHealth{
 			{InstanceID: "i-001", State: "InService"},
 			{InstanceID: "i-002", State: "OutOfService", Description: "Instance has failed health checks"},
@@ -2061,7 +2142,7 @@ func TestCheckLBHealth_LBNotFound(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindCLBByDNSName("unknown-lb.us-east-1.elb.amazonaws.com").Return("", nil)
+	mockAws.EXPECT().FindCLBByDNSName(gomock.Any(), "unknown-lb.us-east-1.elb.amazonaws.com").Return("", nil)
 
 	ic := newDefaultIngressController(nil)
 	svc := newRouterService("unknown-lb.us-east-1.elb.amazonaws.com")
@@ -2084,7 +2165,7 @@ func TestCheckLBHealth_APIError(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindCLBByDNSName("test-clb.us-east-1.elb.amazonaws.com").
+	mockAws.EXPECT().FindCLBByDNSName(gomock.Any(), "test-clb.us-east-1.elb.amazonaws.com").
 		Return("", fmt.Errorf("access denied"))
 
 	ic := newDefaultIngressController(nil)
@@ -2125,9 +2206,9 @@ func TestCheckLBHealth_NLB_NoTargets(t *testing.T) {
 	defer ctrl.Finish()
 	mockAws := awsmock.NewMockClient(ctrl)
 
-	mockAws.EXPECT().FindNLBByDNSName("test-nlb.elb.us-east-1.amazonaws.com").
+	mockAws.EXPECT().FindNLBByDNSName(gomock.Any(), "test-nlb.elb.us-east-1.amazonaws.com").
 		Return("arn:nlb", "test-nlb", nil)
-	mockAws.EXPECT().GetNLBTargetHealth("arn:nlb").
+	mockAws.EXPECT().GetNLBTargetHealth(gomock.Any(), "arn:nlb").
 		Return([]aws.NLBTargetHealth{}, nil)
 
 	ic := newNLBIngressController(nil)
@@ -2152,9 +2233,9 @@ func TestCheckLBHealth_CLB_DefaultType(t *testing.T) {
 	mockAws := awsmock.NewMockClient(ctrl)
 
 	// IC with nil ProviderParameters defaults to Classic — should call CLB APIs.
-	mockAws.EXPECT().FindCLBByDNSName("test-clb.us-east-1.elb.amazonaws.com").
+	mockAws.EXPECT().FindCLBByDNSName(gomock.Any(), "test-clb.us-east-1.elb.amazonaws.com").
 		Return("test-clb", nil)
-	mockAws.EXPECT().GetCLBInstanceHealth("test-clb").
+	mockAws.EXPECT().GetCLBInstanceHealth(gomock.Any(), "test-clb").
 		Return([]aws.CLBInstanceHealth{
 			{InstanceID: "i-001", State: "InService"},
 		}, nil)
@@ -2286,16 +2367,16 @@ func TestRun_PrivateLink_SkipsEgress(t *testing.T) {
 	mockAws := awsmock.NewMockClient(ctrl)
 
 	// Route53 check expects: FindHostedZone (private only for PrivateLink), HasResourceRecordSet
-	mockAws.EXPECT().FindHostedZone("msaary-test.4t01.s1.devshift.org", true).Return("Z1234PRIVATE", nil)
-	mockAws.EXPECT().HasResourceRecordSet("Z1234PRIVATE", "\\052.apps.msaary-test.4t01.s1.devshift.org.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone(gomock.Any(), "msaary-test.4t01.s1.devshift.org", true).Return("Z1234PRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet(gomock.Any(), "Z1234PRIVATE", "\\052.apps.msaary-test.4t01.s1.devshift.org.", "A").Return(true, nil)
 	// No public zone call for PrivateLink clusters.
 
 	// DHCP check expects: GetVpcDhcpConfiguration (classic cluster, not HCP)
-	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"AmazonProvidedDNS"}, nil)
+	mockAws.EXPECT().GetVpcDhcpConfiguration(gomock.Any(), "test-cluster-infra").Return([]string{"AmazonProvidedDNS"}, nil)
 
 	// LB health check expects: FindCLBByDNSName (IC defaults to Classic)
-	mockAws.EXPECT().FindCLBByDNSName("test-elb-123456.us-east-1.elb.amazonaws.com").Return("test-elb", nil)
-	mockAws.EXPECT().GetCLBInstanceHealth("test-elb").Return([]aws.CLBInstanceHealth{
+	mockAws.EXPECT().FindCLBByDNSName(gomock.Any(), "test-elb-123456.us-east-1.elb.amazonaws.com").Return("test-elb", nil)
+	mockAws.EXPECT().GetCLBInstanceHealth(gomock.Any(), "test-elb").Return([]aws.CLBInstanceHealth{
 		{InstanceID: "i-001", State: "InService"},
 		{InstanceID: "i-002", State: "InService"},
 	}, nil)

--- a/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn_test.go
+++ b/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn_test.go
@@ -1,0 +1,1012 @@
+package consoleerrorbudgetburn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/backplane"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	"gotest.tools/v3/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = operatorv1.Install(s)
+	return s
+}
+
+func newFakeClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(objs...).Build()
+}
+
+func newTestCluster(id, machineCIDR string) *cmv1.Cluster {
+	cluster, _ := cmv1.NewCluster().
+		ID(id).
+		Network(cmv1.NewNetwork().MachineCIDR(machineCIDR)).
+		Build()
+	return cluster
+}
+
+func newTestNotes() *notewriter.NoteWriter {
+	return notewriter.New("consoleerrorbudgetburn", nil)
+}
+
+// newDefaultIngressController creates an IngressController named "default" in openshift-ingress-operator
+// with the given allowedSourceRanges. Pass nil for no EndpointPublishingStrategy.
+func newDefaultIngressController(allowedSourceRanges []operatorv1.CIDR) *operatorv1.IngressController {
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "openshift-ingress-operator",
+		},
+	}
+	if allowedSourceRanges != nil {
+		ic.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+			LoadBalancer: &operatorv1.LoadBalancerStrategy{
+				AllowedSourceRanges: allowedSourceRanges,
+			},
+		}
+	}
+	return ic
+}
+
+type mockConsoleServiceChecker struct {
+	output string
+	err    error
+}
+
+func (m *mockConsoleServiceChecker) checkConsoleEndpoint(_ context.Context, _ k8sclient.Client, _ *rest.Config) (string, error) {
+	return m.output, m.err
+}
+
+// healthyConsoleChecker returns a mock that simulates a healthy console (HTTP 200).
+func healthyConsoleChecker() *mockConsoleServiceChecker {
+	return &mockConsoleServiceChecker{output: "200"}
+}
+
+// testRestConfig returns a dummy backplane.RestConfig for tests that need getRestConfig to succeed.
+func testRestConfig() *backplane.RestConfig {
+	return &backplane.RestConfig{Config: rest.Config{Host: "https://test-cluster:6443"}}
+}
+
+func TestName(t *testing.T) {
+	inv := &Investigation{}
+	if inv.Name() != "consoleerrorbudgetburn" {
+		t.Errorf("expected 'consoleerrorbudgetburn', got %q", inv.Name())
+	}
+}
+
+func TestAlertTitle(t *testing.T) {
+	inv := &Investigation{}
+	if inv.AlertTitle() != "console-errorbudgetburn" {
+		t.Errorf("expected 'console-errorbudgetburn', got %q", inv.AlertTitle())
+	}
+}
+
+func TestDescription(t *testing.T) {
+	inv := &Investigation{}
+	if inv.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+}
+
+func TestIsExperimental(t *testing.T) {
+	inv := &Investigation{}
+	if !inv.IsExperimental() {
+		t.Error("expected IsExperimental to be true")
+	}
+}
+
+// checkAllowedSourceRanges unit testing:
+
+func TestCheckAllowedSourceRanges_NotConfigured(t *testing.T) {
+	ic := newDefaultIngressController(nil)
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if result {
+		t.Error("expected false (no misconfiguration), got true")
+	}
+	if !strings.Contains(notes.String(), "not configured") {
+		t.Errorf("expected 'not configured' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckAllowedSourceRanges_MachineIncluded(t *testing.T) {
+	// CIDR 10.0.0.0/16 is contained within allowed range 10.0.0.0/8
+	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/8"})
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if result {
+		t.Error("expected false (machine CIDR covered), got true")
+	}
+	if !strings.Contains(notes.String(), "is covered") {
+		t.Errorf("expected 'is covered' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckAllowedSourceRanges_ExactMatch(t *testing.T) {
+	// Exact match: allowed 10.0.0.0/16 == machine CIDR 10.0.0.0/16
+	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/16"})
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if result {
+		t.Error("expected false (exact match is covered), got true")
+	}
+	if !strings.Contains(notes.String(), "is covered") {
+		t.Errorf("expected 'is covered' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckAllowedSourceRanges_SmallerRangeDoesNotContain(t *testing.T) {
+	// Allowed 10.0.0.0/24 does NOT contain 10.0.0.0/16
+	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/24"})
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if !result {
+		t.Error("expected true (smaller range does not contain machine CIDR), got false")
+	}
+	if !strings.Contains(notes.String(), "NOT included") {
+		t.Errorf("expected 'NOT included' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckAllowedSourceRanges_MachineExcluded(t *testing.T) {
+	// CIDR 10.0.0.0/16 is not covered by 192.168.0.0/16
+	ic := newDefaultIngressController([]operatorv1.CIDR{"192.168.0.0/16"})
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if !result {
+		t.Error("expected true (machine CIDR excluded), got false")
+	}
+	if !strings.Contains(notes.String(), "NOT included") {
+		t.Errorf("expected 'NOT included' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckAllowedSourceRanges_MultipleRangesOneMatch(t *testing.T) {
+	// First range doesn't match, but second range covers the machine CIDR
+	ic := newDefaultIngressController([]operatorv1.CIDR{"192.168.0.0/16", "10.0.0.0/8"})
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if result {
+		t.Error("expected false (second range covers machine CIDR), got true")
+	}
+	if !strings.Contains(notes.String(), "is covered") {
+		t.Errorf("expected 'is covered' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckAllowedSourceRanges_EmptyMachineCIDR(t *testing.T) {
+	// CIDR empty; cluster info incomplete
+	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/8"})
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if result {
+		t.Error("expected false (cannot determine CIDR), got true")
+	}
+	if !strings.Contains(notes.String(), "unable to determine") {
+		t.Errorf("expected 'unable to determine' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckAllowedSourceRanges_IngressControllerNotFound(t *testing.T) {
+	// No IngressController in the fake client
+	k8sClient := newFakeClient()
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if result {
+		t.Error("expected false (error fetching IC), got true")
+	}
+	if !strings.Contains(notes.String(), "failed to get") {
+		t.Errorf("expected 'failed to get' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckAllowedSourceRanges_NilLoadBalancer(t *testing.T) {
+	// EndpointPublishingStrategy exists but LoadBalancer is nil
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "openshift-ingress-operator",
+		},
+		Spec: operatorv1.IngressControllerSpec{
+			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+				// LoadBalancer is nil
+			},
+		},
+	}
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if result {
+		t.Error("expected false (no LB config), got true")
+	}
+	if !strings.Contains(notes.String(), "not configured") {
+		t.Errorf("expected 'not configured' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckAllowedSourceRanges_EmptyAllowedSourceRanges(t *testing.T) {
+	// LoadBalancer exists but AllowedSourceRanges is empty slice
+	ic := newDefaultIngressController([]operatorv1.CIDR{})
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{
+		Cluster:   cluster,
+		K8sClient: k8sClient,
+	}
+
+	result := inv.checkAllowedSourceRanges(context.Background(), r, notes)
+	if result {
+		t.Error("expected false (empty ranges), got true")
+	}
+	if !strings.Contains(notes.String(), "not configured") {
+		t.Errorf("expected 'not configured' in notes, got: %s", notes.String())
+	}
+}
+
+func TestNewAllowedSourceRangesSL(t *testing.T) {
+	machineCIDR := "10.0.0.0/16"
+	expected := &ocm.ServiceLog{
+		Severity:     "Critical",
+		ServiceName:  "SREManualAction",
+		Summary:      "Action required: Incorrect Default IngressController Configuration",
+		Description:  fmt.Sprintf("Your cluster requires you to take action. Your default ingresscontroller is misconfigured, generating alerts for Red Hat SRE and degrading cluster health. The Machine CIDR for the cluster, '%s', needs to be added to the allowlist.", machineCIDR),
+		InternalOnly: false,
+	}
+
+	result := newAllowedSourceRangesSL(machineCIDR)
+	assert.Equal(t, *expected, *result)
+}
+
+// DNS test helper
+// newDefaultDNS creates a dns.operator.openshift.io/default object with the given upstreams.
+func newDefaultDNS(upstreams []operatorv1.Upstream) *operatorv1.DNS {
+	return &operatorv1.DNS{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: operatorv1.DNSSpec{
+			UpstreamResolvers: operatorv1.UpstreamResolvers{
+				Upstreams: upstreams,
+			},
+		},
+	}
+}
+
+// checkUpstreamDNS unit tests
+func TestCheckUpstreamDNS_NoCustomResolvers(t *testing.T) {
+	dns := newDefaultDNS([]operatorv1.Upstream{
+		{Type: operatorv1.SystemResolveConfType},
+	})
+	k8sClient := newFakeClient(dns)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkUpstreamDNS(context.Background(), k8sClient, notes)
+
+	if !strings.Contains(notes.String(), "no custom upstream resolvers") {
+		t.Errorf("expected 'no custom upstream resolvers' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckUpstreamDNS_CustomResolverFound(t *testing.T) {
+	dns := newDefaultDNS([]operatorv1.Upstream{
+		{Type: operatorv1.NetworkResolverType, Address: "1.2.3.4", Port: 53},
+	})
+	k8sClient := newFakeClient(dns)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkUpstreamDNS(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "customer-configured upstream resolvers") {
+		t.Errorf("expected warning about custom resolvers, got: %s", output)
+	}
+	if !strings.Contains(output, "1.2.3.4:53") {
+		t.Errorf("expected '1.2.3.4:53' in notes, got: %s", output)
+	}
+}
+
+func TestCheckUpstreamDNS_MultipleCustomResolvers(t *testing.T) {
+	dns := newDefaultDNS([]operatorv1.Upstream{
+		{Type: operatorv1.NetworkResolverType, Address: "1.2.3.4", Port: 53},
+		{Type: operatorv1.NetworkResolverType, Address: "5.6.7.8", Port: 5353},
+	})
+	k8sClient := newFakeClient(dns)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkUpstreamDNS(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "1.2.3.4:53") {
+		t.Errorf("expected '1.2.3.4:53' in notes, got: %s", output)
+	}
+	if !strings.Contains(output, "5.6.7.8:5353") {
+		t.Errorf("expected '5.6.7.8:5353' in notes, got: %s", output)
+	}
+}
+
+func TestCheckUpstreamDNS_MixedUpstreams(t *testing.T) {
+	dns := newDefaultDNS([]operatorv1.Upstream{
+		{Type: operatorv1.SystemResolveConfType},
+		{Type: operatorv1.NetworkResolverType, Address: "8.8.8.8", Port: 53},
+	})
+	k8sClient := newFakeClient(dns)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkUpstreamDNS(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "customer-configured upstream resolvers") {
+		t.Errorf("expected warning about custom resolvers, got: %s", output)
+	}
+	if !strings.Contains(output, "8.8.8.8:53") {
+		t.Errorf("expected '8.8.8.8:53' in notes, got: %s", output)
+	}
+}
+
+func TestCheckUpstreamDNS_EmptyUpstreams(t *testing.T) {
+	dns := newDefaultDNS([]operatorv1.Upstream{})
+	k8sClient := newFakeClient(dns)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkUpstreamDNS(context.Background(), k8sClient, notes)
+
+	if !strings.Contains(notes.String(), "no custom upstream resolvers") {
+		t.Errorf("expected 'no custom upstream resolvers' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckUpstreamDNS_GetError(t *testing.T) {
+	// No DNS object in the fake client
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkUpstreamDNS(context.Background(), k8sClient, notes)
+
+	if !strings.Contains(notes.String(), "failed to get") {
+		t.Errorf("expected 'failed to get' in notes, got: %s", notes.String())
+	}
+}
+
+// checkPodHealth unit tests (Router)
+
+func newRouterPod(name string, phase corev1.PodPhase, containers []corev1.ContainerStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "openshift-ingress",
+		},
+		Status: corev1.PodStatus{
+			Phase:             phase,
+			ContainerStatuses: containers,
+		},
+	}
+}
+
+func TestCheckPodHealth_Router_AllHealthy(t *testing.T) {
+	pod1 := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 0},
+	})
+	pod2 := newRouterPod("router-default-def", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 0},
+	})
+	k8sClient := newFakeClient(pod1, pod2)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "2 pod(s)") {
+		t.Errorf("expected '2 pod(s)' in notes, got: %s", output)
+	}
+	if !strings.Contains(output, "running and ready") {
+		t.Errorf("expected 'running and ready' in notes, got: %s", output)
+	}
+}
+
+func TestCheckPodHealth_Router_CrashLooping(t *testing.T) {
+	pod := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: false, RestartCount: 10, State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+		}},
+	})
+	k8sClient := newFakeClient(pod)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "CrashLoopBackOff") {
+		t.Errorf("expected 'CrashLoopBackOff' in notes, got: %s", output)
+	}
+}
+
+func TestCheckPodHealth_Router_PodNotReady(t *testing.T) {
+	pod := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: false, RestartCount: 0},
+	})
+	k8sClient := newFakeClient(pod)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "not ready") {
+		t.Errorf("expected 'not ready' in notes, got: %s", output)
+	}
+}
+
+func TestCheckPodHealth_Router_NoPods(t *testing.T) {
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+
+	if !strings.Contains(notes.String(), "no pods found") {
+		t.Errorf("expected 'no pods found' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckPodHealth_Router_WarningEvents(t *testing.T) {
+	pod := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 0},
+	})
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router-default-abc.warning",
+			Namespace: "openshift-ingress",
+		},
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "router-default-abc"},
+		Type:           corev1.EventTypeWarning,
+		Reason:         "Unhealthy",
+		Message:        "Readiness probe failed",
+		Count:          3,
+	}
+	k8sClient := newFakeClient(pod, event)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Unhealthy") {
+		t.Errorf("expected 'Unhealthy' in notes, got: %s", output)
+	}
+	if !strings.Contains(output, "Readiness probe failed") {
+		t.Errorf("expected 'Readiness probe failed' in notes, got: %s", output)
+	}
+}
+
+func TestCheckPodHealth_Router_ExcessiveRestarts(t *testing.T) {
+	pod := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 5},
+	})
+	k8sClient := newFakeClient(pod)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-ingress", "Router", notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "5 restarts") {
+		t.Errorf("expected '5 restarts' in notes, got: %s", output)
+	}
+}
+
+// checkConsoleService unit tests
+
+func TestCheckConsoleService_Healthy(t *testing.T) {
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{consoleChecker: &mockConsoleServiceChecker{output: "200"}}
+
+	r := &investigation.Resources{
+		Cluster:    cluster,
+		K8sClient:  k8sClient,
+		RestConfig: testRestConfig(),
+	}
+
+	inv.checkConsoleService(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "HTTP 200") {
+		t.Errorf("expected 'HTTP 200' in notes, got: %s", output)
+	}
+	if !strings.Contains(output, "responding") {
+		t.Errorf("expected 'responding' in notes, got: %s", output)
+	}
+}
+
+func TestCheckConsoleService_NonOK(t *testing.T) {
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{consoleChecker: &mockConsoleServiceChecker{output: "503"}}
+
+	r := &investigation.Resources{
+		Cluster:    cluster,
+		K8sClient:  k8sClient,
+		RestConfig: testRestConfig(),
+	}
+
+	inv.checkConsoleService(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "HTTP 503") {
+		t.Errorf("expected 'HTTP 503' in notes, got: %s", output)
+	}
+}
+
+func TestCheckConsoleService_ExecError(t *testing.T) {
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{consoleChecker: &mockConsoleServiceChecker{err: fmt.Errorf("connection refused")}}
+
+	r := &investigation.Resources{
+		Cluster:    cluster,
+		K8sClient:  k8sClient,
+		RestConfig: testRestConfig(),
+	}
+
+	inv.checkConsoleService(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "unable to reach") {
+		t.Errorf("expected 'unable to reach' in notes, got: %s", output)
+	}
+}
+
+// checkPodHealth unit tests (console)
+
+func newConsolePod(name, nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "openshift-console",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "console", Ready: true, RestartCount: 0},
+			},
+		},
+	}
+}
+
+func TestCheckPodHealth_Console_AllHealthy(t *testing.T) {
+	pod1 := newConsolePod("console-abc", "node-1")
+	pod2 := newConsolePod("console-def", "node-2")
+	k8sClient := newFakeClient(pod1, pod2)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkPodHealth(context.Background(), k8sClient, "openshift-console", "Console", notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Console: all 2 pod(s)") {
+		t.Errorf("expected 'Console: all 2 pod(s)' in notes, got: %s", output)
+	}
+}
+
+// checkNodeHealth tests
+
+func newTestNode(name string, conditions []corev1.NodeCondition, unschedulable bool) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: corev1.NodeSpec{
+			Unschedulable: unschedulable,
+		},
+		Status: corev1.NodeStatus{
+			Conditions: conditions,
+		},
+	}
+}
+
+func healthyNodeConditions() []corev1.NodeCondition {
+	return []corev1.NodeCondition{
+		{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+		{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+		{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+		{Type: corev1.NodePIDPressure, Status: corev1.ConditionFalse},
+	}
+}
+
+func TestCheckNodeHealth_AllHealthy(t *testing.T) {
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", healthyNodeConditions(), false)
+	k8sClient := newFakeClient(consolePod, node)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "1 node(s) running console pods are healthy") {
+		t.Errorf("expected healthy node message, got: %s", output)
+	}
+}
+
+func TestCheckNodeHealth_NodeNotReady(t *testing.T) {
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", []corev1.NodeCondition{
+		{Type: corev1.NodeReady, Status: corev1.ConditionFalse, Reason: "KubeletNotReady"},
+	}, false)
+	k8sClient := newFakeClient(consolePod, node)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "NotReady") {
+		t.Errorf("expected 'NotReady' in notes, got: %s", output)
+	}
+}
+
+func TestCheckNodeHealth_DiskPressure(t *testing.T) {
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", []corev1.NodeCondition{
+		{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+		{Type: corev1.NodeDiskPressure, Status: corev1.ConditionTrue},
+	}, false)
+	k8sClient := newFakeClient(consolePod, node)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "DiskPressure") {
+		t.Errorf("expected 'DiskPressure' in notes, got: %s", output)
+	}
+}
+
+func TestCheckNodeHealth_NoConsolePods(t *testing.T) {
+	k8sClient := newFakeClient()
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no console pods found") {
+		t.Errorf("expected 'no console pods found' in notes, got: %s", output)
+	}
+}
+
+func TestCheckNodeHealth_PIDPressure(t *testing.T) {
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", []corev1.NodeCondition{
+		{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+		{Type: corev1.NodePIDPressure, Status: corev1.ConditionTrue},
+	}, false)
+	k8sClient := newFakeClient(consolePod, node)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "PIDPressure") {
+		t.Errorf("expected 'PIDPressure' in notes, got: %s", output)
+	}
+}
+
+func TestCheckNodeHealth_Unschedulable(t *testing.T) {
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", healthyNodeConditions(), true)
+	k8sClient := newFakeClient(consolePod, node)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "Unschedulable") {
+		t.Errorf("expected 'Unschedulable' in notes, got: %s", output)
+	}
+}
+
+func TestCheckNodeHealth_MultipleNodesOneUnhealthy(t *testing.T) {
+	pod1 := newConsolePod("console-abc", "node-1")
+	pod2 := newConsolePod("console-def", "node-2")
+	node1 := newTestNode("node-1", healthyNodeConditions(), false)
+	node2 := newTestNode("node-2", []corev1.NodeCondition{
+		{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+		{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
+	}, false)
+	k8sClient := newFakeClient(pod1, pod2, node1, node2)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "MemoryPressure") {
+		t.Errorf("expected 'MemoryPressure' in notes, got: %s", output)
+	}
+	if !strings.Contains(output, "node-2") {
+		t.Errorf("expected 'node-2' in notes, got: %s", output)
+	}
+}
+
+// Run-level tests
+
+func TestRun_HCP_SkipsAllowedSourceRanges(t *testing.T) {
+	ic := newDefaultIngressController([]operatorv1.CIDR{"192.168.0.0/16"})
+	dns := newDefaultDNS([]operatorv1.Upstream{{Type: operatorv1.SystemResolveConfType}})
+	routerPod := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 0},
+	})
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", healthyNodeConditions(), false)
+	k8sClient := newFakeClient(ic, dns, routerPod, consolePod, node)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:    cluster,
+			K8sClient:  k8sClient,
+			IsHCP:      true,
+			RestConfig: testRestConfig(),
+		},
+	}
+
+	inv := &Investigation{consoleChecker: healthyConsoleChecker()}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should escalate (no root cause found), not silence
+	hasSilence := false
+	hasEscalate := false
+	for _, a := range result.Actions {
+		if a.Type() == "silence_incident" {
+			hasSilence = true
+		}
+		if a.Type() == "escalate_incident" {
+			hasEscalate = true
+		}
+	}
+	if hasSilence {
+		t.Error("expected no silence action for HCP cluster")
+	}
+	if !hasEscalate {
+		t.Error("expected escalate action for HCP cluster (no root cause path)")
+	}
+}
+
+func TestRun_AllowedSourceRangesMisconfigured(t *testing.T) {
+	// Classic cluster with machine CIDR excluded from allowedSourceRanges
+	ic := newDefaultIngressController([]operatorv1.CIDR{"192.168.0.0/16"})
+	k8sClient := newFakeClient(ic)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:   cluster,
+			K8sClient: k8sClient,
+			IsHCP:     false,
+		},
+	}
+
+	inv := &Investigation{consoleChecker: healthyConsoleChecker()}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// should have: backplane report, PD note, service log, silence
+	hasServiceLog := false
+	hasSilence := false
+	hasEscalate := false
+	for _, a := range result.Actions {
+		switch a.Type() {
+		case "service_log":
+			hasServiceLog = true
+		case "silence_incident":
+			hasSilence = true
+		case "escalate_incident":
+			hasEscalate = true
+		}
+	}
+	if !hasServiceLog {
+		t.Error("expected service log action for misconfigured allowedSourceRanges")
+	}
+	if !hasSilence {
+		t.Error("expected silence action for misconfigured allowedSourceRanges")
+	}
+	if hasEscalate {
+		t.Error("unexpected escalate action — should silence, not escalate")
+	}
+}
+
+func TestRun_AllowedSourceRangesOK(t *testing.T) {
+	// Classic cluster with machine CIDR properly included
+	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/8"})
+	dns := newDefaultDNS([]operatorv1.Upstream{{Type: operatorv1.SystemResolveConfType}})
+	routerPod := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 0},
+	})
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", healthyNodeConditions(), false)
+	k8sClient := newFakeClient(ic, dns, routerPod, consolePod, node)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16")
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:    cluster,
+			K8sClient:  k8sClient,
+			IsHCP:      false,
+			RestConfig: testRestConfig(),
+		},
+	}
+
+	inv := &Investigation{consoleChecker: healthyConsoleChecker()}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should escalate (no root cause); no SL, no silence
+	hasServiceLog := false
+	hasSilence := false
+	hasEscalate := false
+	for _, a := range result.Actions {
+		switch a.Type() {
+		case "service_log":
+			hasServiceLog = true
+		case "silence_incident":
+			hasSilence = true
+		case "escalate_incident":
+			hasEscalate = true
+		}
+	}
+	if hasServiceLog {
+		t.Error("unexpected service log action — ranges are OK")
+	}
+	if hasSilence {
+		t.Error("unexpected silence action — ranges are OK")
+	}
+	if !hasEscalate {
+		t.Error("expected escalate action (no root cause path)")
+	}
+}
+
+func TestRun_ClusterAccessError(t *testing.T) {
+	rb := &investigation.ResourceBuilderMock{
+		BuildError: investigation.RestConfigError{ClusterID: "test-cluster", Err: fmt.Errorf("backplane unavailable")},
+	}
+
+	inv := &Investigation{}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("expected nil error for cluster access error, got: %v", err)
+	}
+
+	hasEscalate := false
+	for _, a := range result.Actions {
+		if a.Type() == "escalate_incident" {
+			hasEscalate = true
+		}
+	}
+	if !hasEscalate {
+		t.Error("expected escalate action for cluster access error")
+	}
+}

--- a/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn_test.go
+++ b/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn_test.go
@@ -8,11 +8,16 @@ import (
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
+	awsmock "github.com/openshift/configuration-anomaly-detection/pkg/aws/mock"
 	"github.com/openshift/configuration-anomaly-detection/pkg/backplane"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
+	"github.com/openshift/configuration-anomaly-detection/pkg/networkverifier"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +26,14 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	actionSilence   = "silence_incident"
+	actionEscalate  = "escalate_incident"
+	failModeUnknown = "unknown"
+	lbTypeNLB       = "NLB"
+	lbTypeClassic   = "Classic"
 )
 
 func testScheme() *runtime.Scheme {
@@ -38,6 +51,23 @@ func newTestCluster(id, machineCIDR, consoleURL string) *cmv1.Cluster {
 	builder := cmv1.NewCluster().
 		ID(id).
 		Network(cmv1.NewNetwork().MachineCIDR(machineCIDR))
+	if consoleURL != "" {
+		builder = builder.Console(cmv1.NewClusterConsole().URL(consoleURL))
+	}
+	cluster, _ := builder.Build()
+	return cluster
+}
+
+// newAWSTestClusterWithDNS creates a test cluster with AWS provider, DNS, InfraID, and optional PrivateLink.
+func newAWSTestClusterWithDNS(id, machineCIDR, consoleURL, domainPrefix, baseDomain string, privateLink bool) *cmv1.Cluster {
+	builder := cmv1.NewCluster().
+		ID(id).
+		InfraID(id + "-infra").
+		Network(cmv1.NewNetwork().MachineCIDR(machineCIDR)).
+		CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+		DomainPrefix(domainPrefix).
+		DNS(cmv1.NewDNS().BaseDomain(baseDomain)).
+		AWS(cmv1.NewAWS().PrivateLink(privateLink))
 	if consoleURL != "" {
 		builder = builder.Console(cmv1.NewClusterConsole().URL(consoleURL))
 	}
@@ -1009,10 +1039,10 @@ func TestRun_HCP_SkipsAllowedSourceRanges(t *testing.T) {
 	hasSilence := false
 	hasEscalate := false
 	for _, a := range result.Actions {
-		if a.Type() == "silence_incident" {
+		if a.Type() == actionSilence {
 			hasSilence = true
 		}
-		if a.Type() == "escalate_incident" {
+		if a.Type() == actionEscalate {
 			hasEscalate = true
 		}
 	}
@@ -1053,9 +1083,9 @@ func TestRun_AllowedSourceRangesMisconfigured(t *testing.T) {
 		switch a.Type() {
 		case "service_log":
 			hasServiceLog = true
-		case "silence_incident":
+		case actionSilence:
 			hasSilence = true
-		case "escalate_incident":
+		case actionEscalate:
 			hasEscalate = true
 		}
 	}
@@ -1105,9 +1135,9 @@ func TestRun_AllowedSourceRangesOK(t *testing.T) {
 		switch a.Type() {
 		case "service_log":
 			hasServiceLog = true
-		case "silence_incident":
+		case actionSilence:
 			hasSilence = true
-		case "escalate_incident":
+		case actionEscalate:
 			hasEscalate = true
 		}
 	}
@@ -1135,12 +1165,115 @@ func TestRun_ClusterAccessError(t *testing.T) {
 
 	hasEscalate := false
 	for _, a := range result.Actions {
-		if a.Type() == "escalate_incident" {
+		if a.Type() == actionEscalate {
 			hasEscalate = true
 		}
 	}
 	if !hasEscalate {
 		t.Error("expected escalate action for cluster access error")
+	}
+}
+
+func TestRun_NonAWSCluster_SkipsAWSChecks(t *testing.T) {
+	// Cluster with no CloudProvider set; AWS section should be skipped entirely.
+	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/8"})
+	dns := newDefaultDNS([]operatorv1.Upstream{{Type: operatorv1.SystemResolveConfType}})
+	routerPod := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 0},
+	})
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", healthyNodeConditions(), false)
+	k8sClient := newFakeClient(ic, dns, routerPod, consolePod, node)
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "https://console.test.example.com")
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:    cluster,
+			K8sClient:  k8sClient,
+			IsHCP:      false,
+			RestConfig: testRestConfig(),
+		},
+	}
+
+	inv := &Investigation{consoleChecker: healthyConsoleChecker(), blackboxProber: healthyBlackboxProber()}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hasEscalate := false
+	for _, a := range result.Actions {
+		if a.Type() == actionEscalate {
+			hasEscalate = true
+		}
+	}
+	if !hasEscalate {
+		t.Error("expected escalate action")
+	}
+}
+
+func TestRun_AWSCluster_AWSChecksRun(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	// Route53 check expects: FindHostedZone (private + public), HasResourceRecordSet (private + public)
+	mockAws.EXPECT().FindHostedZone("msaary-test.4t01.s1.devshift.org", true).Return("Z1234PRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet("Z1234PRIVATE", "\\052.apps.msaary-test.4t01.s1.devshift.org.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone("4t01.s1.devshift.org", false).Return("Z5678PUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet("Z5678PUBLIC", "\\052.apps.msaary-test.4t01.s1.devshift.org.", "A").Return(true, nil)
+
+	// DHCP check expects: GetVpcDhcpConfiguration (classic cluster, not HCP)
+	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"AmazonProvidedDNS"}, nil)
+
+	// LB health check expects: FindCLBByDNSName (IC has no ProviderParameters → defaults to Classic)
+	mockAws.EXPECT().FindCLBByDNSName("test-elb-123456.us-east-1.elb.amazonaws.com").Return("test-elb", nil)
+	mockAws.EXPECT().GetCLBInstanceHealth("test-elb").Return([]aws.CLBInstanceHealth{
+		{InstanceID: "i-001", State: "InService"},
+		{InstanceID: "i-002", State: "InService"},
+	}, nil)
+
+	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/8"})
+	dns := newDefaultDNS([]operatorv1.Upstream{{Type: operatorv1.SystemResolveConfType}})
+	routerPod := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 0},
+	})
+	routerSvc := newRouterService("test-elb-123456.us-east-1.elb.amazonaws.com")
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", healthyNodeConditions(), false)
+	k8sClient := newFakeClient(ic, dns, routerPod, routerSvc, consolePod, node)
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16",
+		"https://console.test.example.com", "msaary-test", "4t01.s1.devshift.org", false)
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:           cluster,
+			K8sClient:         k8sClient,
+			AwsClient:         mockAws,
+			IsHCP:             false,
+			RestConfig:        testRestConfig(),
+			ClusterDeployment: &hivev1.ClusterDeployment{},
+		},
+	}
+
+	inv := &Investigation{
+		consoleChecker: healthyConsoleChecker(),
+		blackboxProber: healthyBlackboxProber(),
+		egressVerifier: successEgressVerifier(),
+	}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hasEscalate := false
+	for _, a := range result.Actions {
+		if a.Type() == actionEscalate {
+			hasEscalate = true
+		}
+	}
+	if !hasEscalate {
+		t.Error("expected escalate action")
 	}
 }
 
@@ -1229,7 +1362,7 @@ func TestParseProbeResponse_UnknownFailure(t *testing.T) {
 	if pr.success {
 		t.Error("expected success=false")
 	}
-	if pr.failureMode != "unknown" {
+	if pr.failureMode != failModeUnknown {
 		t.Errorf("expected failureMode='unknown', got %q", pr.failureMode)
 	}
 }
@@ -1239,7 +1372,7 @@ func TestParseProbeResponse_EmptyResponse(t *testing.T) {
 	if pr.success {
 		t.Error("expected success=false for empty response")
 	}
-	if pr.failureMode != "unknown" {
+	if pr.failureMode != failModeUnknown {
 		t.Errorf("expected failureMode='unknown' for empty response, got %q", pr.failureMode)
 	}
 }
@@ -1329,5 +1462,892 @@ func TestCheckBlackboxProbe_EmptyConsoleURL(t *testing.T) {
 	output := notes.String()
 	if !strings.Contains(output, "unable to determine console URL") {
 		t.Errorf("expected 'unable to determine console URL' in notes, got: %s", output)
+	}
+}
+
+// checkRoute53DNS unit tests
+
+func TestCheckRoute53DNS_AllRecordsExist(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone("example.com", false).Return("ZPUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet("ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	result := inv.checkRoute53DNS(context.Background(), r, notes)
+
+	if result {
+		t.Error("expected false (no missing records)")
+	}
+	output := notes.String()
+	if !strings.Contains(output, "verified in private and public hosted zones") {
+		t.Errorf("expected success message about both zones, got: %s", output)
+	}
+}
+
+func TestCheckRoute53DNS_MissingPrivateRecord(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
+	// Public zone is still checked (both zones are evaluated before reporting).
+	mockAws.EXPECT().FindHostedZone("example.com", false).Return("ZPUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet("ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	result := inv.checkRoute53DNS(context.Background(), r, notes)
+
+	if !result {
+		t.Error("expected true (missing private record)")
+	}
+	output := notes.String()
+	if !strings.Contains(output, "missing from private hosted zone") {
+		t.Errorf("expected warning about missing private record, got: %s", output)
+	}
+}
+
+func TestCheckRoute53DNS_MissingPublicRecord(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+	mockAws.EXPECT().FindHostedZone("example.com", false).Return("ZPUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet("ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	result := inv.checkRoute53DNS(context.Background(), r, notes)
+
+	if !result {
+		t.Error("expected true (missing public record)")
+	}
+	output := notes.String()
+	if !strings.Contains(output, "missing from public hosted zone") {
+		t.Errorf("expected warning about missing public record, got: %s", output)
+	}
+}
+
+func TestCheckRoute53DNS_BothMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
+	mockAws.EXPECT().FindHostedZone("example.com", false).Return("ZPUBLIC", nil)
+	mockAws.EXPECT().HasResourceRecordSet("ZPUBLIC", "\\052.apps.myprefix.example.com.", "A").Return(false, nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	result := inv.checkRoute53DNS(context.Background(), r, notes)
+
+	if !result {
+		t.Error("expected true (both records missing)")
+	}
+	output := notes.String()
+	if !strings.Contains(output, "BOTH private and public") {
+		t.Errorf("expected warning about both zones missing, got: %s", output)
+	}
+}
+
+func TestCheckRoute53DNS_PrivateLink_SkipsPublic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	// Only private zone should be checked... no public zone calls expected.
+	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("ZPRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet("ZPRIVATE", "\\052.apps.myprefix.example.com.", "A").Return(true, nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", true)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	result := inv.checkRoute53DNS(context.Background(), r, notes)
+
+	if result {
+		t.Error("expected false (private record exists, public skipped)")
+	}
+	output := notes.String()
+	if !strings.Contains(output, "verified in private hosted zone") {
+		t.Errorf("expected success message about private zone only, got: %s", output)
+	}
+}
+
+func TestCheckRoute53DNS_ZoneNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("", nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	result := inv.checkRoute53DNS(context.Background(), r, notes)
+
+	if result {
+		t.Error("expected false (zone not found is not a definitive missing-record finding)")
+	}
+	output := notes.String()
+	if !strings.Contains(output, "no private hosted zone found") {
+		t.Errorf("expected warning about zone not found, got: %s", output)
+	}
+}
+
+func TestCheckRoute53DNS_APIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindHostedZone("myprefix.example.com", true).Return("", fmt.Errorf("access denied"))
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	result := inv.checkRoute53DNS(context.Background(), r, notes)
+
+	if result {
+		t.Error("expected false (API error is not a definitive finding)")
+	}
+	output := notes.String()
+	if !strings.Contains(output, "error looking up private hosted zone") {
+		t.Errorf("expected warning about API error, got: %s", output)
+	}
+}
+
+func TestCheckRoute53DNS_EmptyDomain(t *testing.T) {
+	// Cluster with empty DomainPrefix — should warn and return false, no AWS calls.
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster}
+	result := inv.checkRoute53DNS(context.Background(), r, notes)
+
+	if result {
+		t.Error("expected false (empty domain)")
+	}
+	output := notes.String()
+	if !strings.Contains(output, "unable to determine cluster domain") {
+		t.Errorf("expected warning about missing domain info, got: %s", output)
+	}
+}
+
+// checkDHCPOptions unit tests
+
+func TestCheckDHCPOptions_AmazonDNSOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"AmazonProvidedDNS"}, nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	inv.checkDHCPOptions(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "DHCP: VPC DHCP option set uses AmazonProvidedDNS") {
+		t.Errorf("expected success message, got: %s", output)
+	}
+	if strings.Contains(output, "⚠️") {
+		t.Errorf("expected no warning, got: %s", output)
+	}
+}
+
+func TestCheckDHCPOptions_CustomDNSOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"10.0.0.2", "10.0.0.3"}, nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	inv.checkDHCPOptions(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "custom DNS servers") {
+		t.Errorf("expected warning about custom DNS servers, got: %s", output)
+	}
+	if !strings.Contains(output, "⚠️") {
+		t.Errorf("expected warning emoji, got: %s", output)
+	}
+}
+
+func TestCheckDHCPOptions_MixedDNS(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"AmazonProvidedDNS", "10.0.0.2"}, nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	inv.checkDHCPOptions(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "AmazonProvidedDNS alongside custom servers") {
+		t.Errorf("expected success message about mixed DNS, got: %s", output)
+	}
+	if !strings.Contains(output, "✅") {
+		t.Errorf("expected success emoji (AmazonProvidedDNS is present), got: %s", output)
+	}
+}
+
+func TestCheckDHCPOptions_DefaultDHCPNoServersEntry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{}, nil)
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	inv.checkDHCPOptions(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "AWS default DNS") {
+		t.Errorf("expected success message about AWS default DNS, got: %s", output)
+	}
+}
+
+func TestCheckDHCPOptions_EmptyInfraID(t *testing.T) {
+	cluster := newTestCluster("test-cluster", "10.0.0.0/16", "")
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster}
+	inv.checkDHCPOptions(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "unable to determine cluster infrastructure ID") {
+		t.Errorf("expected warning about missing infra ID, got: %s", output)
+	}
+}
+
+func TestCheckDHCPOptions_APIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return(nil, fmt.Errorf("access denied"))
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	inv.checkDHCPOptions(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "unable to check VPC DHCP options") {
+		t.Errorf("expected warning about API error, got: %s", output)
+	}
+	if !strings.Contains(output, "access denied") {
+		t.Errorf("expected error message to include 'access denied', got: %s", output)
+	}
+}
+
+func TestCheckDHCPOptions_NoVPCFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return(nil, fmt.Errorf("no VPC found with kubernetes.io/cluster/test-cluster-infra tag"))
+
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16", "", "myprefix", "example.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, AwsClient: mockAws}
+	inv.checkDHCPOptions(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "unable to check VPC DHCP options") {
+		t.Errorf("expected warning about DHCP check failure, got: %s", output)
+	}
+	if !strings.Contains(output, "no VPC found") {
+		t.Errorf("expected error message about no VPC, got: %s", output)
+	}
+}
+
+// newRouterService creates a router-default Service in openshift-ingress with the given LB hostname.
+func newRouterService(hostname string) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router-default",
+			Namespace: "openshift-ingress",
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+		},
+	}
+	if hostname != "" {
+		svc.Status = corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{Hostname: hostname},
+				},
+			},
+		}
+	}
+	return svc
+}
+
+// newNLBIngressController creates an IngressController with NLB type.
+func newNLBIngressController(allowedSourceRanges []operatorv1.CIDR) *operatorv1.IngressController {
+	ic := newDefaultIngressController(allowedSourceRanges)
+	if ic.Spec.EndpointPublishingStrategy == nil {
+		ic.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{}
+	}
+	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
+		ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
+			Type: operatorv1.AWSLoadBalancerProvider,
+			AWS: &operatorv1.AWSLoadBalancerParameters{
+				Type: operatorv1.AWSNetworkLoadBalancer,
+			},
+		},
+	}
+	if allowedSourceRanges != nil {
+		ic.Spec.EndpointPublishingStrategy.LoadBalancer.AllowedSourceRanges = allowedSourceRanges
+	}
+	return ic
+}
+
+// determineLBType unit tests
+
+func TestDetermineLBType_NLB(t *testing.T) {
+	ic := &operatorv1.IngressController{}
+	ic.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+		LoadBalancer: &operatorv1.LoadBalancerStrategy{
+			ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
+				Type: operatorv1.AWSLoadBalancerProvider,
+				AWS: &operatorv1.AWSLoadBalancerParameters{
+					Type: operatorv1.AWSNetworkLoadBalancer,
+				},
+			},
+		},
+	}
+	if determineLBType(ic) != lbTypeNLB {
+		t.Errorf("expected NLB, got %s", determineLBType(ic))
+	}
+}
+
+func TestDetermineLBType_Classic(t *testing.T) {
+	ic := &operatorv1.IngressController{}
+	ic.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+		LoadBalancer: &operatorv1.LoadBalancerStrategy{
+			ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
+				Type: operatorv1.AWSLoadBalancerProvider,
+				AWS: &operatorv1.AWSLoadBalancerParameters{
+					Type: operatorv1.AWSClassicLoadBalancer,
+				},
+			},
+		},
+	}
+	if determineLBType(ic) != lbTypeClassic {
+		t.Errorf("expected Classic, got %s", determineLBType(ic))
+	}
+}
+
+func TestDetermineLBType_NilProviderParams(t *testing.T) {
+	ic := newDefaultIngressController(nil)
+	if determineLBType(ic) != lbTypeClassic {
+		t.Errorf("expected Classic (default), got %s", determineLBType(ic))
+	}
+}
+
+func TestDetermineLBType_StatusFallback(t *testing.T) {
+	ic := &operatorv1.IngressController{}
+	ic.Status.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+		LoadBalancer: &operatorv1.LoadBalancerStrategy{
+			ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
+				Type: operatorv1.AWSLoadBalancerProvider,
+				AWS: &operatorv1.AWSLoadBalancerParameters{
+					Type: operatorv1.AWSNetworkLoadBalancer,
+				},
+			},
+		},
+	}
+	if determineLBType(ic) != lbTypeNLB {
+		t.Errorf("expected NLB from status fallback, got %s", determineLBType(ic))
+	}
+}
+
+// checkLoadBalancerHealth unit tests
+
+func TestCheckLBHealth_NLB_AllHealthy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindNLBByDNSName("test-nlb-abc123.elb.us-east-1.amazonaws.com").
+		Return("arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/net/test-nlb/abc", "test-nlb", nil)
+	mockAws.EXPECT().GetNLBTargetHealth("arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/net/test-nlb/abc").
+		Return([]aws.NLBTargetHealth{
+			{TargetID: "i-001", Port: 443, State: "healthy"},
+			{TargetID: "i-002", Port: 443, State: "healthy"},
+		}, nil)
+
+	ic := newNLBIngressController(nil)
+	svc := newRouterService("test-nlb-abc123.elb.us-east-1.amazonaws.com")
+	k8sClient := newFakeClient(ic, svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient, AwsClient: mockAws}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "all 2 target(s) healthy") {
+		t.Errorf("expected all healthy message, got: %s", output)
+	}
+}
+
+func TestCheckLBHealth_NLB_UnhealthyTarget(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindNLBByDNSName("test-nlb-abc123.elb.us-east-1.amazonaws.com").
+		Return("arn:nlb", "test-nlb", nil)
+	mockAws.EXPECT().GetNLBTargetHealth("arn:nlb").
+		Return([]aws.NLBTargetHealth{
+			{TargetID: "i-001", Port: 443, State: "healthy"},
+			{TargetID: "i-002", Port: 443, State: "unhealthy", Reason: "Target.FailedHealthChecks"},
+		}, nil)
+
+	ic := newNLBIngressController(nil)
+	svc := newRouterService("test-nlb-abc123.elb.us-east-1.amazonaws.com")
+	k8sClient := newFakeClient(ic, svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient, AwsClient: mockAws}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "1/2 target(s) unhealthy") {
+		t.Errorf("expected unhealthy target message, got: %s", output)
+	}
+	if !strings.Contains(output, "i-002") {
+		t.Errorf("expected unhealthy target ID, got: %s", output)
+	}
+}
+
+func TestCheckLBHealth_CLB_AllInService(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindCLBByDNSName("test-clb-123456.us-east-1.elb.amazonaws.com").
+		Return("test-clb", nil)
+	mockAws.EXPECT().GetCLBInstanceHealth("test-clb").
+		Return([]aws.CLBInstanceHealth{
+			{InstanceID: "i-001", State: "InService"},
+			{InstanceID: "i-002", State: "InService"},
+		}, nil)
+
+	ic := newDefaultIngressController(nil) // no ProviderParameters → Classic
+	svc := newRouterService("test-clb-123456.us-east-1.elb.amazonaws.com")
+	k8sClient := newFakeClient(ic, svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient, AwsClient: mockAws}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "all 2 instance(s) InService") {
+		t.Errorf("expected all InService message, got: %s", output)
+	}
+}
+
+func TestCheckLBHealth_CLB_OutOfService(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindCLBByDNSName("test-clb-123456.us-east-1.elb.amazonaws.com").
+		Return("test-clb", nil)
+	mockAws.EXPECT().GetCLBInstanceHealth("test-clb").
+		Return([]aws.CLBInstanceHealth{
+			{InstanceID: "i-001", State: "InService"},
+			{InstanceID: "i-002", State: "OutOfService", Description: "Instance has failed health checks"},
+		}, nil)
+
+	ic := newDefaultIngressController(nil)
+	svc := newRouterService("test-clb-123456.us-east-1.elb.amazonaws.com")
+	k8sClient := newFakeClient(ic, svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient, AwsClient: mockAws}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "1/2 instance(s) not InService") {
+		t.Errorf("expected OutOfService message, got: %s", output)
+	}
+	if !strings.Contains(output, "i-002") {
+		t.Errorf("expected unhealthy instance ID, got: %s", output)
+	}
+}
+
+func TestCheckLBHealth_NoHostname(t *testing.T) {
+	ic := newDefaultIngressController(nil)
+	svc := newRouterService("") // no hostname
+	k8sClient := newFakeClient(ic, svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no LoadBalancer hostname assigned") {
+		t.Errorf("expected no hostname warning, got: %s", output)
+	}
+}
+
+func TestCheckLBHealth_LBNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindCLBByDNSName("unknown-lb.us-east-1.elb.amazonaws.com").Return("", nil)
+
+	ic := newDefaultIngressController(nil)
+	svc := newRouterService("unknown-lb.us-east-1.elb.amazonaws.com")
+	k8sClient := newFakeClient(ic, svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient, AwsClient: mockAws}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no CLB found matching DNS name") {
+		t.Errorf("expected LB not found warning, got: %s", output)
+	}
+}
+
+func TestCheckLBHealth_APIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindCLBByDNSName("test-clb.us-east-1.elb.amazonaws.com").
+		Return("", fmt.Errorf("access denied"))
+
+	ic := newDefaultIngressController(nil)
+	svc := newRouterService("test-clb.us-east-1.elb.amazonaws.com")
+	k8sClient := newFakeClient(ic, svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient, AwsClient: mockAws}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "failed to look up CLB") {
+		t.Errorf("expected API error warning, got: %s", output)
+	}
+}
+
+func TestCheckLBHealth_ICNotFound(t *testing.T) {
+	// No IngressController in fake client.
+	svc := newRouterService("test-lb.us-east-1.elb.amazonaws.com")
+	k8sClient := newFakeClient(svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "failed to get default IngressController") {
+		t.Errorf("expected IC not found warning, got: %s", output)
+	}
+}
+
+func TestCheckLBHealth_NLB_NoTargets(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	mockAws.EXPECT().FindNLBByDNSName("test-nlb.elb.us-east-1.amazonaws.com").
+		Return("arn:nlb", "test-nlb", nil)
+	mockAws.EXPECT().GetNLBTargetHealth("arn:nlb").
+		Return([]aws.NLBTargetHealth{}, nil)
+
+	ic := newNLBIngressController(nil)
+	svc := newRouterService("test-nlb.elb.us-east-1.amazonaws.com")
+	k8sClient := newFakeClient(ic, svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient, AwsClient: mockAws}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no registered targets") {
+		t.Errorf("expected no targets warning, got: %s", output)
+	}
+}
+
+func TestCheckLBHealth_CLB_DefaultType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	// IC with nil ProviderParameters defaults to Classic — should call CLB APIs.
+	mockAws.EXPECT().FindCLBByDNSName("test-clb.us-east-1.elb.amazonaws.com").
+		Return("test-clb", nil)
+	mockAws.EXPECT().GetCLBInstanceHealth("test-clb").
+		Return([]aws.CLBInstanceHealth{
+			{InstanceID: "i-001", State: "InService"},
+		}, nil)
+
+	ic := newDefaultIngressController(nil) // no ProviderParameters
+	svc := newRouterService("test-clb.us-east-1.elb.amazonaws.com")
+	k8sClient := newFakeClient(ic, svc)
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	r := &investigation.Resources{Cluster: cluster, K8sClient: k8sClient, AwsClient: mockAws}
+	inv.checkLoadBalancerHealth(context.Background(), r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "CLB") {
+		t.Errorf("expected CLB in output (default type), got: %s", output)
+	}
+	if !strings.Contains(output, "all 1 instance(s) InService") {
+		t.Errorf("expected all InService, got: %s", output)
+	}
+}
+
+// mockEgressVerifier is a test mock for the egressVerifier interface.
+type mockEgressVerifier struct {
+	result  networkverifier.VerifierResult
+	failure string
+	err     error
+	called  bool
+}
+
+func (m *mockEgressVerifier) run(r *investigation.Resources) (networkverifier.VerifierResult, string, error) {
+	m.called = true
+	return m.result, m.failure, m.err
+}
+
+func successEgressVerifier() *mockEgressVerifier {
+	return &mockEgressVerifier{result: networkverifier.Success}
+}
+
+// checkVPCEgress unit tests
+
+func TestCheckVPCEgress_Success(t *testing.T) {
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{egressVerifier: successEgressVerifier()}
+
+	r := &investigation.Resources{
+		Cluster:           cluster,
+		ClusterDeployment: &hivev1.ClusterDeployment{},
+	}
+	inv.checkVPCEgress(r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "network verifier passed") {
+		t.Errorf("expected success message, got: %s", output)
+	}
+}
+
+func TestCheckVPCEgress_Failure(t *testing.T) {
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{egressVerifier: &mockEgressVerifier{
+		result:  networkverifier.Failure,
+		failure: "nosnch.in unreachable",
+	}}
+
+	r := &investigation.Resources{
+		Cluster:           cluster,
+		ClusterDeployment: &hivev1.ClusterDeployment{},
+	}
+	inv.checkVPCEgress(r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "blocked egress") {
+		t.Errorf("expected blocked egress warning, got: %s", output)
+	}
+	if !strings.Contains(output, "nosnch.in unreachable") {
+		t.Errorf("expected failure reason, got: %s", output)
+	}
+}
+
+func TestCheckVPCEgress_Error(t *testing.T) {
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{egressVerifier: &mockEgressVerifier{
+		err: fmt.Errorf("failed to initialize validateEgressInput"),
+	}}
+
+	r := &investigation.Resources{
+		Cluster:           cluster,
+		ClusterDeployment: &hivev1.ClusterDeployment{},
+	}
+	inv.checkVPCEgress(r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "network verifier error") {
+		t.Errorf("expected error warning, got: %s", output)
+	}
+	if !strings.Contains(output, "failed to initialize") {
+		t.Errorf("expected error detail, got: %s", output)
+	}
+}
+
+func TestCheckVPCEgress_Undefined(t *testing.T) {
+	cluster := newAWSTestClusterWithDNS("test", "10.0.0.0/16", "", "p", "e.com", false)
+	notes := newTestNotes()
+	inv := &Investigation{egressVerifier: &mockEgressVerifier{
+		result: networkverifier.Undefined,
+	}}
+
+	r := &investigation.Resources{
+		Cluster:           cluster,
+		ClusterDeployment: &hivev1.ClusterDeployment{},
+	}
+	inv.checkVPCEgress(r, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "undefined result") {
+		t.Errorf("expected undefined result warning, got: %s", output)
+	}
+}
+
+// Run-level test: PrivateLink cluster skips egress but runs other AWS checks
+
+func TestRun_PrivateLink_SkipsEgress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockAws := awsmock.NewMockClient(ctrl)
+
+	// Route53 check expects: FindHostedZone (private only for PrivateLink), HasResourceRecordSet
+	mockAws.EXPECT().FindHostedZone("msaary-test.4t01.s1.devshift.org", true).Return("Z1234PRIVATE", nil)
+	mockAws.EXPECT().HasResourceRecordSet("Z1234PRIVATE", "\\052.apps.msaary-test.4t01.s1.devshift.org.", "A").Return(true, nil)
+	// No public zone call for PrivateLink clusters.
+
+	// DHCP check expects: GetVpcDhcpConfiguration (classic cluster, not HCP)
+	mockAws.EXPECT().GetVpcDhcpConfiguration("test-cluster-infra").Return([]string{"AmazonProvidedDNS"}, nil)
+
+	// LB health check expects: FindCLBByDNSName (IC defaults to Classic)
+	mockAws.EXPECT().FindCLBByDNSName("test-elb-123456.us-east-1.elb.amazonaws.com").Return("test-elb", nil)
+	mockAws.EXPECT().GetCLBInstanceHealth("test-elb").Return([]aws.CLBInstanceHealth{
+		{InstanceID: "i-001", State: "InService"},
+		{InstanceID: "i-002", State: "InService"},
+	}, nil)
+
+	// No egress verifier calls expected — PrivateLink clusters skip egress.
+
+	ic := newDefaultIngressController([]operatorv1.CIDR{"10.0.0.0/8"})
+	dns := newDefaultDNS([]operatorv1.Upstream{{Type: operatorv1.SystemResolveConfType}})
+	routerPod := newRouterPod("router-default-abc", corev1.PodRunning, []corev1.ContainerStatus{
+		{Name: "router", Ready: true, RestartCount: 0},
+	})
+	routerSvc := newRouterService("test-elb-123456.us-east-1.elb.amazonaws.com")
+	consolePod := newConsolePod("console-abc", "node-1")
+	node := newTestNode("node-1", healthyNodeConditions(), false)
+	k8sClient := newFakeClient(ic, dns, routerPod, routerSvc, consolePod, node)
+	cluster := newAWSTestClusterWithDNS("test-cluster", "10.0.0.0/16",
+		"https://console.test.example.com", "msaary-test", "4t01.s1.devshift.org", true) // PrivateLink=true
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:    cluster,
+			K8sClient:  k8sClient,
+			AwsClient:  mockAws,
+			IsHCP:      false,
+			RestConfig: testRestConfig(),
+		},
+	}
+
+	egressMock := successEgressVerifier()
+	inv := &Investigation{
+		consoleChecker: healthyConsoleChecker(),
+		blackboxProber: healthyBlackboxProber(),
+		egressVerifier: egressMock,
+	}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify egress was skipped — mock should not have been called.
+	if egressMock.called {
+		t.Error("expected egress check to be skipped for PrivateLink cluster")
+	}
+
+	// Verify escalation still happens (other checks ran).
+	hasEscalate := false
+	for _, a := range result.Actions {
+		if a.Type() == actionEscalate {
+			hasEscalate = true
+		}
+	}
+	if !hasEscalate {
+		t.Error("expected escalate action")
 	}
 }

--- a/pkg/investigations/consoleerrorbudgetburn/metadata.yaml
+++ b/pkg/investigations/consoleerrorbudgetburn/metadata.yaml
@@ -1,0 +1,40 @@
+name: consoleerrorbudgetburn
+rbac:
+  roles:
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['pods']
+          verbs: ['get', 'list']
+        - apiGroups: ['']
+          resources: ['events']
+          verbs: ['list']
+    - namespace: "openshift-monitoring"
+      rules:
+        - apiGroups: ['']
+          resources: ['pods']
+          verbs: ['get', 'list']
+        - apiGroups: ['']
+          resources: ['pods/exec']
+          verbs: ['create']
+    - namespace: "openshift-console"
+      rules:
+        - apiGroups: ['']
+          resources: ['pods']
+          verbs: ['get', 'list']
+        - apiGroups: ['']
+          resources: ['events']
+          verbs: ['list']
+  clusterRoleRules:
+    - apiGroups: ['operator.openshift.io']
+      resources: ['dnses']
+      verbs: ['get']
+    - apiGroups: ['']
+      resources: ['nodes']
+      verbs: ['get']
+customerDataAccess: false

--- a/pkg/investigations/consoleerrorbudgetburn/metadata.yaml
+++ b/pkg/investigations/consoleerrorbudgetburn/metadata.yaml
@@ -14,6 +14,9 @@ rbac:
         - apiGroups: ['']
           resources: ['events']
           verbs: ['list']
+        - apiGroups: ['']
+          resources: ['services']
+          verbs: ['get']
     - namespace: "openshift-route-monitor-operator"
       rules:
         - apiGroups: ['']

--- a/pkg/investigations/consoleerrorbudgetburn/metadata.yaml
+++ b/pkg/investigations/consoleerrorbudgetburn/metadata.yaml
@@ -14,6 +14,14 @@ rbac:
         - apiGroups: ['']
           resources: ['events']
           verbs: ['list']
+    - namespace: "openshift-route-monitor-operator"
+      rules:
+        - apiGroups: ['']
+          resources: ['pods']
+          verbs: ['get', 'list']
+        - apiGroups: ['']
+          resources: ['pods/exec']
+          verbs: ['create']
     - namespace: "openshift-monitoring"
       rules:
         - apiGroups: ['']

--- a/pkg/investigations/consoleerrorbudgetburn/metadata.yaml
+++ b/pkg/investigations/consoleerrorbudgetburn/metadata.yaml
@@ -48,4 +48,7 @@ rbac:
     - apiGroups: ['']
       resources: ['nodes']
       verbs: ['get']
+    - apiGroups: ['metrics.k8s.io']
+      resources: ['nodes']
+      verbs: ['get', 'list']
 customerDataAccess: false

--- a/pkg/investigations/consoleerrorbudgetburn/testing/README.md
+++ b/pkg/investigations/consoleerrorbudgetburn/testing/README.md
@@ -1,0 +1,5 @@
+# Testing consoleerrorbudgetburn Investigation
+
+TODO:
+- Add a test script or test objects to this `testing/` directory for future maintainers to use
+- Edit this README file and add detailed instructions on how to use the script/objects to recreate the conditions for the investigation. Be sure to include any assumptions or prerequisites about the environment (disable hive syncsetting, etc)

--- a/pkg/investigations/consoleerrorbudgetburn/testing/README.md
+++ b/pkg/investigations/consoleerrorbudgetburn/testing/README.md
@@ -1,5 +1,0 @@
-# Testing consoleerrorbudgetburn Investigation
-
-TODO:
-- Add a test script or test objects to this `testing/` directory for future maintainers to use
-- Edit this README file and add detailed instructions on how to use the script/objects to recreate the conditions for the investigation. Be sure to include any assumptions or prerequisites about the environment (disable hive syncsetting, etc)

--- a/pkg/investigations/investigation/investigation.go
+++ b/pkg/investigations/investigation/investigation.go
@@ -453,7 +453,7 @@ func (r *ResourceBuilderMock) WithManagementOCClient() ResourceBuilder {
 
 func (r *ResourceBuilderMock) Build() (*Resources, error) {
 	if r.BuildError != nil {
-		return nil, r.BuildError
+		return r.Resources, r.BuildError
 	}
 	return r.Resources, nil
 }

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/chgm"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clusterhealthcheck"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clustermonitoringerrorbudgetburn"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/consoleerrorbudgetburn"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/cpd"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/describenodes"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/etcddatabasequotalowspace"
@@ -36,6 +37,7 @@ var availableInvestigations = []investigation.Investigation{
 	&mustgather.Investigation{},
 	&describenodes.Investigation{},
 	&clusterhealthcheck.Investigation{},
+	&consoleerrorbudgetburn.Investigation{},
 }
 
 // GetInvestigation returns the first Investigation that applies to the given alert title.

--- a/pkg/k8s/scheme.go
+++ b/pkg/k8s/scheme.go
@@ -6,6 +6,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	certsv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,10 @@ func initScheme() (*runtime.Scheme, error) {
 
 	if err := mcfgv1.Install(scheme); err != nil {
 		return nil, fmt.Errorf("unable to add machineconfiguration.openshift.io/v1 scheme: %w", err)
+	}
+
+	if err := operatorv1.Install(scheme); err != nil {
+		return nil, fmt.Errorf("unable to add operator.openshift.io/v1 scheme: %w", err)
 	}
 
 	if err := certsv1.AddToScheme(scheme); err != nil {


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

Adds a new experimental investigation for the console-ErrorBudgetBurn alert, automating the manual SOP triage steps that SREs currently perform. The investigation progressively gathers context from K8s and (for AWS clusters) cloud-provider APIs, identifies definitive root causes where possible, and escalates with detailed diagnostic notes when manual investigation is still needed.
Checks performed:
- Blackbox probe analysis (exec into blackbox-exporter, parse/classify probe results: DNS, TLS, timeout, connection refused, server error)
- allowedSourceRanges misconfiguration on the default IngressController (CIDR containment against machine CIDR) — sends SL + silences on detection
- Upstream DNS resolver configuration (dns.operator.openshift.io/default)
- Router and console pod health (phase, container readiness, restart counts, warning events)
- Console service reachability from within the cluster (curl via CMO pod)
- Node health for nodes running console pods (conditions, pressure, unschedulable)
- AWS-only: Route53 DNS record verification (private + public hosted zones) — sends SL + silences on missing *.apps records
- AWS-only: VPC DHCP option set validation (AmazonProvidedDNS vs custom DNS servers)
- AWS-only: Load balancer health (CLB instance health / NLB target health, with automatic LB type detection from IngressController spec)
- AWS-only, non-PrivateLink: VPC egress verification via osd-network-verifier
Supporting changes:
- 7 new methods on the AWS client (FindHostedZone, HasResourceRecordSet, GetVpcDhcpConfiguration, FindNLBByDNSName, FindCLBByDNSName, GetNLBTargetHealth, GetCLBInstanceHealth) with corresponding mock interface updates
- ResourceBuilderMock.Build() now returns partial resources on error (matching real builder behavior), enabling progressive build testing
- aws_test.go moved to package aws_test (black-box testing) to accommodate exported mock types

### Special notes for your reviewer

_This is obviously a huge PR, I'm not opposed to splitting it, perhaps along the 3 separate commits corresponding to `k8s`, `blackbox probe` and `aws` checks. Ping me/comment if we'd prefer to do so._

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [x] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added investigation for console-ErrorBudgetBurn alerts with automated diagnosis and remediation of network, DNS, and configuration issues affecting console availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->