### PR TITLE
Dashboard fixes

### DIFF
--- a/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
+++ b/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
@@ -740,7 +740,7 @@ data:
                 "uid": "${cad_ds}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(cad_investigate_must_gather_performed_total{alert_type=\"mustgather\"}[$__range])) / sum(increase(cad_investigate_alerts_total{alert_type=\"mustgather\"}[$__range])) * 100",
+              "expr": "sum(increase(cad_investigate_must_gather_performed_total{alert_type=\"mustgather\"}[$__range])) / (sum(increase(cad_investigate_alerts_total{alert_type=\"mustgather\"}[$__range])) - (sum(increase(cad_investigate_alerts_filtered_total{alert_type=\"mustgather\"}[$__range])) OR on() vector(0))) * 100",
               "hide": false,
               "legendFormat": "__auto",
               "range": true,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -328,6 +328,7 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 	// Evaluate the investigation filter if one is configured for this investigation.
 	// Only populate OCM fields (org ID, owner) when a filter actually needs them.
 	if filtered := c.evaluateFilter(inv.Name(), filterCtx, builder, clusterId, pdClient); filtered {
+		metrics.Inc(metrics.AlertsFiltered, inv.Name())
 		c.recordManualCompletion(inv.Name(), pdClient, "filtered")
 		return nil
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,6 +16,7 @@ func Push() {
 	if pushgateway := os.Getenv("CAD_PROMETHEUS_PUSHGATEWAY"); pushgateway != "" {
 		promPusher = push.New(pushgateway, "cad").Format(expfmt.NewFormat(expfmt.TypeTextPlain))
 		promPusher.Collector(Alerts)
+		promPusher.Collector(AlertsFiltered)
 		promPusher.Collector(LimitedSupportSet)
 		promPusher.Collector(ServicelogPrepared)
 		promPusher.Collector(ServicelogSent)
@@ -80,6 +81,12 @@ var (
 			Namespace: namespace, Subsystem: subsystemInvestigate,
 			Name: "servicelog_sent_total",
 			Help: "counts investigations resulting in a sent servicelog",
+		}, []string{alertTypeLabel})
+	AlertsFiltered = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace, Subsystem: subsystemInvestigate,
+			Name: "alerts_filtered_total",
+			Help: "counts alerts filtered out by investigation filter configuration",
 		}, []string{alertTypeLabel})
 	MustGatherPerformed = prometheus.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Adds a new cad_investigate_alerts_filtered_total Prometheus metric that counts alerts filtered out by investigation filter configuration. The Must-Gather Success Rate dashboard panel is updated to subtract filtered alerts from its denominator.

When a filter is configured (e.g. to limit investigations to specific orgs), filtered-out runs still increment alerts_total but never increment must_gather_performed_total. This deflates the success rate, a filter dropping 50% of runs would show ~50% success even if every actual must-gather succeeded.   
  Subtracting filtered alerts from the denominator ensures the panel reflects the true success rate of investigations that were allowed to run. 

###

Fixes https://redhat.atlassian.net/browse/ROSAENG-59376

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new metric to track filtered alerts by type, providing visibility into alerts excluded from investigation processing.

* **Improvements**
  * Updated success rate calculations in monitoring dashboards to exclude filtered alerts from the denominator, providing more accurate success metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->