### PR TITLE
fix: use value comparison for route CIDR in IsSubnetPrivate

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -385,7 +385,7 @@ func (c *SdkClient) IsSubnetPrivate(subnet string) (bool, error) {
 	for _, route := range rtb.Routes {
 		// GatewayId can contain an internet gateway *or* a virtual private gateway:
 		// "The ID of an internet gateway or virtual private gateway attached to your VPC."
-		if route.DestinationCidrBlock == awsv2.String("0.0.0.0/0") &&
+		if awsv2.ToString(route.DestinationCidrBlock) == "0.0.0.0/0" &&
 			(route.GatewayId != nil && strings.HasPrefix(*route.GatewayId, "igw")) {
 			// This is a public subnet
 			return false, nil

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -89,6 +89,21 @@ func TestSdkClient_IsSubnetPrivate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "A subnet with an internet gateway ID is public even when MapPublicIpOnLaunch is false",
+			fields: fields{
+				Region:           "us-east-1",
+				StsClient:        nil,
+				Ec2Client:        setupSubnetMock(t, awsv2.String("igw-1"), false),
+				CloudTrailClient: nil,
+				BaseConfig:       awsv2.Config{},
+			},
+			args: args{
+				subnet: "subnet-1",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
 			name: "A subnet with an virtual private gateway ID is considered private",
 			fields: fields{
 				Region:           "us-east-1",


### PR DESCRIPTION
[ROSAENG-59855](https://redhat.atlassian.net/browse/ROSAENG-59855)

IsSubnetPrivate compared route.DestinationCidrBlock (a *string) against awsv2.String("0.0.0.0/0") (a new *string) using ==, which compares pointers and never matches. This meant the IGW route was never detected, falling back to MapPublicIpOnLaunch which masked the bug in most real clusters but fails when a public subnet has MapPublicIpOnLaunch=false.

### What type of PR is this?

bug



[ROSAENG-59855]: https://redhat.atlassian.net/browse/ROSAENG-59855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ