### PR TITLE
Fix duplicate cluster reports in AI-assisted investigation

### DIFF
--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -203,12 +203,11 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 
 	// Return actions for executor to handle
-	// The report action will append to notes when executed, then note sends them to PagerDuty
-	result.Actions = append(
-		executor.NoteAndReportFrom(notes, clusterID, c.Name()),
-		backplaneReportAction, // write a second report here, as this contains the formatted AI results
+	result.Actions = []executor.Action{
+		executor.NoteFrom(notes), // Send automation message to PagerDuty
+		backplaneReportAction,    // Create cluster report with AI investigation results
 		executor.Escalate("AI investigation completed - see cluster report for details"),
-	)
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
Replace NoteAndReportFrom with NoteFrom to prevent creating an empty duplicate report. NoteAndReportFrom was creating both a report and a PagerDuty note, resulting in two reports: one empty with just the automation message, and one with the actual AI analysis. Now only the AI results report is created.

### What type of PR is this?

(feature/bug/documentation/other)

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal action handling for AI investigations to improve how investigation notes and escalations are processed and reported to cluster management systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->