### PR TITLE
 Add IRSA annotation support to cad-sa

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -24,6 +24,8 @@ parameters:
 - name: TEKTON_RESOURCE_PRUNER_IMAGE
   value: quay.io/openshift-pipeline/openshift-pipelines-pipelines-cli-tkn-rhel8
 - name: TEKTON_RESOURCE_PRUNER_SHA
+- name: CAD_SA_ROLE_ARN
+  value: ""
 objects:
 - apiVersion: apps/v1
   kind: Deployment
@@ -60,6 +62,8 @@ objects:
             value: ${CAD_OCTOSQL_IMAGE}
           - name: CAD_INVESTIGATION_CONFIG_PATH
             value: /config/cad-config.yaml
+          - name: CAD_SA_ROLE_ARN
+            value: ${CAD_SA_ROLE_ARN}
           envFrom:
           - secretRef:
               name: cad-pd-token
@@ -299,6 +303,8 @@ objects:
   kind: ServiceAccount
   metadata:
     name: cad-sa
+    annotations:
+      eks.amazonaws.com/role-arn: ${CAD_SA_ROLE_ARN}
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:


### PR DESCRIPTION
Add CAD_SA_ROLE_ARN parameter to allow the cad-sa ServiceAccount to be annotated with an IAM role ARN for IRSA.

When deployed on ROSA STS clusters with this parameter set, pods using the cad-sa ServiceAccount will automatically receive AWS credentials via the cluster's OIDC provider, enabling passwordless AWS API access.

- Add CAD_SA_ROLE_ARN parameter with empty default
- Annotate cad-sa ServiceAccount with eks.amazonaws.com/role-arn
- Expose parameter as environment variable for runtime access

### What type of PR is this?

(feature/bug/documentation/other)

### What this PR does / Why we need it?

### Special notes for your reviewer
Depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/192140

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift template with AWS EKS IAM role parameter and service account annotation configuration for role association support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->