### PR TITLE
SREP-4521: revert metadata changes and use own remediation for precheck

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -29,6 +29,8 @@ import (
 
 const pagerdutyTitlePrefix = "[CAD Investigated]"
 
+var certPreCheckSkip = []string{"mustgather"}
+
 type PagerDutyConfig struct {
 	PayloadPath string
 }
@@ -355,25 +357,9 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 		}
 	}
 
-	// Skip cert pre-check for investigations that use management cluster access,
-	// because backplane validates all RBAC (including hosted-cluster rules) against
-	// infrastructure cluster restrictions, rejecting secrets access.
-	certPreCheckSkip := []string{"mustgather", "restartcontrolplane", "etcddatabasequotalowspace"}
 	certCheck := &expiredcertificates.Investigation{}
-	if inv.Name() != certCheck.Name() && !slices.Contains(certPreCheckSkip, inv.Name()) {
-		certResult, certErr := certCheck.Run(builder)
-		if certErr != nil {
-			logging.Warnf("Expired certificates pre-check failed: %v", certErr)
-		}
-		if len(certResult.Actions) > 0 {
-			if certErr = c.executeActions(builder, &certResult, certCheck.Name()); certErr != nil {
-				logging.Warnf("Failed to execute expired certificates actions: %v", certErr)
-			}
-		}
-		// Reset notes so cert check findings don't leak into the main investigation's NoteWriter
-		if r, _ := builder.Build(); r != nil {
-			r.Notes = nil
-		}
+	if pdClient != nil && inv.Name() != certCheck.Name() && !slices.Contains(certPreCheckSkip, inv.Name()) {
+		c.runCertPreCheck(clusterId, pdClient, certCheck)
 	}
 
 	logging.Infof("Starting investigation for %s", inv.Name())
@@ -406,6 +392,30 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 		c.recordManualCompletion(inv.Name(), pdClient, "no_findings")
 	}
 	return nil
+}
+
+func (c *investigationRunner) runCertPreCheck(clusterId string, pdClient *pagerduty.SdkClient, certCheck *expiredcertificates.Investigation) {
+	certBuilder, err := investigation.NewResourceBuilder(c.ocmClient, c.bpClient, clusterId, certCheck.Name(), c.dependencies.BackplaneURL, nil)
+	if err != nil {
+		logging.Warnf("Expired certificates pre-check: failed to create resource builder: %v", err)
+		return
+	}
+	certBuilder.WithPdClient(pdClient)
+
+	certResult, certErr := certCheck.Run(certBuilder)
+	if certErr != nil {
+		logging.Warnf("Expired certificates pre-check failed: %v", certErr)
+	}
+	if len(certResult.Actions) > 0 {
+		if certErr = c.executeActions(certBuilder, &certResult, certCheck.Name()); certErr != nil {
+			logging.Warnf("Failed to execute expired certificates actions: %v", certErr)
+		}
+	}
+	if certResources, _ := certBuilder.Build(); certResources != nil && certResources.RestConfig != nil {
+		if cleanErr := certResources.RestConfig.Clean(); cleanErr != nil {
+			logging.Warnf("Failed to clean expired certificates rest config: %v", cleanErr)
+		}
+	}
 }
 
 // runInvestigationWithRetry executes an investigation with retry logic for transient errors.

--- a/pkg/investigations/aiassisted/metadata.yaml
+++ b/pkg/investigations/aiassisted/metadata.yaml
@@ -1,34 +1,6 @@
 name: aiassisted
 rbac:
-  roles:
-    - namespace: "openshift-config"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
-  clusterRoleRules:
-    - apiGroups: ['config.openshift.io']
-      resources: ['apiservers', 'ingresses', 'clusteroperators']
-      verbs: ['get', 'list']
+  roles: []
+  clusterRoleRules: []
 customerDataAccess: false
 

--- a/pkg/investigations/cannotretrieveupdatessre/metadata.yaml
+++ b/pkg/investigations/cannotretrieveupdatessre/metadata.yaml
@@ -1,31 +1,6 @@
 name: cannotretrieveupdatessre
 rbac:
-  roles:
-    - namespace: "openshift-config"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
+  roles: []
   clusterRoleRules:
     - verbs:
         - "get"
@@ -34,7 +9,4 @@ rbac:
         - "config.openshift.io"
       resources:
         - clusterversions
-        - apiservers
-        - ingresses
-        - clusteroperators
 customerDataAccess: false

--- a/pkg/investigations/clusterhealthcheck/metadata.yaml
+++ b/pkg/investigations/clusterhealthcheck/metadata.yaml
@@ -17,31 +17,6 @@ rbac:
         - apiGroups: ['']
           resources: ['pods/exec']
           verbs: ['create']
-    - namespace: "openshift-config"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
   clusterRoleRules:
     - apiGroups: ['']
       resources: ['namespaces']
@@ -53,7 +28,7 @@ rbac:
       resources: ['pods', 'pods/log']
       verbs: ['get', 'list', 'watch']
     - apiGroups: ['config.openshift.io']
-      resources: ['clusteroperators', 'clusterversions', 'apiservers', 'ingresses']
+      resources: ['clusteroperators', 'clusterversions']
       verbs: ['get', 'list']
     - apiGroups: ['machineconfiguration.openshift.io']
       resources: ['machineconfigpools']

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/metadata.yaml
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/metadata.yaml
@@ -1,31 +1,6 @@
 name: clustermonitoringerrorbudgetburn
 rbac:
-  roles:
-    - namespace: "openshift-config"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
+  roles: []
   clusterRoleRules:
     - verbs:
         - "get"
@@ -34,6 +9,4 @@ rbac:
         - "config.openshift.io"
       resources:
         - clusteroperators
-        - apiservers
-        - ingresses
 customerDataAccess: false

--- a/pkg/investigations/describenodes/metadata.yaml
+++ b/pkg/investigations/describenodes/metadata.yaml
@@ -6,31 +6,6 @@ rbac:
         - apiGroups: ['coordination.k8s.io']
           resources: ['leases']
           verbs: ['get', 'list']
-    - namespace: "openshift-config"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
   clusterRoleRules:
     - apiGroups: ['']
       resources: ['nodes']
@@ -40,8 +15,5 @@ rbac:
       verbs: ['get', 'list']
     - apiGroups: ['']
       resources: ['events']
-      verbs: ['get', 'list']
-    - apiGroups: ['config.openshift.io']
-      resources: ['apiservers', 'ingresses', 'clusteroperators']
       verbs: ['get', 'list']
 customerDataAccess: true

--- a/pkg/investigations/insightsoperatordown/metadata.yaml
+++ b/pkg/investigations/insightsoperatordown/metadata.yaml
@@ -1,31 +1,6 @@
 name: insightsoperatordown
 rbac:
-  roles:
-    - namespace: "openshift-config"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
+  roles: []
   clusterRoleRules:
     - verbs:
         - "get"
@@ -34,6 +9,4 @@ rbac:
         - "config.openshift.io"
       resources:
         - clusteroperators
-        - apiservers
-        - ingresses
 customerDataAccess: false

--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/metadata.yaml
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/metadata.yaml
@@ -11,31 +11,6 @@ rbac:
           resources:
             - "machines"
             - "machinehealthchecks"
-    - namespace: "openshift-config"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
   clusterRoleRules:
     - verbs:
         - "get"
@@ -44,7 +19,4 @@ rbac:
         - ""
       resources:
         - "nodes"
-    - apiGroups: ['config.openshift.io']
-      resources: ['apiservers', 'ingresses', 'clusteroperators']
-      verbs: ['get', 'list']
 customerDataAccess: false

--- a/pkg/investigations/ocmagentresponsefailure/metadata.yaml
+++ b/pkg/investigations/ocmagentresponsefailure/metadata.yaml
@@ -3,31 +3,13 @@ rbac:
   roles:
     - namespace: "openshift-config"
       rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
-  clusterRoleRules:
-    - apiGroups: ['config.openshift.io']
-      resources: ['apiservers', 'ingresses', 'clusteroperators']
-      verbs: ['get', 'list']
+        - verbs:
+            - "get"
+          apiGroups:
+            - ""
+          resources:
+            - "secrets"
+          resourceNames:
+            - "pull-secret"
+  clusterRoleRules: []
 customerDataAccess: false

--- a/pkg/investigations/pruningcronjoberror/metadata.yaml
+++ b/pkg/investigations/pruningcronjoberror/metadata.yaml
@@ -1,31 +1,6 @@
 name: pruningcronjoberror
 rbac:
-  roles:
-    - namespace: "openshift-config"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
+  roles: []
   clusterRoleRules:
     - verbs:
         - "get"
@@ -34,8 +9,6 @@ rbac:
         - "config.openshift.io"
       resources:
         - clusteroperators
-        - apiservers
-        - ingresses
     - apiGroups:
         - ""
       resources:

--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/metadata.yaml
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/metadata.yaml
@@ -3,31 +3,12 @@ rbac:
   roles:
     - namespace: "openshift-config"
       rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-config-managed"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-service-ca"
-      rules:
-        - apiGroups: ['']
-          resources: ['secrets']
-          verbs: ['get', 'list']
-    - namespace: "openshift-ingress-operator"
-      rules:
-        - apiGroups: ['operator.openshift.io']
-          resources: ['ingresscontrollers']
-          verbs: ['get']
-  clusterRoleRules:
-    - apiGroups: ['config.openshift.io']
-      resources: ['apiservers', 'ingresses', 'clusteroperators']
-      verbs: ['get', 'list']
+        - verbs:
+            - "get"
+          apiGroups:
+            - ""
+          resources:
+            - "secrets"
+          resourceNames:
+            - "pull-secret"
 customerDataAccess: false


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Some investigations don't have a metadata.yml file, and with the new expired certs investigation, they all create a remediation, which doesn't work without the right RBAC permissions.

This commit reverts the metadata.yaml bloat and gives the pre-check its own ResourceBuilder with its own backplane remediation. It also gates the pre-check on pdClient != nil so it only runs for PagerDuty-triggered alerts, and reduces the skip list to just mustgather.

### Special notes for your reviewer

 - restartcontrolplane and etcddatabasequotalowspace no longer need to be skipped since the pre-check uses its own remediation with the expiredcertificates metadata                                                                                                                                               
  - Backplane validates all RBAC sections (not just managementClusterRbac) against infrastructure cluster restrictions. This is arguably a backplane bug (tracked separately)

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [x] Validated the changes in a cluster: test run: https://redhat.pagerduty.com/incidents/Q30BU7Y0L0RT6J
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate pre-checks now run only when appropriate (tied to PagerDuty presence and skip rules), reducing unnecessary checks and improving investigation flow.

* **Security**
  * RBAC tightened across multiple investigations to follow least-privilege practices — reduced broad secret access, narrowed cluster resource permissions, and restricted access to specific named secrets where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->