### PR TITLE
Remove srep-infra-cicd from OWNERS files [SDCICD-1761]

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,0 +1,25 @@
+reviewers:
+- AlexSmithGH
+- Makdaam
+- Nikokolas3270
+- rafael-azevedo
+- RaphaelBut
+- typeid
+- tnierman
+- zmird-r
+- joshbranham
+- MateSaary
+- srep-functional-team-orange
+approvers:
+- AlexSmithGH
+- Makdaam
+- Nikokolas3270
+- rafael-azevedo
+- RaphaelBut
+- typeid
+- tnierman
+- zmird-r
+- joshbranham
+- MateSaary
+- srep-functional-team-orange
+- srep-team-leads


### PR DESCRIPTION
The srep-infra-cicd migration is now complete. This PR removes the team as owners from this repository.

Related: Similar cleanup across OpenShift managed services repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration to establish reviewers and approvers for the code review and approval workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->