### PR TITLE
SREP-4521: add investigation for expired certs

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/ccam"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/chgm"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/expiredcertificates"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/precheck"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
@@ -351,6 +352,27 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 		if inv.AlertTitle() == chgmInv.AlertTitle() {
 			c.recordManualCompletion(inv.Name(), pdClient, "ccam_stopped")
 			return nil
+		}
+	}
+
+	// Skip cert pre-check for investigations that use management cluster access,
+	// because backplane validates all RBAC (including hosted-cluster rules) against
+	// infrastructure cluster restrictions, rejecting secrets access.
+	certPreCheckSkip := []string{"mustgather", "restartcontrolplane", "etcddatabasequotalowspace"}
+	certCheck := &expiredcertificates.Investigation{}
+	if inv.Name() != certCheck.Name() && !slices.Contains(certPreCheckSkip, inv.Name()) {
+		certResult, certErr := certCheck.Run(builder)
+		if certErr != nil {
+			logging.Warnf("Expired certificates pre-check failed: %v", certErr)
+		}
+		if len(certResult.Actions) > 0 {
+			if certErr = c.executeActions(builder, &certResult, certCheck.Name()); certErr != nil {
+				logging.Warnf("Failed to execute expired certificates actions: %v", certErr)
+			}
+		}
+		// Reset notes so cert check findings don't leak into the main investigation's NoteWriter
+		if r, _ := builder.Build(); r != nil {
+			r.Notes = nil
 		}
 	}
 

--- a/pkg/investigations/aiassisted/metadata.yaml
+++ b/pkg/investigations/aiassisted/metadata.yaml
@@ -1,6 +1,34 @@
 name: aiassisted
 rbac:
-  roles: []
-  clusterRoleRules: []
+  roles:
+    - namespace: "openshift-config"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-config-managed"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-service-ca"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
+  clusterRoleRules:
+    - apiGroups: ['config.openshift.io']
+      resources: ['apiservers', 'ingresses', 'clusteroperators']
+      verbs: ['get', 'list']
 customerDataAccess: false
 

--- a/pkg/investigations/cannotretrieveupdatessre/metadata.yaml
+++ b/pkg/investigations/cannotretrieveupdatessre/metadata.yaml
@@ -1,6 +1,31 @@
 name: cannotretrieveupdatessre
 rbac:
-  roles: []
+  roles:
+    - namespace: "openshift-config"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-config-managed"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-service-ca"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
   clusterRoleRules:
     - verbs:
         - "get"
@@ -9,4 +34,7 @@ rbac:
         - "config.openshift.io"
       resources:
         - clusterversions
+        - apiservers
+        - ingresses
+        - clusteroperators
 customerDataAccess: false

--- a/pkg/investigations/clusterhealthcheck/metadata.yaml
+++ b/pkg/investigations/clusterhealthcheck/metadata.yaml
@@ -17,6 +17,31 @@ rbac:
         - apiGroups: ['']
           resources: ['pods/exec']
           verbs: ['create']
+    - namespace: "openshift-config"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-config-managed"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-service-ca"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
   clusterRoleRules:
     - apiGroups: ['']
       resources: ['namespaces']
@@ -28,7 +53,7 @@ rbac:
       resources: ['pods', 'pods/log']
       verbs: ['get', 'list', 'watch']
     - apiGroups: ['config.openshift.io']
-      resources: ['clusteroperators', 'clusterversions']
+      resources: ['clusteroperators', 'clusterversions', 'apiservers', 'ingresses']
       verbs: ['get', 'list']
     - apiGroups: ['machineconfiguration.openshift.io']
       resources: ['machineconfigpools']

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/metadata.yaml
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/metadata.yaml
@@ -1,6 +1,31 @@
 name: clustermonitoringerrorbudgetburn
 rbac:
-  roles: []
+  roles:
+    - namespace: "openshift-config"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-config-managed"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-service-ca"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
   clusterRoleRules:
     - verbs:
         - "get"
@@ -9,4 +34,6 @@ rbac:
         - "config.openshift.io"
       resources:
         - clusteroperators
+        - apiservers
+        - ingresses
 customerDataAccess: false

--- a/pkg/investigations/describenodes/metadata.yaml
+++ b/pkg/investigations/describenodes/metadata.yaml
@@ -6,6 +6,31 @@ rbac:
         - apiGroups: ['coordination.k8s.io']
           resources: ['leases']
           verbs: ['get', 'list']
+    - namespace: "openshift-config"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-config-managed"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-service-ca"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
   clusterRoleRules:
     - apiGroups: ['']
       resources: ['nodes']
@@ -15,5 +40,8 @@ rbac:
       verbs: ['get', 'list']
     - apiGroups: ['']
       resources: ['events']
+      verbs: ['get', 'list']
+    - apiGroups: ['config.openshift.io']
+      resources: ['apiservers', 'ingresses', 'clusteroperators']
       verbs: ['get', 'list']
 customerDataAccess: true

--- a/pkg/investigations/expiredcertificates/README.md
+++ b/pkg/investigations/expiredcertificates/README.md
@@ -1,0 +1,16 @@
+# expiredcertificates Investigation
+
+Investigates expired or expiring TLS certificates in the cluster. Runs both as a standalone investigation and as a pre-check before other investigations.
+
+On HCP clusters, API server cert checks are skipped since backplane restricts secret access on management clusters.
+
+## Checks
+
+- **API Server Certificates** — reads `APIServer/cluster` and resolves any secrets referenced in `spec.servingCerts.namedCertificates`. Reports expiry, subject, issuer, and SANs.
+- **Ingress Certificate** — reads `IngressController/default` in `openshift-ingress-operator` and resolves the secret referenced in `spec.defaultCertificate`. Reports expiry and issuer.
+- **Component Route Certificates** — reads `Ingress/cluster` and resolves secrets referenced in `spec.componentRoutes` (covers OAuth, console, and other custom component routes). Reports expiry and issuer per component.
+- **Critical Namespace TLS Secrets** — enumerates all `kubernetes.io/tls` secrets in `openshift-config`, `openshift-ingress`, `openshift-config-managed`, and `openshift-service-ca`. Flags any that are expired or expiring within 7 days.
+
+## Estimated time saved
+
+20 minutes per alert. Manual investigation requires backplane access, checking multiple API objects and their referenced secrets across several namespaces, parsing certificate data, and writing up findings.

--- a/pkg/investigations/expiredcertificates/expiredcertificates.go
+++ b/pkg/investigations/expiredcertificates/expiredcertificates.go
@@ -1,0 +1,329 @@
+package expiredcertificates
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	expiryWarningThreshold = 7 * 24 * time.Hour
+
+	clusterSingletonName       = "cluster"
+	nsOpenshiftConfig          = "openshift-config"
+	nsOpenshiftIngress         = "openshift-ingress"
+	nsOpenshiftConfigManaged   = "openshift-config-managed"
+	nsOpenshiftIngressOperator = "openshift-ingress-operator"
+	nsOpenShiftServiceCA       = "openshift-service-ca"
+	defaultIngressController   = "default"
+)
+
+var criticalTLSNamespaces = []string{
+	nsOpenshiftConfig,
+	nsOpenshiftIngress,
+	nsOpenshiftConfigManaged,
+	nsOpenShiftServiceCA,
+}
+
+type certInfo struct {
+	Subject   string
+	Issuer    string
+	SANs      []string
+	NotBefore time.Time
+	NotAfter  time.Time
+}
+
+func (c *certInfo) isExpired() bool {
+	return time.Now().After(c.NotAfter)
+}
+
+func (c *certInfo) isExpiringSoon() bool {
+	return !c.isExpired() && time.Until(c.NotAfter) < expiryWarningThreshold
+}
+
+func (c *certInfo) statusString() string {
+	if c.isExpired() {
+		return fmt.Sprintf("EXPIRED (expired %dd ago)", int(time.Since(c.NotAfter).Hours()/24))
+	}
+	if c.isExpiringSoon() {
+		return fmt.Sprintf("EXPIRING SOON (expires in %dd)", int(time.Until(c.NotAfter).Hours()/24))
+	}
+	return fmt.Sprintf("valid (expires in %dd)", int(time.Until(c.NotAfter).Hours()/24))
+}
+
+type Investigation struct{}
+
+func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
+	ctx := context.Background()
+	result := investigation.InvestigationResult{}
+
+	r, err := rb.WithCluster().WithK8sClient().WithNotes().Build()
+	if err != nil {
+		if msg, ok := investigation.ClusterAccessErrorMessage(err); ok {
+			logging.Warnf("Cluster access error for expiredcertificates: %v", err)
+			result.Actions = []types.Action{
+				executor.Note(msg),
+			}
+			return result, nil
+		}
+		return result, investigation.WrapInfrastructure(err, "failed to build resources for expiredcertificates")
+	}
+
+	notes := r.Notes
+
+	if r.IsHCP {
+		notes.AppendSuccess("API Server Certs: skipped (secret access on management cluster is restricted by backplane)")
+	} else {
+		i.checkAPIServerCerts(ctx, r.K8sClient, notes)
+	}
+	i.checkIngressCert(ctx, r.K8sClient, notes)
+	i.checkComponentRouteCerts(ctx, r.K8sClient, notes)
+	i.checkCriticalTLSSecrets(ctx, r.K8sClient, notes)
+
+	result.Actions = executor.NoteAndReportFrom(notes, r.Cluster.ID(), i.Name())
+	return result, nil
+}
+
+func (i *Investigation) checkAPIServerCerts(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	apiServer := &configv1.APIServer{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: clusterSingletonName}, apiServer); err != nil {
+		notes.AppendWarning("API Server Certs: failed to get APIServer config - %v", err)
+		return
+	}
+
+	namedCerts := apiServer.Spec.ServingCerts.NamedCertificates
+	if len(namedCerts) == 0 {
+		notes.AppendSuccess("API Server Certs: no named serving certificates configured")
+		return
+	}
+
+	var issues []string
+	for _, nc := range namedCerts {
+		secretName := nc.ServingCertificate.Name
+		if secretName == "" {
+			continue
+		}
+
+		info, err := i.getSecretCertInfo(ctx, k8sClient, nsOpenshiftConfig, secretName)
+		if err != nil {
+			issues = append(issues, fmt.Sprintf("%s: %v", secretName, err))
+			continue
+		}
+
+		// If Names is empty, the API server uses the cert's SANs to match requests
+		names := nc.Names
+		if len(names) == 0 {
+			names = info.SANs
+		}
+
+		status := info.statusString()
+		entry := fmt.Sprintf("%s (names: %s, subject: %s, issuer: %s, expires: %s) - %s",
+			secretName, strings.Join(names, ", "), info.Subject, info.Issuer,
+			info.NotAfter.Format(time.RFC3339), status)
+
+		if info.isExpired() || info.isExpiringSoon() {
+			issues = append(issues, entry)
+		} else {
+			notes.AppendSuccess("API Server Certs: %s", entry)
+		}
+	}
+
+	if len(issues) > 0 {
+		notes.AppendWarning("API Server Certs: %d issue(s):\n  %s", len(issues), strings.Join(issues, "\n  "))
+	}
+}
+
+func (i *Investigation) checkIngressCert(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	secretName := i.getIngressCertSecretName(ctx, k8sClient, notes)
+	if secretName == "" {
+		notes.AppendWarning("Ingress Certificate: no defaultCertificate configured on IngressController/default")
+		return
+	}
+
+	info, err := i.getSecretCertInfo(ctx, k8sClient, nsOpenshiftIngress, secretName)
+	if err != nil {
+		notes.AppendWarning("Ingress Certificate: failed to read %s in %s - %v", secretName, nsOpenshiftIngress, err)
+		return
+	}
+
+	entry := fmt.Sprintf("secret: %s, subject: %s, issuer: %s, expires: %s - %s",
+		secretName, info.Subject, info.Issuer, info.NotAfter.Format(time.RFC3339), info.statusString())
+
+	if info.isExpired() || info.isExpiringSoon() {
+		notes.AppendWarning("Ingress Certificate: %s", entry)
+	} else {
+		notes.AppendSuccess("Ingress Certificate: %s", entry)
+	}
+}
+
+func (i *Investigation) getIngressCertSecretName(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) string {
+	ic := &operatorv1.IngressController{}
+	err := k8sClient.Get(ctx, client.ObjectKey{Namespace: nsOpenshiftIngressOperator, Name: defaultIngressController}, ic)
+	if err != nil {
+		notes.AppendWarning("Ingress Certificate: could not read IngressController/default - %v", err)
+		return ""
+	}
+
+	if ic.Spec.DefaultCertificate == nil {
+		return ""
+	}
+	return ic.Spec.DefaultCertificate.Name
+}
+
+// checkComponentRouteCerts checks certs for OAuth, console, etc. These secrets live in openshift-config
+// and would also be caught by checkCriticalTLSSecrets, but this check adds which component route is affected.
+func (i *Investigation) checkComponentRouteCerts(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	ingress := &configv1.Ingress{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: clusterSingletonName}, ingress); err != nil {
+		notes.AppendWarning("Component Route Certs: failed to get Ingress config - %v", err)
+		return
+	}
+
+	if len(ingress.Spec.ComponentRoutes) == 0 {
+		notes.AppendSuccess("Component Route Certs: no custom component route certificates configured (OAuth, console use default certs)")
+		return
+	}
+
+	var issues []string
+	var healthy []string
+
+	for _, route := range ingress.Spec.ComponentRoutes {
+		secretName := route.ServingCertKeyPairSecret.Name
+		if secretName == "" {
+			continue
+		}
+
+		componentName := fmt.Sprintf("%s/%s", route.Namespace, route.Name)
+		info, err := i.getSecretCertInfo(ctx, k8sClient, nsOpenshiftConfig, secretName)
+		if err != nil {
+			issues = append(issues, fmt.Sprintf("%s (secret: %s): %v", componentName, secretName, err))
+			continue
+		}
+
+		entry := fmt.Sprintf("%s (secret: %s, subject: %s, issuer: %s, expires: %s) - %s",
+			componentName, secretName, info.Subject, info.Issuer,
+			info.NotAfter.Format(time.RFC3339), info.statusString())
+
+		if info.isExpired() || info.isExpiringSoon() {
+			issues = append(issues, entry)
+		} else {
+			healthy = append(healthy, entry)
+		}
+	}
+
+	for _, h := range healthy {
+		notes.AppendSuccess("Component Route Certs: %s", h)
+	}
+	if len(issues) > 0 {
+		notes.AppendWarning("Component Route Certs: %d issue(s):\n  %s", len(issues), strings.Join(issues, "\n  "))
+		notes.AppendWarning("Component Route Certs: customer-supplied certificates require customer action to rotate")
+	}
+}
+
+func (i *Investigation) checkCriticalTLSSecrets(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) {
+	var allIssues []string
+
+	for _, ns := range criticalTLSNamespaces {
+		secretList := &corev1.SecretList{}
+		if err := k8sClient.List(ctx, secretList, client.InNamespace(ns), client.MatchingFields{"type": string(corev1.SecretTypeTLS)}); err != nil {
+			notes.AppendWarning("TLS Secrets (%s): failed to list - %v", ns, err)
+			continue
+		}
+
+		var nsIssues []string
+		tlsCount := len(secretList.Items)
+
+		for idx := range secretList.Items {
+			secret := &secretList.Items[idx]
+			info, err := parseTLSCert(secret.Data["tls.crt"])
+			if err != nil {
+				nsIssues = append(nsIssues, fmt.Sprintf("%s/%s: failed to parse - %v", ns, secret.Name, err))
+				continue
+			}
+
+			if info.isExpired() || info.isExpiringSoon() {
+				nsIssues = append(nsIssues, fmt.Sprintf("%s/%s (subject: %s, issuer: %s, expires: %s) - %s",
+					ns, secret.Name, info.Subject, info.Issuer,
+					info.NotAfter.Format(time.RFC3339), info.statusString()))
+			}
+		}
+
+		if len(nsIssues) == 0 {
+			if tlsCount == 0 {
+				notes.AppendSuccess("TLS Secrets (%s): no TLS secrets found", ns)
+			} else {
+				notes.AppendSuccess("TLS Secrets (%s): all %d TLS secrets are valid", ns, tlsCount)
+			}
+		} else {
+			allIssues = append(allIssues, nsIssues...)
+		}
+	}
+
+	if len(allIssues) > 0 {
+		notes.AppendWarning("TLS Secrets: %d expired or expiring certificate(s):\n  %s", len(allIssues), strings.Join(allIssues, "\n  "))
+	}
+}
+
+func (i *Investigation) getSecretCertInfo(ctx context.Context, k8sClient k8sclient.Client, namespace, name string) (*certInfo, error) {
+	secret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get secret %s/%s: %w", namespace, name, err)
+	}
+	return parseTLSCert(secret.Data["tls.crt"])
+}
+
+func parseTLSCert(certData []byte) (*certInfo, error) {
+	if len(certData) == 0 {
+		return nil, fmt.Errorf("empty certificate data")
+	}
+
+	block, _ := pem.Decode(certData)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	return &certInfo{
+		Subject:   cert.Subject.CommonName,
+		Issuer:    cert.Issuer.CommonName,
+		SANs:      cert.DNSNames,
+		NotBefore: cert.NotBefore,
+		NotAfter:  cert.NotAfter,
+	}, nil
+}
+
+func (i *Investigation) Name() string {
+	return "expiredcertificates"
+}
+
+func (i *Investigation) AlertTitle() string {
+	return "expiredcertificates"
+}
+
+func (i *Investigation) Description() string {
+	return "Investigate expired or expiring certificates in the cluster, including custom API server, ingress, and OAuth certificates"
+}
+
+func (i *Investigation) IsExperimental() bool {
+	return false
+}

--- a/pkg/investigations/expiredcertificates/expiredcertificates_test.go
+++ b/pkg/investigations/expiredcertificates/expiredcertificates_test.go
@@ -1,0 +1,556 @@
+package expiredcertificates
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = configv1.Install(s)
+	_ = operatorv1.Install(s)
+	return s
+}
+
+type clientImpl struct {
+	client.Client
+}
+
+func newFakeClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		WithIndex(&corev1.Secret{}, "type", func(o client.Object) []string {
+			return []string{string(o.(*corev1.Secret).Type)}
+		}).
+		Build()
+}
+
+func newTestCluster(id string) *cmv1.Cluster {
+	cluster, _ := cmv1.NewCluster().ID(id).Build()
+	return cluster
+}
+
+func newTestNotes() *notewriter.NoteWriter {
+	return notewriter.New("expiredcertificates", nil)
+}
+
+func generateTestCert(cn string, notBefore, notAfter time.Time, dnsNames ...string) []byte {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		Issuer:       pkix.Name{CommonName: "Test CA"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		DNSNames:     dnsNames,
+	}
+	certBytes, _ := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+}
+
+func validCert(cn string, dnsNames ...string) []byte {
+	return generateTestCert(cn, time.Now().Add(-24*time.Hour), time.Now().Add(365*24*time.Hour), dnsNames...)
+}
+
+func expiredCert(cn string) []byte {
+	return generateTestCert(cn, time.Now().Add(-48*time.Hour), time.Now().Add(-1*time.Hour))
+}
+
+func expiringSoonCert(cn string) []byte {
+	return generateTestCert(cn, time.Now().Add(-24*time.Hour), time.Now().Add(7*24*time.Hour))
+}
+
+func tlsSecret(namespace, name string, certData []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": certData,
+			"tls.key": []byte("fake-key"),
+		},
+	}
+}
+
+func ingressController(secretName string) *operatorv1.IngressController {
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-ingress-operator",
+			Name:      "default",
+		},
+	}
+	if secretName != "" {
+		ic.Spec.DefaultCertificate = &corev1.LocalObjectReference{Name: secretName}
+	}
+	return ic
+}
+
+// --- parseTLSCert tests ---
+
+func TestParseTLSCert_Valid(t *testing.T) {
+	certPEM := validCert("test.example.com", "test.example.com", "*.test.example.com")
+	info, err := parseTLSCert(certPEM)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Subject != "test.example.com" {
+		t.Errorf("expected subject 'test.example.com', got %q", info.Subject)
+	}
+	if len(info.SANs) != 2 {
+		t.Errorf("expected 2 SANs, got %d", len(info.SANs))
+	}
+	if info.isExpired() {
+		t.Error("expected cert not to be expired")
+	}
+	if info.isExpiringSoon() {
+		t.Error("expected cert not to be expiring soon")
+	}
+}
+
+func TestParseTLSCert_Expired(t *testing.T) {
+	certPEM := expiredCert("expired.example.com")
+	info, err := parseTLSCert(certPEM)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !info.isExpired() {
+		t.Error("expected cert to be expired")
+	}
+	if !strings.Contains(info.statusString(), "EXPIRED") {
+		t.Errorf("expected EXPIRED in status, got %q", info.statusString())
+	}
+}
+
+func TestParseTLSCert_ExpiringSoon(t *testing.T) {
+	certPEM := expiringSoonCert("expiring.example.com")
+	info, err := parseTLSCert(certPEM)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.isExpired() {
+		t.Error("expected cert not to be expired yet")
+	}
+	if !info.isExpiringSoon() {
+		t.Error("expected cert to be expiring soon")
+	}
+	if !strings.Contains(info.statusString(), "EXPIRING SOON") {
+		t.Errorf("expected EXPIRING SOON in status, got %q", info.statusString())
+	}
+}
+
+func TestParseTLSCert_EmptyData(t *testing.T) {
+	_, err := parseTLSCert(nil)
+	if err == nil {
+		t.Error("expected error for empty data")
+	}
+}
+
+func TestParseTLSCert_InvalidPEM(t *testing.T) {
+	_, err := parseTLSCert([]byte("not a pem block"))
+	if err == nil {
+		t.Error("expected error for invalid PEM")
+	}
+}
+
+// --- checkCertRelevantOperators tests ---
+
+// --- checkAPIServerCerts tests ---
+
+func TestCheckAPIServerCustomCerts_NoCerts(t *testing.T) {
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+	}
+	k8s := newFakeClient(apiServer)
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkAPIServerCerts(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no named serving certificates configured") {
+		t.Errorf("expected no custom certs message, got:\n%s", output)
+	}
+}
+
+func TestCheckAPIServerCustomCerts_ValidCert(t *testing.T) {
+	secret := tlsSecret("openshift-config", "api-cert", validCert("api.example.com", "api.example.com"))
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			ServingCerts: configv1.APIServerServingCerts{
+				NamedCertificates: []configv1.APIServerNamedServingCert{
+					{
+						Names:              []string{"api.example.com"},
+						ServingCertificate: configv1.SecretNameReference{Name: "api-cert"},
+					},
+				},
+			},
+		},
+	}
+	k8s := newFakeClient(apiServer, secret)
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkAPIServerCerts(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "api-cert") {
+		t.Errorf("expected cert info in output, got:\n%s", output)
+	}
+	if strings.Contains(output, "issue(s)") {
+		t.Errorf("expected no issues for valid cert, got:\n%s", output)
+	}
+}
+
+func TestCheckAPIServerCustomCerts_ExpiredCert(t *testing.T) {
+	secret := tlsSecret("openshift-config", "api-cert", expiredCert("api.example.com"))
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			ServingCerts: configv1.APIServerServingCerts{
+				NamedCertificates: []configv1.APIServerNamedServingCert{
+					{
+						Names:              []string{"api.example.com"},
+						ServingCertificate: configv1.SecretNameReference{Name: "api-cert"},
+					},
+				},
+			},
+		},
+	}
+	k8s := newFakeClient(apiServer, secret)
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkAPIServerCerts(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "EXPIRED") {
+		t.Errorf("expected EXPIRED in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "1 issue") {
+		t.Errorf("expected issue count, got:\n%s", output)
+	}
+}
+
+// --- checkIngressCert tests ---
+
+func TestCheckIngressCert_ValidCert(t *testing.T) {
+	secret := tlsSecret("openshift-ingress", "ingress-cert", validCert("*.apps.example.com", "*.apps.example.com"))
+	k8s := newFakeClient(secret, ingressController("ingress-cert"))
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkIngressCert(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "ingress-cert") {
+		t.Errorf("expected secret name in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "valid") {
+		t.Errorf("expected valid status, got:\n%s", output)
+	}
+}
+
+func TestCheckIngressCert_ExpiredCert(t *testing.T) {
+	secret := tlsSecret("openshift-ingress", "ingress-cert", expiredCert("*.apps.example.com"))
+	k8s := newFakeClient(secret, ingressController("ingress-cert"))
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkIngressCert(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "EXPIRED") {
+		t.Errorf("expected EXPIRED in output, got:\n%s", output)
+	}
+}
+
+func TestCheckIngressCert_NoCertConfigured(t *testing.T) {
+	k8s := newFakeClient(ingressController(""))
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkIngressCert(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no defaultCertificate configured") {
+		t.Errorf("expected warning about missing cert, got:\n%s", output)
+	}
+}
+
+// --- checkComponentRouteCerts tests ---
+
+func TestCheckComponentRouteCerts_NoneConfigured(t *testing.T) {
+	ingress := &configv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+	}
+	k8s := newFakeClient(ingress)
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkComponentRouteCerts(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "no custom component route certificates") {
+		t.Errorf("expected no custom certs message, got:\n%s", output)
+	}
+}
+
+func TestCheckComponentRouteCerts_ValidOAuthCert(t *testing.T) {
+	secret := tlsSecret("openshift-config", "oauth-cert", validCert("oauth.example.com", "oauth.example.com"))
+	ingress := &configv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.IngressSpec{
+			ComponentRoutes: []configv1.ComponentRouteSpec{
+				{
+					Namespace:                "openshift-authentication",
+					Name:                     "oauth-openshift",
+					Hostname:                 "oauth.example.com",
+					ServingCertKeyPairSecret: configv1.SecretNameReference{Name: "oauth-cert"},
+				},
+			},
+		},
+	}
+	k8s := newFakeClient(ingress, secret)
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkComponentRouteCerts(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "openshift-authentication/oauth-openshift") {
+		t.Errorf("expected component route info, got:\n%s", output)
+	}
+	if strings.Contains(output, "issue(s)") {
+		t.Errorf("expected no issues for valid cert, got:\n%s", output)
+	}
+}
+
+func TestCheckComponentRouteCerts_ExpiredOAuthCert(t *testing.T) {
+	secret := tlsSecret("openshift-config", "oauth-cert", expiredCert("oauth.example.com"))
+	ingress := &configv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.IngressSpec{
+			ComponentRoutes: []configv1.ComponentRouteSpec{
+				{
+					Namespace:                "openshift-authentication",
+					Name:                     "oauth-openshift",
+					Hostname:                 "oauth.example.com",
+					ServingCertKeyPairSecret: configv1.SecretNameReference{Name: "oauth-cert"},
+				},
+			},
+		},
+	}
+	k8s := newFakeClient(ingress, secret)
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkComponentRouteCerts(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "EXPIRED") {
+		t.Errorf("expected EXPIRED in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "customer-supplied") {
+		t.Errorf("expected customer-supplied rotation note, got:\n%s", output)
+	}
+}
+
+// --- checkCriticalTLSSecrets tests ---
+
+func TestCheckCriticalTLSSecrets_AllValid(t *testing.T) {
+	objs := []client.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-ingress"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config-managed"}},
+		tlsSecret("openshift-config", "cert-1", validCert("cert1.example.com")),
+		tlsSecret("openshift-ingress", "router-certs-default", validCert("*.apps.example.com")),
+		tlsSecret("openshift-config-managed", "managed-cert", validCert("managed.example.com")),
+	}
+	k8s := newFakeClient(objs...)
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkCriticalTLSSecrets(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if strings.Contains(output, "expired or expiring") {
+		t.Errorf("expected no expired certs, got:\n%s", output)
+	}
+}
+
+func TestCheckCriticalTLSSecrets_ExpiredCert(t *testing.T) {
+	objs := []client.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-ingress"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config-managed"}},
+		tlsSecret("openshift-config", "good-cert", validCert("good.example.com")),
+		tlsSecret("openshift-config", "bad-cert", expiredCert("bad.example.com")),
+	}
+	k8s := newFakeClient(objs...)
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkCriticalTLSSecrets(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if !strings.Contains(output, "1 expired or expiring") {
+		t.Errorf("expected 1 expired cert, got:\n%s", output)
+	}
+	if !strings.Contains(output, "bad-cert") {
+		t.Errorf("expected bad-cert in output, got:\n%s", output)
+	}
+}
+
+func TestCheckCriticalTLSSecrets_IgnoresNonTLSSecrets(t *testing.T) {
+	objs := []client.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-ingress"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config-managed"}},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-config", Name: "opaque-secret"},
+			Type:       corev1.SecretTypeOpaque,
+			Data:       map[string][]byte{"key": []byte("value")},
+		},
+	}
+	k8s := newFakeClient(objs...)
+	notes := newTestNotes()
+	inv := &Investigation{}
+	inv.checkCriticalTLSSecrets(context.Background(), clientImpl{k8s}, notes)
+
+	output := notes.String()
+	if strings.Contains(output, "expired or expiring") {
+		t.Errorf("expected no cert issues, got:\n%s", output)
+	}
+}
+
+// --- Run integration tests ---
+
+func TestRun_HealthyCluster(t *testing.T) {
+	objs := []client.Object{
+		&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+		&configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+		ingressController("ingress-cert"),
+		tlsSecret("openshift-ingress", "ingress-cert", validCert("*.apps.example.com")),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-ingress"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config-managed"}},
+	}
+
+	fakeK8s := newFakeClient(objs...)
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:   newTestCluster("test-cluster"),
+			K8sClient: clientImpl{fakeK8s},
+			Notes:     newTestNotes(),
+		},
+	}
+
+	inv := &Investigation{}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Actions) != 2 {
+		t.Fatalf("expected 2 actions (backplane report + PD note), got %d", len(result.Actions))
+	}
+}
+
+func TestRun_ClusterAccessError(t *testing.T) {
+	rb := &investigation.ResourceBuilderMock{
+		BuildError: investigation.RestConfigError{
+			ClusterID: "test-cluster",
+			Err:       fmt.Errorf("cannot create remediations on hive, management or service clusters"),
+		},
+	}
+
+	inv := &Investigation{}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("cluster access errors should not return an error, got: %v", err)
+	}
+	if len(result.Actions) == 0 {
+		t.Fatal("expected a note action for cluster access error")
+	}
+}
+
+func TestRun_BuildError(t *testing.T) {
+	rb := &investigation.ResourceBuilderMock{
+		BuildError: fmt.Errorf("some unexpected infrastructure error"),
+	}
+
+	inv := &Investigation{}
+	_, err := inv.Run(rb)
+	if err == nil {
+		t.Fatal("expected an error for non-cluster-access build failures")
+	}
+}
+
+func TestRun_HCPCluster(t *testing.T) {
+	objs := []client.Object{
+		&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+		&configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+		ingressController("ingress-cert"),
+		tlsSecret("openshift-ingress", "ingress-cert", validCert("*.apps.example.com")),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-ingress"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config-managed"}},
+	}
+
+	fakeK8s := newFakeClient(objs...)
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:   newTestCluster("test-hcp-cluster"),
+			K8sClient: clientImpl{fakeK8s},
+			IsHCP:     true,
+			Notes:     newTestNotes(),
+		},
+	}
+
+	inv := &Investigation{}
+	result, err := inv.Run(rb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Actions) == 0 {
+		t.Fatal("expected actions to be returned")
+	}
+}
+
+// --- getIngressCertSecretName tests ---
+
+func TestGetIngressCertSecretName_WithCert(t *testing.T) {
+	k8s := newFakeClient(ingressController("custom-ingress-cert"))
+	notes := newTestNotes()
+	inv := &Investigation{}
+	name := inv.getIngressCertSecretName(context.Background(), clientImpl{k8s}, notes)
+
+	if name != "custom-ingress-cert" {
+		t.Errorf("expected 'custom-ingress-cert', got %q", name)
+	}
+}
+
+func TestGetIngressCertSecretName_NoCert(t *testing.T) {
+	k8s := newFakeClient(ingressController(""))
+	notes := newTestNotes()
+	inv := &Investigation{}
+	name := inv.getIngressCertSecretName(context.Background(), clientImpl{k8s}, notes)
+
+	if name != "" {
+		t.Errorf("expected empty string, got %q", name)
+	}
+}

--- a/pkg/investigations/expiredcertificates/metadata.yaml
+++ b/pkg/investigations/expiredcertificates/metadata.yaml
@@ -1,4 +1,4 @@
-name: ocmagentresponsefailure
+name: expiredcertificates
 rbac:
   roles:
     - namespace: "openshift-config"
@@ -30,4 +30,4 @@ rbac:
     - apiGroups: ['config.openshift.io']
       resources: ['apiservers', 'ingresses', 'clusteroperators']
       verbs: ['get', 'list']
-customerDataAccess: false
+customerDataAccess: true

--- a/pkg/investigations/expiredcertificates/testing/README.md
+++ b/pkg/investigations/expiredcertificates/testing/README.md
@@ -1,0 +1,54 @@
+# Testing expiredcertificates Investigation
+
+## Prerequisites
+
+- A running ROSA or HCP cluster
+- `cadctl` built locally (`make build-cadctl`)
+- Environment variables set (`source test/set_stage_env.sh`)
+
+## Testing with a custom ingress certificate
+
+### Valid certificate
+
+Generate a self-signed cert, create the secret, and patch the IngressController:
+
+```bash
+APPS_DOMAIN=$(oc get ingresscontroller/default -n openshift-ingress-operator -o jsonpath='{.status.domain}')
+
+openssl req -x509 -newkey rsa:2048 -nodes -keyout /tmp/ingress-test.key -out /tmp/ingress-test.crt -days 365 -subj "/CN=*.${APPS_DOMAIN}" -addext "subjectAltName=DNS:*.${APPS_DOMAIN}"
+
+oc create secret tls custom-ingress-cert --cert=/tmp/ingress-test.crt --key=/tmp/ingress-test.key -n openshift-ingress
+
+oc patch ingresscontroller/default -n openshift-ingress-operator --type=merge -p '{"spec":{"defaultCertificate":{"name":"custom-ingress-cert"}}}'
+```
+
+### Expired certificate
+
+Generate a cert and backdate it so it's already expired, then replace the secret.
+Requires OpenSSL 3.0+ for `-not_before`/`-not_after`. The re-sign step strips SANs
+from the cert, but the investigation only uses SANs for display — expiry detection
+still works correctly.
+
+```bash
+APPS_DOMAIN=$(oc get ingresscontroller/default -n openshift-ingress-operator -o jsonpath='{.status.domain}')
+
+openssl req -x509 -newkey rsa:2048 -nodes -keyout /tmp/ingress-expired.key -out /tmp/ingress-expired.crt -days 1 -subj "/CN=*.${APPS_DOMAIN}" -addext "subjectAltName=DNS:*.${APPS_DOMAIN}" -set_serial 1
+
+openssl x509 -in /tmp/ingress-expired.crt -signkey /tmp/ingress-expired.key -not_before 20240101000000Z -not_after 20240102000000Z -out /tmp/ingress-expired.crt
+
+oc delete secret custom-ingress-cert -n openshift-ingress
+oc create secret tls custom-ingress-cert --cert=/tmp/ingress-expired.crt --key=/tmp/ingress-expired.key -n openshift-ingress
+```
+
+### Cleanup
+
+```bash
+oc patch ingresscontroller/default -n openshift-ingress-operator --type=merge -p '{"spec":{"defaultCertificate":null}}'
+oc delete secret custom-ingress-cert -n openshift-ingress
+```
+
+## Running the investigation
+
+```bash
+./bin/cadctl investigate --cluster-id=<CLUSTER_ID> --investigation=expiredcertificates
+```

--- a/pkg/investigations/insightsoperatordown/metadata.yaml
+++ b/pkg/investigations/insightsoperatordown/metadata.yaml
@@ -1,6 +1,31 @@
 name: insightsoperatordown
 rbac:
-  roles: []
+  roles:
+    - namespace: "openshift-config"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-config-managed"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-service-ca"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
   clusterRoleRules:
     - verbs:
         - "get"
@@ -9,4 +34,6 @@ rbac:
         - "config.openshift.io"
       resources:
         - clusteroperators
+        - apiservers
+        - ingresses
 customerDataAccess: false

--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/metadata.yaml
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/metadata.yaml
@@ -11,6 +11,31 @@ rbac:
           resources:
             - "machines"
             - "machinehealthchecks"
+    - namespace: "openshift-config"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-config-managed"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-service-ca"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
   clusterRoleRules:
     - verbs:
         - "get"
@@ -19,4 +44,7 @@ rbac:
         - ""
       resources:
         - "nodes"
+    - apiGroups: ['config.openshift.io']
+      resources: ['apiservers', 'ingresses', 'clusteroperators']
+      verbs: ['get', 'list']
 customerDataAccess: false

--- a/pkg/investigations/pruningcronjoberror/metadata.yaml
+++ b/pkg/investigations/pruningcronjoberror/metadata.yaml
@@ -1,6 +1,31 @@
 name: pruningcronjoberror
 rbac:
-  roles: []
+  roles:
+    - namespace: "openshift-config"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-config-managed"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-service-ca"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
   clusterRoleRules:
     - verbs:
         - "get"
@@ -9,6 +34,8 @@ rbac:
         - "config.openshift.io"
       resources:
         - clusteroperators
+        - apiservers
+        - ingresses
     - apiGroups:
         - ""
       resources:

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/cpd"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/describenodes"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/etcddatabasequotalowspace"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/expiredcertificates"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/insightsoperatordown"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre"
@@ -36,6 +37,7 @@ var availableInvestigations = []investigation.Investigation{
 	&mustgather.Investigation{},
 	&describenodes.Investigation{},
 	&clusterhealthcheck.Investigation{},
+	&expiredcertificates.Investigation{},
 }
 
 // GetInvestigation returns the first Investigation that applies to the given alert title.

--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/metadata.yaml
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/metadata.yaml
@@ -3,12 +3,31 @@ rbac:
   roles:
     - namespace: "openshift-config"
       rules:
-        - verbs:
-            - "get"
-          apiGroups:
-            - ""
-          resources:
-            - "secrets"
-          resourceNames:
-            - "pull-secret"
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-config-managed"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-service-ca"
+      rules:
+        - apiGroups: ['']
+          resources: ['secrets']
+          verbs: ['get', 'list']
+    - namespace: "openshift-ingress-operator"
+      rules:
+        - apiGroups: ['operator.openshift.io']
+          resources: ['ingresscontrollers']
+          verbs: ['get']
+  clusterRoleRules:
+    - apiGroups: ['config.openshift.io']
+      resources: ['apiservers', 'ingresses', 'clusteroperators']
+      verbs: ['get', 'list']
 customerDataAccess: false

--- a/pkg/k8s/scheme.go
+++ b/pkg/k8s/scheme.go
@@ -6,6 +6,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	certsv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +44,10 @@ func initScheme() (*runtime.Scheme, error) {
 
 	if err := policyv1.AddToScheme(scheme); err != nil {
 		return nil, fmt.Errorf("unable to add policy/v1 scheme: %w", err)
+	}
+
+	if err := operatorv1.Install(scheme); err != nil {
+		return nil, fmt.Errorf("unable to add operator.openshift.io/v1 scheme: %w", err)
 	}
 
 	return scheme, nil

--- a/pkg/ocm/mock/ocmmock.go
+++ b/pkg/ocm/mock/ocmmock.go
@@ -12,7 +12,7 @@ package ocmmock
 import (
 	reflect "reflect"
 
-	sdk "github.com/openshift-online/ocm-sdk-go"
+	ocm_sdk_go "github.com/openshift-online/ocm-sdk-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	v10 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	v11 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
@@ -119,10 +119,10 @@ func (mr *MockClientMockRecorder) GetClusterMachinePools(internalClusterID any) 
 }
 
 // GetConnection mocks base method.
-func (m *MockClient) GetConnection() *sdk.Connection {
+func (m *MockClient) GetConnection() *ocm_sdk_go.Connection {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnection")
-	ret0, _ := ret[0].(*sdk.Connection)
+	ret0, _ := ret[0].(*ocm_sdk_go.Connection)
 	return ret0
 }
 

--- a/test/generate_incident.sh
+++ b/test/generate_incident.sh
@@ -15,6 +15,7 @@ declare -A alert_mapping=(
     ["etcdDatabaseQuotaLowSpace"]="etcdDatabaseQuotaLowSpace CRITICAL (1)"
     ["console-errorbudgetburn"]="console-errorbudgetburn Critical (1)"
     ["OCMAgentResponseFailureServiceLogsSRE"]="OCMAgentResponseFailureServiceLogsSRE CRITICAL (1)"
+    ["ExpiredCertificates"]="expiredcertificates"
 )
 
 # Function to print help message


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

Adds a new CAD investigation for expired or expiring TLS certificates in the cluster. When triggered, it checks:                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                  
  - Custom API server serving certificates (`APIServer/cluster` namedCertificates)                                                                                                                                                                                                                                  
  - Custom ingress certificates (`IngressController/default` defaultCertificate)                                                                                                                                                                                                                                  
  - Custom component route certificates (OAuth, console via `Ingress/cluster` componentRoutes)                                                                                                                                                                                                                      
  - TLS secrets in critical namespaces (openshift-config, openshift-ingress, openshift-config-managed, openshift-service-ca)                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
 Certificates that are expired or expiring within 7 days are flagged. The investigation runs both as a standalone investigation and as a pre-check before other investigations.                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
 On HCP clusters, API server cert checks are skipped since backplane restricts secret access on management clusters.                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                  
 Estimated time saved per alert: 20 minutes.

Jira: [ROSAENG-5561](https://redhat.atlassian.net/browse/ROSAENG-5561) 

### Special notes for your reviewer

The investigation is registered in the controller as a pre-check (similar to CCAM) and also in the investigation registry for standalone triggering. The controller guard `inv.Name() != certCheck.Name()` prevents double-running.

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [x] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR


[ROSAENG-5561]: https://redhat.atlassian.net/browse/ROSAENG-5561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expired certificate detection investigation to identify TLS certificates that have expired or are expiring within 7 days across your cluster, including API server certificates, ingress certificates, component route certificates, and critical namespace TLS secrets.

* **Documentation**
  * Added investigation documentation and end-to-end testing guidance.

* **Tests**
  * Added comprehensive test suite for certificate parsing and detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->