### PR TITLE
feat: persist AI investigation output to cluster report

### DIFF
--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -193,10 +193,22 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	logging.Infof("AI Output:\n%s", aiResponse.String())
 
 	// Add simple note about AI automation completion
-	notes.AppendAutomation("AI automation completed. Check recent cluster reports for report Summary %s: 'osdctl cluster reports list --cluster-id %s'", incidentID, clusterID)
+	notes.AppendAutomation("AI automation completed. Check recent cluster reports for AI investigation details: 'osdctl cluster reports list --cluster-id %s'", clusterID)
+
+	// Create backplane report action with the AI investigation results
+	backplaneReportAction := &executor.BackplaneReportAction{
+		ClusterID: r.Cluster.ExternalID(),
+		Summary:   fmt.Sprintf("CAD Investigation: AI-Assisted Analysis for %s", alertName),
+		Data:      aiResponse.String(),
+	}
 
 	// Return actions for executor to handle
-	result.Actions = executor.NoteAndReportFrom(notes, clusterID, c.Name())
+	// The report action will append to notes when executed, then note sends them to PagerDuty
+	result.Actions = append(
+		executor.NoteAndReportFrom(notes, clusterID, c.Name()),
+		backplaneReportAction, // write a second report here, as this contains the formatted AI results
+		executor.Escalate("AI investigation completed - see cluster report for details"),
+	)
 	return result, nil
 }
 


### PR DESCRIPTION
## Summary
Add BackplaneReportAction to store CORA investigation results in a separate cluster report, following the same pattern as the `etcddatabasequotalowspace` investigation.

## Changes
- Create dedicated cluster report containing full AI conversation output
- Include session ID, runtime details, and complete CORA analysis
- Update automation note to reference cluster reports for details
- Update escalation message to direct users to cluster report

## Why
Previously, AI investigation output was only logged and not persisted to cluster reports. This meant SREs had no way to access CORA's investigation results after the fact.

Now CORA investigation results are stored in backplane and accessible via `osdctl cluster reports list` and `osdctl cluster reports get`, similar to other investigations like etcd analysis.

## Testing
- [ ] Manual test with test cluster to verify report creation
- [ ] Verify report contains complete CORA output
- [ ] Verify PagerDuty note includes osdctl command to access report

## Note
Reopening #828 on a fresh branch now that Konflux/Quay is back online to allow CI checks to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cluster reference information in investigation completion notifications

* **Improvements**
  * Investigation completion reports enhanced with comprehensive automated cluster analysis, formatted summaries, and complete cluster information
  * Investigation escalation messaging improved to clearly communicate investigation completion status with cluster report details
  * Notification workflow streamlined to provide easier access to cluster information for investigation review and follow-up activities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->