### PR TITLE
feat: support additional trust bundles in network verifier

### DIFF
--- a/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
+++ b/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
@@ -25,7 +25,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	notes := notewriter.New("CannotRetrieveUpdatesSRE", logging.RawLogger)
 
 	// Run network verifier
-	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
+	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 	if err != nil {
 		notes.AppendWarning("NetworkVerifier failed to run:\n\t %s", err.Error())
 	} else {

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -100,7 +100,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 
 	// 3. Check if the customer blocked egresses
-	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
+	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 	if err != nil {
 		logging.Error("Network verifier ran into an error: %s", err.Error())
 		r.Notes.AppendWarning("NetworkVerifier failed to run:\n %s", err.Error())

--- a/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
+++ b/pkg/investigations/consoleerrorbudgetburn/consoleerrorbudgetburn.go
@@ -49,7 +49,7 @@ type egressVerifier interface {
 type defaultEgressVerifier struct{}
 
 func (d *defaultEgressVerifier) run(r *investigation.Resources) (networkverifier.VerifierResult, string, error) {
-	return networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
+	return networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 }
 
 type Investigation struct {

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -119,7 +119,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 	notes.AppendSuccess("BYOVPC has valid routing")
 
-	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
+	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 	if err != nil {
 		logging.Error("Network verifier ran into an error: %s", err.Error())
 		notes.AppendWarning("NetworkVerifier failed to run:\n\t %s", err.Error())

--- a/pkg/investigations/insightsoperatordown/insightsoperatordown.go
+++ b/pkg/investigations/insightsoperatordown/insightsoperatordown.go
@@ -89,7 +89,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		notes.AppendSuccess("Ruled out OCPBUGS-22226")
 	}
 
-	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
+	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 	if err != nil {
 		logging.Error("Network verifier ran into an error: %s", err.Error())
 		notes.AppendWarning("NetworkVerifier failed to run:\n\t %s", err.Error())

--- a/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
+++ b/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
@@ -173,7 +173,7 @@ func checkUserBanStatus(r *investigation.Resources) (checkResult, error) {
 // It returns a set of actions, and a boolean indicating whether the investigation should halt
 func validateEgress(r *investigation.Resources) (checkResult, error) {
 	actions := []types.Action{}
-	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient)
+	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 	if err != nil {
 		logging.Errorf("Network verifier ran into an error: %s", err.Error())
 		r.Notes.AppendWarning("NetworkVerifier failed to run:\n %s", err.Error())

--- a/pkg/networkverifier/networkverifier.go
+++ b/pkg/networkverifier/networkverifier.go
@@ -10,6 +10,7 @@ import (
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 
 	ocmlog "github.com/openshift-online/ocm-sdk-go/logging"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -29,8 +30,10 @@ const (
 	Success   VerifierResult = 2
 )
 
-// InitializeValidateEgressInput computes the input to pass to the network verifier tool
-func InitializeValidateEgressInput(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsClient aws.Client) (*verifier.ValidateEgressInput, error) {
+// InitializeValidateEgressInput computes the input to pass to the network verifier tool.
+// If the cluster has an additional trust bundle configured, additionalTrustBundle should
+// contain the PEM-encoded CA bundle retrieved from Hive.
+func InitializeValidateEgressInput(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsClient aws.Client, additionalTrustBundle string) (*verifier.ValidateEgressInput, error) {
 	if clusterDeployment == nil {
 		return nil, fmt.Errorf("nil clusterDeployment")
 	}
@@ -74,9 +77,11 @@ func InitializeValidateEgressInput(cluster *v1.Cluster, clusterDeployment *hivev
 		proxy.HttpsProxy = cluster.Proxy().HTTPSProxy()
 	}
 
-	// The actual trust bundle is redacted in OCM - we would have to get it from hive once CAD has backplane access
 	if cluster.AdditionalTrustBundle() != "" {
-		return nil, errors.New("cluster has an additional trust bundle configured - this is currently not supported by CAD's network verifier")
+		if additionalTrustBundle == "" {
+			return nil, errors.New("cluster has an additional trust bundle configured but it could not be retrieved - skipping network verifier to avoid false negatives")
+		}
+		proxy.Cacert = additionalTrustBundle
 	}
 
 	return &verifier.ValidateEgressInput{
@@ -93,9 +98,16 @@ func InitializeValidateEgressInput(cluster *v1.Cluster, clusterDeployment *hivev
 	}, nil
 }
 
-// Run runs the network verifier tool to check for network misconfigurations
-func Run(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsClient aws.Client) (result VerifierResult, failures string, name error) {
-	validateEgressInput, err := InitializeValidateEgressInput(cluster, clusterDeployment, awsClient)
+// Run runs the network verifier tool to check for network misconfigurations.
+// If the cluster has an additional trust bundle configured, it is automatically
+// retrieved via the OCM cluster resources API.
+func Run(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsClient aws.Client, ocmClient ocm.Client) (result VerifierResult, failures string, name error) {
+	trustBundle, err := GetAdditionalTrustBundle(ocmClient, cluster)
+	if err != nil {
+		return Undefined, "", fmt.Errorf("failed to retrieve additional trust bundle: %w", err)
+	}
+
+	validateEgressInput, err := InitializeValidateEgressInput(cluster, clusterDeployment, awsClient, trustBundle)
 	if err != nil {
 		return Undefined, "", fmt.Errorf("failed to initialize validateEgressInput: %w", err)
 	}

--- a/pkg/networkverifier/networkverifier_test.go
+++ b/pkg/networkverifier/networkverifier_test.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	awsmock "github.com/openshift/configuration-anomaly-detection/pkg/aws/mock"
 	"github.com/openshift/configuration-anomaly-detection/pkg/networkverifier"
+	ocmmock "github.com/openshift/configuration-anomaly-detection/pkg/ocm/mock"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"go.uber.org/mock/gomock"
 )
@@ -20,11 +21,13 @@ var _ = Describe("RunVerifier", func() {
 			clusterBuilder    *v1.ClusterBuilder
 			clusterDeployment *hivev1.ClusterDeployment
 			awsCli            *awsmock.MockClient
+			ocmCli            *ocmmock.MockClient
 		)
 		BeforeEach(func() {
 			mockCtrl = gomock.NewController(GinkgoT())
 
 			awsCli = awsmock.NewMockClient(mockCtrl)
+			ocmCli = ocmmock.NewMockClient(mockCtrl)
 
 			region := v1.NewCloudRegion().ID("us-east-1")
 
@@ -55,7 +58,7 @@ var _ = Describe("RunVerifier", func() {
 				awsCli.EXPECT().GetSecurityGroupID(gomock.Eq(clusterDeployment.Spec.ClusterMetadata.InfraID)).Return("", expectedError)
 
 				// Act
-				result, failures, gotErr := networkverifier.Run(cluster, clusterDeployment, awsCli)
+				result, failures, gotErr := networkverifier.Run(cluster, clusterDeployment, awsCli, ocmCli)
 				fmt.Printf("result %v, failures %v", result, failures)
 
 				// Assert
@@ -79,12 +82,43 @@ var _ = Describe("RunVerifier", func() {
 				awsCli.EXPECT().GetSubnetID(gomock.Eq(clusterDeployment.Spec.ClusterMetadata.InfraID)).Return([]string{"string1", "string2"}, nil)
 
 				// Act
-				input, gotErr := networkverifier.InitializeValidateEgressInput(cluster, clusterDeployment, awsCli)
+				input, gotErr := networkverifier.InitializeValidateEgressInput(cluster, clusterDeployment, awsCli, "")
 				fmt.Printf("input %v", input)
 
 				// Assert
 				Expect(gotErr).ToNot(HaveOccurred())
 				Expect(input.AWS.KmsKeyID).To(BeIdenticalTo(kmsKey))
+			})
+
+			It("Should set proxy CaCert when additional trust bundle is provided", func() {
+				trustBundle := "-----BEGIN CERTIFICATE-----\ntest-ca-bundle\n-----END CERTIFICATE-----"
+				clusterBuilder.AdditionalTrustBundle("REDACTED")
+
+				cluster, err := clusterBuilder.Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				awsCli.EXPECT().GetSecurityGroupID(gomock.Eq(clusterDeployment.Spec.ClusterMetadata.InfraID)).Return("sg-123", nil)
+				awsCli.EXPECT().GetSubnetID(gomock.Eq(clusterDeployment.Spec.ClusterMetadata.InfraID)).Return([]string{"subnet-1"}, nil)
+
+				input, gotErr := networkverifier.InitializeValidateEgressInput(cluster, clusterDeployment, awsCli, trustBundle)
+
+				Expect(gotErr).ToNot(HaveOccurred())
+				Expect(input.Proxy.Cacert).To(Equal(trustBundle))
+			})
+
+			It("Should error when cluster has trust bundle but none is provided", func() {
+				clusterBuilder.AdditionalTrustBundle("REDACTED")
+
+				cluster, err := clusterBuilder.Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				awsCli.EXPECT().GetSecurityGroupID(gomock.Eq(clusterDeployment.Spec.ClusterMetadata.InfraID)).Return("sg-123", nil)
+				awsCli.EXPECT().GetSubnetID(gomock.Eq(clusterDeployment.Spec.ClusterMetadata.InfraID)).Return([]string{"subnet-1"}, nil)
+
+				_, gotErr := networkverifier.InitializeValidateEgressInput(cluster, clusterDeployment, awsCli, "")
+
+				Expect(gotErr).To(HaveOccurred())
+				Expect(gotErr.Error()).To(ContainSubstring("could not be retrieved"))
 			})
 		})
 	})

--- a/pkg/networkverifier/trustbundle.go
+++ b/pkg/networkverifier/trustbundle.go
@@ -1,0 +1,59 @@
+package networkverifier
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const caBundleConfigMapKey = "ca-bundle.crt"
+
+// GetAdditionalTrustBundle retrieves the additional CA trust bundle for a
+// cluster from its Hive SyncSets via the OCM cluster resources API.
+func GetAdditionalTrustBundle(ocmClient ocm.Client, cluster *v1.Cluster) (string, error) {
+	if cluster == nil || cluster.AdditionalTrustBundle() == "" {
+		return "", nil
+	}
+
+	logging.Infof("Cluster has an additional trust bundle configured, retrieving from Hive...")
+
+	syncSets, err := ocmClient.GetSyncSets(cluster.ID())
+	if err != nil {
+		return "", fmt.Errorf("failed to get SyncSets: %w", err)
+	}
+
+	for i := range syncSets {
+		if syncSets[i].Name == "proxy" {
+			caBundle, err := getCaBundleFromSyncSet(&syncSets[i])
+			if err != nil {
+				return "", fmt.Errorf("failed to extract CA bundle from SyncSet: %w", err)
+			}
+			logging.Infof("Successfully retrieved additional trust bundle from Hive")
+			return caBundle, nil
+		}
+	}
+
+	return "", fmt.Errorf("proxy SyncSet not found in cluster resources")
+}
+
+// getCaBundleFromSyncSet extracts the CA trust bundle from a Hive SyncSet's embedded ConfigMap resources.
+func getCaBundleFromSyncSet(ss *hivev1.SyncSet) (string, error) {
+	for i := range ss.Spec.Resources {
+		cm := &corev1.ConfigMap{}
+		if err := json.Unmarshal(ss.Spec.Resources[i].Raw, cm); err != nil {
+			logging.Debugf("Skipping SyncSet resource %d: failed to unmarshal as ConfigMap: %v", i, err)
+			continue
+		}
+
+		if bundle, ok := cm.Data[caBundleConfigMapKey]; ok {
+			return bundle, nil
+		}
+	}
+
+	return "", fmt.Errorf("ca-bundle.crt ConfigMap not found in SyncSet %s/%s", ss.Namespace, ss.Name)
+}

--- a/pkg/networkverifier/trustbundle_test.go
+++ b/pkg/networkverifier/trustbundle_test.go
@@ -1,0 +1,153 @@
+package networkverifier_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/networkverifier"
+	ocmmock "github.com/openshift/configuration-anomaly-detection/pkg/ocm/mock"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func makeSyncSetsWithBundle(bundle string) []hivev1.SyncSet {
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "user-ca-bundle", Namespace: "openshift-config"},
+		Data:       map[string]string{"ca-bundle.crt": bundle},
+	}
+	cmJSON, err := json.Marshal(cm)
+	Expect(err).ToNot(HaveOccurred())
+
+	return []hivev1.SyncSet{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "groups"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "proxy"},
+			Spec: hivev1.SyncSetSpec{
+				SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
+					Resources: []runtime.RawExtension{{Raw: cmJSON}},
+				},
+			},
+		},
+	}
+}
+
+var _ = Describe("TrustBundle", func() {
+	Describe("GetAdditionalTrustBundle", func() {
+		const caBundle = "-----BEGIN CERTIFICATE-----\nMIItest\n-----END CERTIFICATE-----"
+
+		var (
+			mockCtrl *gomock.Controller
+			ocmCli   *ocmmock.MockClient
+		)
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+			ocmCli = ocmmock.NewMockClient(mockCtrl)
+		})
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		When("cluster is nil", func() {
+			It("should return empty string", func() {
+				result, err := networkverifier.GetAdditionalTrustBundle(ocmCli, nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		When("cluster has no additional trust bundle", func() {
+			It("should return empty string", func() {
+				cluster, err := cmv1.NewCluster().ID("test-id").Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				result, err := networkverifier.GetAdditionalTrustBundle(ocmCli, cluster)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		When("GetSyncSets fails", func() {
+			It("should return the error", func() {
+				cluster, err := cmv1.NewCluster().ID("test-id").AdditionalTrustBundle("REDACTED").Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				ocmCli.EXPECT().GetSyncSets("test-id").Return(nil, fmt.Errorf("api error"))
+
+				result, err := networkverifier.GetAdditionalTrustBundle(ocmCli, cluster)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to get SyncSets"))
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		When("no proxy SyncSet exists", func() {
+			It("should return an error", func() {
+				cluster, err := cmv1.NewCluster().ID("test-id").AdditionalTrustBundle("REDACTED").Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				ocmCli.EXPECT().GetSyncSets("test-id").Return([]hivev1.SyncSet{
+					{ObjectMeta: metav1.ObjectMeta{Name: "groups"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "identity-providers"}},
+				}, nil)
+
+				result, err := networkverifier.GetAdditionalTrustBundle(ocmCli, cluster)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("proxy SyncSet not found"))
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		When("proxy SyncSet has no ca-bundle.crt ConfigMap", func() {
+			It("should return an error", func() {
+				cluster, err := cmv1.NewCluster().ID("test-id").AdditionalTrustBundle("REDACTED").Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				otherCM, err := json.Marshal(&corev1.ConfigMap{
+					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "other"},
+					Data:       map[string]string{"foo": "bar"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				ocmCli.EXPECT().GetSyncSets("test-id").Return([]hivev1.SyncSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "proxy"},
+						Spec: hivev1.SyncSetSpec{
+							SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
+								Resources: []runtime.RawExtension{{Raw: otherCM}},
+							},
+						},
+					},
+				}, nil)
+
+				result, err := networkverifier.GetAdditionalTrustBundle(ocmCli, cluster)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ca-bundle.crt ConfigMap not found"))
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		When("proxy SyncSet contains the trust bundle", func() {
+			It("should return the CA bundle", func() {
+				cluster, err := cmv1.NewCluster().ID("test-id").AdditionalTrustBundle("REDACTED").Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				ocmCli.EXPECT().GetSyncSets("test-id").Return(makeSyncSetsWithBundle(caBundle), nil)
+
+				result, err := networkverifier.GetAdditionalTrustBundle(ocmCli, cluster)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(caBundle))
+			})
+		})
+	})
+})

--- a/pkg/ocm/mock/ocmmock.go
+++ b/pkg/ocm/mock/ocmmock.go
@@ -17,6 +17,7 @@ import (
 	v10 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	v11 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	ocm "github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	v12 "github.com/openshift/hive/apis/hive/v1"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -205,6 +206,21 @@ func (m *MockClient) GetSupportRoleARN(internalClusterID string) (string, error)
 func (mr *MockClientMockRecorder) GetSupportRoleARN(internalClusterID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportRoleARN", reflect.TypeOf((*MockClient)(nil).GetSupportRoleARN), internalClusterID)
+}
+
+// GetSyncSets mocks base method.
+func (m *MockClient) GetSyncSets(internalClusterID string) ([]v12.SyncSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSyncSets", internalClusterID)
+	ret0, _ := ret[0].([]v12.SyncSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSyncSets indicates an expected call of GetSyncSets.
+func (mr *MockClientMockRecorder) GetSyncSets(internalClusterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncSets", reflect.TypeOf((*MockClient)(nil).GetSyncSets), internalClusterID)
 }
 
 // IsAccessProtected mocks base method.

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -58,6 +58,7 @@ type Client interface {
 	GetDynatraceURL(cluster *cmv1.Cluster) (string, error)
 	CheckIfUserBanned(cluster *cmv1.Cluster) error
 	GetCreatorFromCluster(cluster *cmv1.Cluster) (*amv1.Account, error)
+	GetSyncSets(internalClusterID string) ([]hivev1.SyncSet, error)
 }
 
 // SdkClient is the ocm client with which we can run the commands
@@ -450,6 +451,25 @@ func (c *SdkClient) GetDynatraceURL(cluster *cmv1.Cluster) (string, error) {
 	}
 
 	return "", errors.New("dynatrace tenant label not found in subscription")
+}
+
+// GetSyncSets returns all Hive SyncSets for a cluster via the OCM cluster resources API.
+func (c *SdkClient) GetSyncSets(internalClusterID string) ([]hivev1.SyncSet, error) {
+	ssString, err := c.getClusterResource(internalClusterID, "syncsets")
+	if err != nil {
+		return nil, fmt.Errorf("client failed to load SyncSets: %w", err)
+	}
+	if ssString == "" {
+		return nil, nil
+	}
+	var ssList struct {
+		Items []hivev1.SyncSet `json:"items"`
+	}
+	err = json.Unmarshal([]byte(ssString), &ssList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal SyncSets response: %w", err)
+	}
+	return ssList.Items, nil
 }
 
 func (e UserBannedError) Error() string {


### PR DESCRIPTION
[ROSAENG-16035](https://redhat.atlassian.net/browse/ROSAENG-16035)

Previously, clusters with additional trust bundles caused the network verifier to fail with an unsupported error. This retrieves the trust bundle from the cluster's Hive SyncSets via the OCM cluster resources API and passes it to the network verifier's proxy configuration.

### What type of PR is this?

bug/feat


[ROSAENG-16035]: https://redhat.atlassian.net/browse/ROSAENG-16035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network verifier can now retrieve and apply additional cluster CA bundles for egress validation.

* **Improvements**
  * Egress checks use retrieved trust-bundle data for more accurate reachability and failure analysis across investigations.

* **Tests**
  * Added tests covering retrieval, error cases, and application of additional CA bundles in egress validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->