### PR TITLE
feat: persist AI investigation output to cluster report

### DIFF
--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -184,12 +184,21 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	logging.Infof("AI Output:\n%s", aiResponse.String())
 
 	// Add simple note about AI automation completion
-	notes.AppendAutomation("AI automation completed. Check recent cluster reports for report Summary %s: 'osdctl cluster reports list --cluster-id %s'", incidentID, clusterID)
+	notes.AppendAutomation("AI automation completed. Check recent cluster reports for AI investigation details: 'osdctl cluster reports list --cluster-id %s'", clusterID)
+
+	// Create backplane report action with the AI investigation results
+	backplaneReportAction := &executor.BackplaneReportAction{
+		ClusterID: r.Cluster.ExternalID(),
+		Summary:   fmt.Sprintf("CAD Investigation: AI-Assisted Analysis for %s", alertName),
+		Data:      aiResponse.String(),
+	}
 
 	// Return actions for executor to handle
+	// The report action will append to notes when executed, then note sends them to PagerDuty
 	result.Actions = append(
 		executor.NoteAndReportFrom(notes, clusterID, c.Name()),
-		executor.Escalate("AI investigation completed - manual review required"),
+		backplaneReportAction, // write a second report here, as this contains the formatted AI results
+		executor.Escalate("AI investigation completed - see cluster report for details"),
 	)
 	return result, nil
 }


### PR DESCRIPTION
## Summary
Add BackplaneReportAction to store CORA investigation results in a separate cluster report, following the same pattern as the `etcddatabasequotalowspace` investigation.

## Changes
- Create dedicated cluster report containing full AI conversation output
- Include session ID, runtime details, and complete CORA analysis
- Update automation note to reference cluster reports for details
- Update escalation message to direct users to cluster report

## Why
Previously, AI investigation output was only logged and not persisted to cluster reports. This meant SREs had no way to access CORA's investigation results after the fact.

Now CORA investigation results are stored in backplane and accessible via `osdctl cluster reports list` and `osdctl cluster reports get`, similar to other investigations like etcd analysis.

## Testing
- [ ] Manual test with test cluster to verify report creation
- [ ] Verify report contains complete CORA output
- [ ] Verify PagerDuty note includes osdctl command to access report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI investigations now generate and upload formatted cluster reports to backplane with summaries based on alert names.

* **Improvements**
  * Updated automation notes with cluster report retrieval commands.
  * Enhanced escalation messaging to direct users to cluster reports for investigation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->