### PR TITLE
ROSAENG-14105: Add investigation for HCPNodepoolUpgradeDelay

### DIFF
--- a/pkg/investigations/pdbblockingnodedrain/README.md
+++ b/pkg/investigations/pdbblockingnodedrain/README.md
@@ -1,0 +1,48 @@
+# pdbblockingnodedrain Investigation
+
+Investigates PodDisruptionBudgets (PDBs) blocking node drain during HCP cluster upgrades,
+triggered by the `HCPNodepoolUpgradeDelay` alert.
+
+When a node drain stalls during an upgrade, this investigation identifies which PDBs are
+blocking eviction, classifies them as customer-managed or platform-managed, and assesses
+whether scaling can resolve the issue without requiring a PDB change.
+
+## Investigation Flow
+
+| # | Check | Description | Type |
+|---|-------|-------------|------|
+| 1 | **Draining nodes** | Lists all nodes with the `node.kubernetes.io/unschedulable` taint and flags those stalled longer than 10 minutes | Informational |
+| 2 | **Blocking PDBs** | Enumerates PDBs with `disruptionsAllowed=0` whose selected pods are on stalled nodes; resolves owner workloads (Deployment, StatefulSet, etc.) and classifies each PDB as customer-managed or platform-managed based on namespace | Informational |
+| 3 | **Scaling assessment** | For each blocking PDB, compares `minAvailable`/`maxUnavailable` against healthy replica count to determine if scaling up the workload would unblock the drain | Informational |
+
+If no stalled nodes are found, the investigation escalates for manual review since the alert
+may indicate an issue outside the scope of this investigation. Otherwise, it escalates with
+all collected findings.
+
+## Design Decisions
+
+### Eviction event correlation not implemented
+
+The Jira ticket (ROSAENG-14105) originally called for correlating eviction failure events
+(e.g. "Cannot evict pod", "disruption budget") with stalled nodes. Testing showed these
+events are produced by the drain controller on the management cluster, not on the service
+cluster. Accessing MC events would require RHOBS integration (blocked by ROSAENG-15920) and
+MC-to-RHOBS log forwarding on staging (not yet available). The blocking PDB check (step 2)
+already provides definitive detection without events: if a PDB has `disruptionsAllowed=0` and
+its pods are on a draining node, it is the blocker.
+
+## Architecture
+
+Single-phase resource build: `rb.WithCluster().WithK8sClient().WithNotes().Build()`
+
+All checks run against the service cluster K8s API using controller-runtime's client.
+
+### Platform vs customer classification
+
+A PDB is classified as platform-managed if its namespace starts with `openshift-` or `kube-`,
+or is exactly `openshift`. All other namespaces are treated as customer-managed.
+This determines the remediation guidance (customer should fix vs. platform issue to escalate).
+
+## Testing
+
+Refer to the [testing README](./testing/README.md) for instructions on testing this investigation.

--- a/pkg/investigations/pdbblockingnodedrain/metadata.yaml
+++ b/pkg/investigations/pdbblockingnodedrain/metadata.yaml
@@ -1,0 +1,17 @@
+name: pdbblockingnodedrain
+rbac:
+  roles: []
+  clusterRoleRules:
+    - apiGroups: ['']
+      resources: ['nodes']
+      verbs: ['get', 'list']
+    - apiGroups: ['']
+      resources: ['pods']
+      verbs: ['get', 'list']
+    - apiGroups: ['policy']
+      resources: ['poddisruptionbudgets']
+      verbs: ['get', 'list']
+    - apiGroups: ['apps']
+      resources: ['deployments', 'statefulsets', 'replicasets']
+      verbs: ['get', 'list']
+customerDataAccess: false

--- a/pkg/investigations/pdbblockingnodedrain/pdbblockingnodedrain.go
+++ b/pkg/investigations/pdbblockingnodedrain/pdbblockingnodedrain.go
@@ -1,0 +1,452 @@
+package pdbblockingnodedrain
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/types"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	drainStallThreshold = 10 * time.Minute
+	ownerNone           = "none"
+)
+
+type stalledNode struct {
+	Node               corev1.Node
+	UnschedulableSince time.Time
+	DrainDuration      time.Duration
+}
+
+type blockingPDB struct {
+	Namespace          string
+	Name               string
+	MinAvailable       string
+	MaxUnavailable     string
+	DisruptionsAllowed int32
+	CurrentHealthy     int32
+	ExpectedPods       int32
+	MatchingPods       []string // pod names on draining nodes
+	OwnerWorkloads     []string // deduplicated "Kind/name" strings
+	IsPlatformManaged  bool
+}
+
+type Investigation struct{}
+
+func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
+	result := investigation.InvestigationResult{}
+
+	r, err := rb.WithCluster().WithK8sClient().WithNotes().Build()
+	if err != nil {
+		if msg, ok := investigation.ClusterAccessErrorMessage(err); ok {
+			logging.Warnf("Cluster access error for %s: %v", i.Name(), err)
+			result.Actions = []types.Action{
+				executor.Note(msg),
+				executor.Escalate(msg),
+			}
+			return result, nil
+		}
+		return result, investigation.WrapInfrastructure(err, "failed to build resources for "+i.Name())
+	}
+
+	ctx := context.Background()
+
+	stalledNodes := i.checkDrainingNodes(ctx, r.K8sClient, r.Notes)
+
+	if len(stalledNodes) == 0 {
+		r.Notes.AppendSuccess("No nodes are stalled in draining state")
+		result.Actions = append(
+			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
+			executor.Escalate("No stalled node drains detected, but alert fired: manual review required"),
+		)
+		return result, nil
+	}
+
+	blockingPDBs := i.checkBlockingPDBs(ctx, r.K8sClient, stalledNodes, r.Notes)
+	unhealthyNodeCount := i.checkNodeHealth(ctx, r.K8sClient, r.Notes)
+	i.checkScalingAssessment(blockingPDBs, unhealthyNodeCount, r.Notes)
+
+	result.Actions = append(
+		executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
+		executor.Escalate("PDB blocking node drain investigation: manual review required"),
+	)
+	return result, nil
+}
+
+// checkDrainingNodes lists all nodes and identifies those stuck in a draining state.
+// A node is considered draining if it has the node.kubernetes.io/unschedulable taint.
+// Nodes draining longer than drainStallThreshold are flagged as stalled.
+//
+// Returns the stalled draining nodes for use by subsequent investigation steps.
+func (i *Investigation) checkDrainingNodes(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) []stalledNode {
+	nodeList := &corev1.NodeList{}
+	if err := k8sClient.List(ctx, nodeList, &client.ListOptions{}); err != nil {
+		notes.AppendWarning("Draining Nodes: failed to list nodes: %v", err)
+		return nil
+	}
+
+	now := time.Now()
+	var drainingCount int
+	var stalled []stalledNode
+	var stalledDetails []string
+	var recentDetails []string
+
+	for _, node := range nodeList.Items {
+		taint, found := findUnschedulableTaint(node)
+		if !found {
+			continue
+		}
+
+		var unschedulableSince time.Time
+		switch {
+		case taint.TimeAdded != nil:
+			unschedulableSince = taint.TimeAdded.Time
+		case !node.CreationTimestamp.IsZero():
+			unschedulableSince = node.CreationTimestamp.Time
+		default:
+			unschedulableSince = now
+		}
+
+		dn := stalledNode{
+			Node:               node,
+			UnschedulableSince: unschedulableSince,
+			DrainDuration:      now.Sub(unschedulableSince),
+		}
+		drainingCount++
+
+		duration := dn.DrainDuration.Truncate(time.Second)
+		detail := fmt.Sprintf("%s: draining for %s", dn.Node.Name, duration)
+		if dn.DrainDuration >= drainStallThreshold {
+			stalled = append(stalled, dn)
+			stalledDetails = append(stalledDetails, detail)
+		} else {
+			recentDetails = append(recentDetails, detail)
+		}
+	}
+
+	if drainingCount == 0 {
+		notes.AppendSuccess("Draining Nodes: no nodes are currently draining")
+		return nil
+	}
+
+	if len(recentDetails) > 0 {
+		notes.AppendSuccess("Draining Nodes: %d node(s) draining within threshold:\n  %s",
+			len(recentDetails), strings.Join(recentDetails, "\n  "))
+	}
+
+	if len(stalled) == 0 {
+		notes.AppendSuccess("Draining Nodes: %d node(s) draining, none stalled (all under %s threshold)",
+			drainingCount, drainStallThreshold)
+		return nil
+	}
+
+	notes.AppendWarning("Draining Nodes: %d/%d draining node(s) stalled (>%s):\n  %s",
+		len(stalled), drainingCount, drainStallThreshold, strings.Join(stalledDetails, "\n  "))
+
+	return stalled
+}
+
+// checkNodeHealth examines non-draining nodes and reports any that are NotReady or have
+// resource pressure conditions. Unhealthy schedulable nodes mean evicted pods may not
+// reschedule successfully, so scaling recommendations may not be effective.
+func (i *Investigation) checkNodeHealth(ctx context.Context, k8sClient k8sclient.Client, notes *notewriter.NoteWriter) int {
+	nodeList := &corev1.NodeList{}
+	if err := k8sClient.List(ctx, nodeList, &client.ListOptions{}); err != nil {
+		notes.AppendWarning("Node Health: failed to list nodes: %v", err)
+		return 0
+	}
+
+	var unhealthyDetails []string
+	for _, node := range nodeList.Items {
+		if _, draining := findUnschedulableTaint(node); draining {
+			continue
+		}
+
+		var issues []string
+		for _, cond := range node.Status.Conditions {
+			switch cond.Type {
+			case corev1.NodeReady:
+				if cond.Status != corev1.ConditionTrue {
+					issues = append(issues, "NotReady")
+				}
+			case corev1.NodeDiskPressure, corev1.NodeMemoryPressure, corev1.NodePIDPressure:
+				if cond.Status == corev1.ConditionTrue {
+					issues = append(issues, string(cond.Type))
+				}
+			}
+		}
+
+		if len(issues) > 0 {
+			unhealthyDetails = append(unhealthyDetails, fmt.Sprintf("%s: %s", node.Name, strings.Join(issues, ", ")))
+		}
+	}
+
+	if len(unhealthyDetails) == 0 {
+		notes.AppendSuccess("Node Health: all non-draining nodes are Ready with no resource pressure")
+		return 0
+	}
+
+	notes.AppendWarning("Node Health: %d non-draining node(s) unhealthy, evicted pods may fail to reschedule:\n  %s",
+		len(unhealthyDetails), strings.Join(unhealthyDetails, "\n  "))
+	return len(unhealthyDetails)
+}
+
+// checkBlockingPDBs enumerates all PDBs with disruptionsAllowed==0 whose controlled pods
+// are on draining nodes. For each blocking PDB it reports the configured constraint,
+// matching pod names, and owning workloads.
+//
+// Returns the blocking PDBs for use by subsequent investigation steps.
+func (i *Investigation) checkBlockingPDBs(ctx context.Context, k8sClient k8sclient.Client, stalledNodes []stalledNode, notes *notewriter.NoteWriter) []blockingPDB {
+	stalledNodeNames := make(map[string]bool, len(stalledNodes))
+	for _, dn := range stalledNodes {
+		stalledNodeNames[dn.Node.Name] = true
+	}
+
+	pdbList := &policyv1.PodDisruptionBudgetList{}
+	if err := k8sClient.List(ctx, pdbList); err != nil {
+		notes.AppendWarning("Blocking PDBs: failed to list PodDisruptionBudgets: %v", err)
+		return nil
+	}
+
+	// List all pods once and index by namespace for selector matching.
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(ctx, podList); err != nil {
+		notes.AppendWarning("Blocking PDBs: failed to list pods: %v", err)
+		return nil
+	}
+
+	podsByNamespace := make(map[string][]corev1.Pod)
+	for _, pod := range podList.Items {
+		podsByNamespace[pod.Namespace] = append(podsByNamespace[pod.Namespace], pod)
+	}
+
+	blocking := make([]blockingPDB, 0, len(pdbList.Items))
+
+	for _, pdb := range pdbList.Items {
+		// Only consider PDBs that are fully blocking (no disruptions allowed at all).
+		if pdb.Status.DisruptionsAllowed != 0 {
+			continue
+		}
+
+		selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+		if err != nil {
+			notes.AppendWarning("Blocking PDBs: failed to parse selector for %s/%s: %v", pdb.Namespace, pdb.Name, err)
+			continue
+		}
+
+		// Find pods that match this PDB's selector AND are running on stalled nodes.
+		var matchingPodNames []string
+		ownerSet := make(map[string]bool)
+
+		for _, pod := range podsByNamespace[pdb.Namespace] {
+			if !selector.Matches(labels.Set(pod.Labels)) {
+				continue
+			}
+			if !stalledNodeNames[pod.Spec.NodeName] {
+				continue
+			}
+
+			matchingPodNames = append(matchingPodNames, pod.Name)
+
+			owner := resolveWorkloadOwner(ctx, k8sClient, pod)
+			ownerSet[owner] = true
+		}
+
+		if len(matchingPodNames) == 0 {
+			continue
+		}
+
+		// Deduplicate owners (multiple pods may belong to the same workload).
+		owners := make([]string, 0, len(ownerSet))
+		for o := range ownerSet {
+			owners = append(owners, o)
+		}
+
+		bp := blockingPDB{
+			Namespace:          pdb.Namespace,
+			Name:               pdb.Name,
+			DisruptionsAllowed: pdb.Status.DisruptionsAllowed,
+			CurrentHealthy:     pdb.Status.CurrentHealthy,
+			ExpectedPods:       pdb.Status.ExpectedPods,
+			MatchingPods:       matchingPodNames,
+			OwnerWorkloads:     owners,
+			IsPlatformManaged:  isPlatformNamespace(pdb.Namespace),
+		}
+		if pdb.Spec.MinAvailable != nil {
+			bp.MinAvailable = pdb.Spec.MinAvailable.String()
+		}
+		if pdb.Spec.MaxUnavailable != nil {
+			bp.MaxUnavailable = pdb.Spec.MaxUnavailable.String()
+		}
+
+		blocking = append(blocking, bp)
+	}
+
+	if len(blocking) == 0 {
+		notes.AppendSuccess("Blocking PDBs: no PDBs with disruptionsAllowed=0 have pods on stalled nodes")
+		return nil
+	}
+
+	var customerPDBs, platformPDBs []string
+	for _, bp := range blocking {
+		constraint := "minAvailable: " + bp.MinAvailable
+		if bp.MinAvailable == "" {
+			constraint = "maxUnavailable: " + bp.MaxUnavailable
+		}
+		managedBy := "customer"
+		if bp.IsPlatformManaged {
+			managedBy = "platform"
+		}
+		detail := fmt.Sprintf("%s/%s [%s] (%s, healthy: %d/%d)\n    Owner: %s\n    Pods on draining nodes: %s",
+			bp.Namespace, bp.Name, managedBy, constraint, bp.CurrentHealthy, bp.ExpectedPods,
+			strings.Join(bp.OwnerWorkloads, ", "),
+			strings.Join(bp.MatchingPods, ", "))
+		if bp.IsPlatformManaged {
+			platformPDBs = append(platformPDBs, detail)
+		} else {
+			customerPDBs = append(customerPDBs, detail)
+		}
+	}
+
+	allDetails := make([]string, 0, len(customerPDBs)+len(platformPDBs))
+	allDetails = append(allDetails, customerPDBs...)
+	allDetails = append(allDetails, platformPDBs...)
+	notes.AppendWarning("Blocking PDBs: %d PDB(s) with disruptionsAllowed=0 affecting pods on stalled nodes:\n  %s",
+		len(blocking), strings.Join(allDetails, "\n  "))
+
+	if len(customerPDBs) > 0 {
+		notes.AppendWarning("Remediation: %d customer-managed PDB(s): customer should relax the PDB or scale the workload to allow disruptions", len(customerPDBs))
+	}
+	if len(platformPDBs) > 0 {
+		notes.AppendWarning("Remediation: %d platform-managed PDB(s): check node health or escalate to engineering if you suspect a bug that is blocking upgrades", len(platformPDBs))
+	}
+
+	return blocking
+}
+
+// resolveWorkloadOwner walks the owner reference chain of a pod to find the
+// top-level workload (e.g. Deployment, StatefulSet, DaemonSet).
+// For pods owned by a ReplicaSet, it checks if the ReplicaSet is owned by a Deployment.
+func resolveWorkloadOwner(ctx context.Context, k8sClient k8sclient.Client, pod corev1.Pod) string {
+	if len(pod.OwnerReferences) == 0 {
+		return ownerNone
+	}
+
+	owner := pod.OwnerReferences[0]
+	if owner.Kind != "ReplicaSet" {
+		return fmt.Sprintf("%s/%s", owner.Kind, owner.Name)
+	}
+
+	rs := &appsv1.ReplicaSet{}
+	if err := k8sClient.Get(ctx, ktypes.NamespacedName{Namespace: pod.Namespace, Name: owner.Name}, rs); err != nil {
+		return fmt.Sprintf("ReplicaSet/%s", owner.Name)
+	}
+	for _, rsOwner := range rs.OwnerReferences {
+		if rsOwner.Kind == "Deployment" {
+			return fmt.Sprintf("Deployment/%s", rsOwner.Name)
+		}
+	}
+	return fmt.Sprintf("ReplicaSet/%s", owner.Name)
+}
+
+// checkScalingAssessment evaluates whether scaling up the workload would unblock
+// the drain for each blocking PDB, without requiring a PDB change.
+func (i *Investigation) checkScalingAssessment(blockingPDBs []blockingPDB, unhealthyNodeCount int, notes *notewriter.NoteWriter) {
+	if len(blockingPDBs) == 0 {
+		return
+	}
+
+	var scalable, notScalable []string
+	for _, bp := range blockingPDBs {
+		assessment, canScale := assessScaling(bp)
+		entry := fmt.Sprintf("%s/%s: %s", bp.Namespace, bp.Name, assessment)
+		if canScale {
+			scalable = append(scalable, entry)
+		} else {
+			notScalable = append(notScalable, entry)
+		}
+	}
+
+	if len(scalable) > 0 {
+		scalableMsg := strings.Join(scalable, "\n  ")
+		if unhealthyNodeCount > 0 {
+			scalableMsg += fmt.Sprintf("\n  NOTE: %d non-draining node(s) are unhealthy: new replicas may not schedule", unhealthyNodeCount)
+		}
+		notes.AppendWarning("Scaling Assessment: %d PDB(s) can be unblocked by scaling:\n  %s",
+			len(scalable), scalableMsg)
+	}
+	if len(notScalable) > 0 {
+		notes.AppendWarning("Scaling Assessment: %d PDB(s) cannot be unblocked by scaling alone:\n  %s",
+			len(notScalable), strings.Join(notScalable, "\n  "))
+	}
+}
+
+// assessScaling determines whether scaling the workload would unblock the drain
+// for a given blocking PDB.
+func assessScaling(bp blockingPDB) (string, bool) {
+	if bp.MaxUnavailable != "" {
+		if bp.MaxUnavailable == "0" || bp.MaxUnavailable == "0%" {
+			return "scaling will not help: maxUnavailable=0 forbids all disruptions, PDB must be changed", false
+		}
+		unhealthy := bp.ExpectedPods - bp.CurrentHealthy
+		return fmt.Sprintf("scaling will not help: %d pod(s) unhealthy beyond maxUnavailable threshold, unhealthy pods must recover (check for scheduling constraints such as anti-affinity, node selectors, or resource limits)", unhealthy), false
+	}
+
+	if bp.MinAvailable == "100%" {
+		return "scaling will not help: minAvailable=100% requires all pods healthy, PDB must be changed", false
+	}
+
+	if bp.CurrentHealthy == bp.ExpectedPods {
+		return fmt.Sprintf("scaling up by 1 replica would unblock the drain (healthy: %d, minAvailable: %s)", bp.CurrentHealthy, bp.MinAvailable), true
+	}
+
+	unhealthy := bp.ExpectedPods - bp.CurrentHealthy
+	return fmt.Sprintf("scaling may help if new pods become healthy: %d of %d pod(s) currently unhealthy (minAvailable: %s); if pods remain Pending, check for scheduling constraints such as anti-affinity, node selectors, or resource limits",
+		unhealthy, bp.ExpectedPods, bp.MinAvailable), true
+}
+
+func isPlatformNamespace(namespace string) bool {
+	return strings.HasPrefix(namespace, "openshift-") ||
+		strings.HasPrefix(namespace, "kube-") ||
+		namespace == "openshift"
+}
+
+func findUnschedulableTaint(node corev1.Node) (corev1.Taint, bool) {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == corev1.TaintNodeUnschedulable && taint.Effect == corev1.TaintEffectNoSchedule {
+			return taint, true
+		}
+	}
+	return corev1.Taint{}, false
+}
+
+func (i *Investigation) Name() string {
+	return "pdbblockingnodedrain"
+}
+
+func (i *Investigation) AlertTitle() string {
+	return "HCPNodepoolUpgradeDelay"
+}
+
+func (i *Investigation) Description() string {
+	return "Investigates PodDisruptionBudgets blocking node drain during cluster upgrades"
+}
+
+func (i *Investigation) IsExperimental() bool {
+	return false
+}

--- a/pkg/investigations/pdbblockingnodedrain/pdbblockingnodedrain_test.go
+++ b/pkg/investigations/pdbblockingnodedrain/pdbblockingnodedrain_test.go
@@ -1,0 +1,1017 @@
+package pdbblockingnodedrain
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = policyv1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+	return s
+}
+
+func newFakeClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(objs...).Build()
+}
+
+func newTestNotes() *notewriter.NoteWriter {
+	return notewriter.New("pdbblockingnodedrain", nil)
+}
+
+func timePtr(t time.Time) *metav1.Time {
+	mt := metav1.NewTime(t)
+	return &mt
+}
+
+func newNode(name string, taints []corev1.Taint) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.NodeSpec{Taints: taints},
+	}
+}
+
+func newNodeWithConditions(name string, taints []corev1.Taint, conditions []corev1.NodeCondition) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.NodeSpec{Taints: taints},
+		Status:     corev1.NodeStatus{Conditions: conditions},
+	}
+}
+
+func readyCondition(status corev1.ConditionStatus) corev1.NodeCondition {
+	return corev1.NodeCondition{Type: corev1.NodeReady, Status: status}
+}
+
+func pressureCondition(condType corev1.NodeConditionType) corev1.NodeCondition {
+	return corev1.NodeCondition{Type: condType, Status: corev1.ConditionTrue}
+}
+
+func unschedulableTaint(timeAdded *metav1.Time) corev1.Taint {
+	return corev1.Taint{
+		Key:       corev1.TaintNodeUnschedulable,
+		Effect:    corev1.TaintEffectNoSchedule,
+		TimeAdded: timeAdded,
+	}
+}
+
+func newLabeledPod(name, namespace, nodeName string, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			OwnerReferences: ownerRefs,
+		},
+		Spec: corev1.PodSpec{NodeName: nodeName},
+	}
+}
+
+func newPDB(name, namespace string, selector map[string]string, minAvailable *intstr.IntOrString, maxUnavailable *intstr.IntOrString, disruptionsAllowed, currentHealthy, expectedPods int32) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector:       &metav1.LabelSelector{MatchLabels: selector},
+			MinAvailable:   minAvailable,
+			MaxUnavailable: maxUnavailable,
+		},
+		Status: policyv1.PodDisruptionBudgetStatus{
+			DisruptionsAllowed: disruptionsAllowed,
+			CurrentHealthy:     currentHealthy,
+			ExpectedPods:       expectedPods,
+		},
+	}
+}
+
+func intstrPtr(val int32) *intstr.IntOrString {
+	v := intstr.FromInt32(val)
+	return &v
+}
+
+func newReplicaSet(name, namespace, deploymentOwner string) *appsv1.ReplicaSet {
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	if deploymentOwner != "" {
+		rs.OwnerReferences = []metav1.OwnerReference{
+			{Kind: "Deployment", Name: deploymentOwner, APIVersion: "apps/v1"},
+		}
+	}
+	return rs
+}
+
+// --- Interface method tests ---
+
+func TestName(t *testing.T) {
+	inv := &Investigation{}
+	if inv.Name() != "pdbblockingnodedrain" {
+		t.Errorf("expected 'pdbblockingnodedrain', got %q", inv.Name())
+	}
+}
+
+func TestAlertTitle(t *testing.T) {
+	inv := &Investigation{}
+	if inv.AlertTitle() != "HCPNodepoolUpgradeDelay" {
+		t.Errorf("expected 'HCPNodepoolUpgradeDelay', got %q", inv.AlertTitle())
+	}
+}
+
+func TestDescription(t *testing.T) {
+	inv := &Investigation{}
+	if inv.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+}
+
+// --- findUnschedulableTaint tests ---
+
+func TestFindUnschedulableTaint_Present(t *testing.T) {
+	node := corev1.Node{
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: "other-taint", Effect: corev1.TaintEffectNoSchedule},
+				unschedulableTaint(nil),
+			},
+		},
+	}
+	taint, found := findUnschedulableTaint(node)
+	if !found {
+		t.Fatal("expected taint to be found")
+	}
+	if taint.Key != corev1.TaintNodeUnschedulable {
+		t.Errorf("unexpected taint key: %s", taint.Key)
+	}
+}
+
+func TestFindUnschedulableTaint_Absent(t *testing.T) {
+	node := corev1.Node{
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: "other-taint", Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+	}
+	_, found := findUnschedulableTaint(node)
+	if found {
+		t.Error("expected taint to not be found")
+	}
+}
+
+func TestFindUnschedulableTaint_WrongEffect(t *testing.T) {
+	node := corev1.Node{
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: corev1.TaintNodeUnschedulable, Effect: corev1.TaintEffectNoExecute},
+			},
+		},
+	}
+	_, found := findUnschedulableTaint(node)
+	if found {
+		t.Error("expected taint with wrong effect to not match")
+	}
+}
+
+func TestFindUnschedulableTaint_NoTaints(t *testing.T) {
+	node := corev1.Node{}
+	_, found := findUnschedulableTaint(node)
+	if found {
+		t.Error("expected no taint found on node with no taints")
+	}
+}
+
+// --- checkDrainingNodes tests ---
+
+func TestCheckDrainingNodes_NoDrainingNodes(t *testing.T) {
+	k8sClient := newFakeClient(
+		newNode("node-1", nil),
+		newNode("node-2", []corev1.Taint{{Key: "other", Effect: corev1.TaintEffectNoSchedule}}),
+	)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	result := inv.checkDrainingNodes(context.Background(), k8sClient, notes)
+
+	if result != nil {
+		t.Errorf("expected nil, got %d stalled nodes", len(result))
+	}
+	if !strings.Contains(notes.String(), "no nodes are currently draining") {
+		t.Errorf("expected 'no nodes are currently draining' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckDrainingNodes_AllUnderThreshold(t *testing.T) {
+	recentTime := timePtr(time.Now().Add(-5 * time.Minute))
+	k8sClient := newFakeClient(
+		newNode("node-1", []corev1.Taint{unschedulableTaint(recentTime)}),
+	)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	result := inv.checkDrainingNodes(context.Background(), k8sClient, notes)
+
+	if result != nil {
+		t.Errorf("expected nil (all under threshold), got %d stalled nodes", len(result))
+	}
+	if !strings.Contains(notes.String(), "none stalled") {
+		t.Errorf("expected 'none stalled' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckDrainingNodes_StalledNode(t *testing.T) {
+	stalledTime := timePtr(time.Now().Add(-30 * time.Minute))
+	k8sClient := newFakeClient(
+		newNode("stalled-node", []corev1.Taint{unschedulableTaint(stalledTime)}),
+	)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	result := inv.checkDrainingNodes(context.Background(), k8sClient, notes)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 stalled node, got %d", len(result))
+	}
+	if result[0].Node.Name != "stalled-node" {
+		t.Errorf("expected 'stalled-node', got %q", result[0].Node.Name)
+	}
+	if !strings.Contains(notes.String(), "stalled") {
+		t.Errorf("expected 'stalled' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckDrainingNodes_MixedStalledAndRecent(t *testing.T) {
+	stalledTime := timePtr(time.Now().Add(-20 * time.Minute))
+	recentTime := timePtr(time.Now().Add(-3 * time.Minute))
+	k8sClient := newFakeClient(
+		newNode("stalled-node", []corev1.Taint{unschedulableTaint(stalledTime)}),
+		newNode("recent-node", []corev1.Taint{unschedulableTaint(recentTime)}),
+		newNode("healthy-node", nil),
+	)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	result := inv.checkDrainingNodes(context.Background(), k8sClient, notes)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 stalled node, got %d", len(result))
+	}
+	if result[0].Node.Name != "stalled-node" {
+		t.Errorf("expected 'stalled-node', got %q", result[0].Node.Name)
+	}
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "1/2 draining node(s) stalled") {
+		t.Errorf("expected '1/2 draining node(s) stalled' in notes, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "1 node(s) draining within threshold") {
+		t.Errorf("expected '1 node(s) draining within threshold' in notes, got: %s", noteStr)
+	}
+}
+
+func TestCheckDrainingNodes_MultipleStalledNodes(t *testing.T) {
+	stalledTime1 := timePtr(time.Now().Add(-15 * time.Minute))
+	stalledTime2 := timePtr(time.Now().Add(-45 * time.Minute))
+	k8sClient := newFakeClient(
+		newNode("stalled-1", []corev1.Taint{unschedulableTaint(stalledTime1)}),
+		newNode("stalled-2", []corev1.Taint{unschedulableTaint(stalledTime2)}),
+	)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	result := inv.checkDrainingNodes(context.Background(), k8sClient, notes)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 stalled nodes, got %d", len(result))
+	}
+	if !strings.Contains(notes.String(), "2/2 draining node(s) stalled") {
+		t.Errorf("expected '2/2 draining node(s) stalled' in notes, got: %s", notes.String())
+	}
+}
+
+// --- checkNodeHealth tests ---
+
+func TestCheckNodeHealth_AllHealthy(t *testing.T) {
+	sn := newNodeWithConditions("stalled-node",
+		[]corev1.Taint{unschedulableTaint(timePtr(time.Now().Add(-20 * time.Minute)))},
+		[]corev1.NodeCondition{readyCondition(corev1.ConditionTrue)})
+	healthyNode := newNodeWithConditions("healthy-node", nil,
+		[]corev1.NodeCondition{readyCondition(corev1.ConditionTrue)})
+
+	k8sClient := newFakeClient(sn, healthyNode)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "all non-draining nodes are Ready") {
+		t.Errorf("expected healthy message, got: %s", noteStr)
+	}
+}
+
+func TestCheckNodeHealth_NotReadyNode(t *testing.T) {
+	sn := newNode("stalled-node", []corev1.Taint{unschedulableTaint(timePtr(time.Now().Add(-20 * time.Minute)))})
+	notReadyNode := newNodeWithConditions("bad-node", nil,
+		[]corev1.NodeCondition{readyCondition(corev1.ConditionFalse)})
+
+	k8sClient := newFakeClient(sn, notReadyNode)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "bad-node: NotReady") {
+		t.Errorf("expected NotReady warning for bad-node, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "evicted pods may fail to reschedule") {
+		t.Errorf("expected reschedule warning, got: %s", noteStr)
+	}
+}
+
+func TestCheckNodeHealth_DiskPressure(t *testing.T) {
+	sn := newNode("stalled-node", []corev1.Taint{unschedulableTaint(timePtr(time.Now().Add(-20 * time.Minute)))})
+	pressureNode := newNodeWithConditions("pressure-node", nil,
+		[]corev1.NodeCondition{
+			readyCondition(corev1.ConditionTrue),
+			pressureCondition(corev1.NodeDiskPressure),
+		})
+
+	k8sClient := newFakeClient(sn, pressureNode)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "pressure-node: DiskPressure") {
+		t.Errorf("expected DiskPressure warning, got: %s", noteStr)
+	}
+}
+
+func TestCheckNodeHealth_MultipleIssues(t *testing.T) {
+	sn := newNode("stalled-node", []corev1.Taint{unschedulableTaint(timePtr(time.Now().Add(-20 * time.Minute)))})
+	badNode := newNodeWithConditions("bad-node", nil,
+		[]corev1.NodeCondition{
+			readyCondition(corev1.ConditionFalse),
+			pressureCondition(corev1.NodeMemoryPressure),
+			pressureCondition(corev1.NodePIDPressure),
+		})
+
+	k8sClient := newFakeClient(sn, badNode)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "NotReady") {
+		t.Errorf("expected NotReady, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "MemoryPressure") {
+		t.Errorf("expected MemoryPressure, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "PIDPressure") {
+		t.Errorf("expected PIDPressure, got: %s", noteStr)
+	}
+}
+
+func TestCheckNodeHealth_StalledNodeExcluded(t *testing.T) {
+	sn := newNodeWithConditions("stalled-node",
+		[]corev1.Taint{unschedulableTaint(timePtr(time.Now().Add(-20 * time.Minute)))},
+		[]corev1.NodeCondition{readyCondition(corev1.ConditionFalse)})
+
+	k8sClient := newFakeClient(sn)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "all non-draining nodes are Ready") {
+		t.Errorf("stalled node should be excluded from health check, got: %s", noteStr)
+	}
+}
+
+func TestCheckNodeHealth_RecentlyDrainingNodeExcluded(t *testing.T) {
+	// A node draining for less than the stall threshold should still be excluded
+	// from health checks since it's unschedulable and can't accept rescheduled pods.
+	recentDraining := newNodeWithConditions("recent-draining",
+		[]corev1.Taint{unschedulableTaint(timePtr(time.Now().Add(-2 * time.Minute)))},
+		[]corev1.NodeCondition{readyCondition(corev1.ConditionFalse)})
+
+	k8sClient := newFakeClient(recentDraining)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkNodeHealth(context.Background(), k8sClient, notes)
+
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "all non-draining nodes are Ready") {
+		t.Errorf("recently-draining node should be excluded from health check, got: %s", noteStr)
+	}
+}
+
+// --- checkBlockingPDBs tests ---
+
+func TestCheckBlockingPDBs_NoBlockingPDBs(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	appLabels := map[string]string{"app": "web"}
+	pod := newLabeledPod("web-abc-1", "default", "stalled-node", appLabels, nil)
+	pdb := newPDB("web-pdb", "default", appLabels, intstrPtr(1), nil, 1, 2, 2)
+
+	k8sClient := newFakeClient(sn, pod, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if result != nil {
+		t.Errorf("expected nil (PDB allows disruptions), got %d blocking PDBs", len(result))
+	}
+	if !strings.Contains(notes.String(), "no PDBs with disruptionsAllowed=0") {
+		t.Errorf("expected 'no PDBs with disruptionsAllowed=0' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckBlockingPDBs_BlockingPDBWithMinAvailable(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	appLabels := map[string]string{"app": "web"}
+	pod := newLabeledPod("web-abc-1", "default", "stalled-node", appLabels, nil)
+	pdb := newPDB("web-pdb", "default", appLabels, intstrPtr(2), nil, 0, 2, 2)
+
+	k8sClient := newFakeClient(sn, pod, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 blocking PDB, got %d", len(result))
+	}
+	bp := result[0]
+	if bp.Name != "web-pdb" || bp.Namespace != "default" {
+		t.Errorf("expected default/web-pdb, got %s/%s", bp.Namespace, bp.Name)
+	}
+	if bp.MinAvailable != "2" {
+		t.Errorf("expected MinAvailable '2', got %q", bp.MinAvailable)
+	}
+	if len(bp.MatchingPods) != 1 || bp.MatchingPods[0] != "web-abc-1" {
+		t.Errorf("expected matching pod 'web-abc-1', got %v", bp.MatchingPods)
+	}
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "1 PDB(s) with disruptionsAllowed=0") {
+		t.Errorf("expected '1 PDB(s) with disruptionsAllowed=0' in notes, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "minAvailable: 2") {
+		t.Errorf("expected 'minAvailable: 2' in notes, got: %s", noteStr)
+	}
+}
+
+func TestCheckBlockingPDBs_BlockingPDBWithMaxUnavailable(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	appLabels := map[string]string{"app": "db"}
+	pod := newLabeledPod("db-0", "prod", "stalled-node", appLabels, nil)
+	pdb := newPDB("db-pdb", "prod", appLabels, nil, intstrPtr(0), 0, 3, 3)
+
+	k8sClient := newFakeClient(sn, pod, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 blocking PDB, got %d", len(result))
+	}
+	if result[0].MaxUnavailable != "0" {
+		t.Errorf("expected MaxUnavailable '0', got %q", result[0].MaxUnavailable)
+	}
+	if !strings.Contains(notes.String(), "maxUnavailable: 0") {
+		t.Errorf("expected 'maxUnavailable: 0' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckBlockingPDBs_PodNotOnStalledNode(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	appLabels := map[string]string{"app": "web"}
+	pod := newLabeledPod("web-abc-1", "default", "other-node", appLabels, nil)
+	pdb := newPDB("web-pdb", "default", appLabels, intstrPtr(2), nil, 0, 2, 2)
+
+	k8sClient := newFakeClient(sn, pod, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if result != nil {
+		t.Errorf("expected nil (pod not on stalled node), got %d blocking PDBs", len(result))
+	}
+}
+
+func TestCheckBlockingPDBs_LabelMismatch(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	pod := newLabeledPod("web-abc-1", "default", "stalled-node", map[string]string{"app": "api"}, nil)
+	pdb := newPDB("web-pdb", "default", map[string]string{"app": "web"}, intstrPtr(2), nil, 0, 2, 2)
+
+	k8sClient := newFakeClient(sn, pod, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if result != nil {
+		t.Errorf("expected nil (label mismatch), got %d blocking PDBs", len(result))
+	}
+}
+
+func TestCheckBlockingPDBs_ResolvesDeploymentOwner(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	appLabels := map[string]string{"app": "web"}
+	ownerRefs := []metav1.OwnerReference{
+		{Kind: "ReplicaSet", Name: "web-deploy-abc", APIVersion: "apps/v1"},
+	}
+	pod := newLabeledPod("web-deploy-abc-1", "default", "stalled-node", appLabels, ownerRefs)
+	rs := newReplicaSet("web-deploy-abc", "default", "web-deploy")
+	pdb := newPDB("web-pdb", "default", appLabels, intstrPtr(2), nil, 0, 2, 2)
+
+	k8sClient := newFakeClient(sn, pod, rs, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 blocking PDB, got %d", len(result))
+	}
+	if len(result[0].OwnerWorkloads) != 1 || result[0].OwnerWorkloads[0] != "Deployment/web-deploy" {
+		t.Errorf("expected owner 'Deployment/web-deploy', got %v", result[0].OwnerWorkloads)
+	}
+	if !strings.Contains(notes.String(), "Deployment/web-deploy") {
+		t.Errorf("expected 'Deployment/web-deploy' in notes, got: %s", notes.String())
+	}
+}
+
+func TestCheckBlockingPDBs_ResolvesStatefulSetOwner(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	appLabels := map[string]string{"app": "db"}
+	ownerRefs := []metav1.OwnerReference{
+		{Kind: "StatefulSet", Name: "db-sts", APIVersion: "apps/v1"},
+	}
+	pod := newLabeledPod("db-sts-0", "default", "stalled-node", appLabels, ownerRefs)
+	pdb := newPDB("db-pdb", "default", appLabels, intstrPtr(2), nil, 0, 2, 2)
+
+	k8sClient := newFakeClient(sn, pod, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 blocking PDB, got %d", len(result))
+	}
+	if len(result[0].OwnerWorkloads) != 1 || result[0].OwnerWorkloads[0] != "StatefulSet/db-sts" {
+		t.Errorf("expected owner 'StatefulSet/db-sts', got %v", result[0].OwnerWorkloads)
+	}
+}
+
+func TestCheckBlockingPDBs_NoOwner(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	appLabels := map[string]string{"app": "standalone"}
+	pod := newLabeledPod("standalone-pod", "default", "stalled-node", appLabels, nil)
+	pdb := newPDB("standalone-pdb", "default", appLabels, intstrPtr(1), nil, 0, 1, 1)
+
+	k8sClient := newFakeClient(sn, pod, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 blocking PDB, got %d", len(result))
+	}
+	if len(result[0].OwnerWorkloads) != 1 || result[0].OwnerWorkloads[0] != ownerNone {
+		t.Errorf("expected owner 'none', got %v", result[0].OwnerWorkloads)
+	}
+}
+
+func TestCheckBlockingPDBs_MultipleBlockingPDBs(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	webLabels := map[string]string{"app": "web"}
+	dbLabels := map[string]string{"app": "db"}
+	webPod := newLabeledPod("web-1", "default", "stalled-node", webLabels, nil)
+	dbPod := newLabeledPod("db-0", "default", "stalled-node", dbLabels, nil)
+	webPDB := newPDB("web-pdb", "default", webLabels, intstrPtr(2), nil, 0, 2, 2)
+	dbPDB := newPDB("db-pdb", "default", dbLabels, intstrPtr(1), nil, 0, 1, 1)
+
+	k8sClient := newFakeClient(sn, webPod, dbPod, webPDB, dbPDB)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 blocking PDBs, got %d", len(result))
+	}
+	if !strings.Contains(notes.String(), "2 PDB(s) with disruptionsAllowed=0") {
+		t.Errorf("expected '2 PDB(s) with disruptionsAllowed=0' in notes, got: %s", notes.String())
+	}
+}
+
+// --- isPlatformNamespace tests ---
+
+func TestIsPlatformNamespace(t *testing.T) {
+	tests := []struct {
+		namespace string
+		expected  bool
+	}{
+		{"openshift-monitoring", true},
+		{"openshift-ingress", true},
+		{"openshift", true},
+		{"kube-system", true},
+		{"kube-public", true},
+		{"default", false},
+		{"my-app", false},
+		{"production", false},
+		{"openshift-like-app", true},
+		{"not-openshift", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.namespace, func(t *testing.T) {
+			result := isPlatformNamespace(tt.namespace)
+			if result != tt.expected {
+				t.Errorf("isPlatformNamespace(%q) = %v, want %v", tt.namespace, result, tt.expected)
+			}
+		})
+	}
+}
+
+// --- checkBlockingPDBs classification tests ---
+
+func TestCheckBlockingPDBs_CustomerManagedClassification(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	appLabels := map[string]string{"app": "web"}
+	pod := newLabeledPod("web-1", "my-app", "stalled-node", appLabels, nil)
+	pdb := newPDB("web-pdb", "my-app", appLabels, intstrPtr(2), nil, 0, 2, 2)
+
+	k8sClient := newFakeClient(sn, pod, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 blocking PDB, got %d", len(result))
+	}
+	if result[0].IsPlatformManaged {
+		t.Error("expected customer-managed PDB, got platform-managed")
+	}
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "[customer]") {
+		t.Errorf("expected '[customer]' tag in notes, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "customer-managed PDB(s)") {
+		t.Errorf("expected customer remediation guidance in notes, got: %s", noteStr)
+	}
+}
+
+func TestCheckBlockingPDBs_PlatformManagedClassification(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	appLabels := map[string]string{"app": "router"}
+	pod := newLabeledPod("router-1", "openshift-ingress", "stalled-node", appLabels, nil)
+	pdb := newPDB("router-pdb", "openshift-ingress", appLabels, intstrPtr(1), nil, 0, 1, 1)
+
+	k8sClient := newFakeClient(sn, pod, pdb)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 blocking PDB, got %d", len(result))
+	}
+	if !result[0].IsPlatformManaged {
+		t.Error("expected platform-managed PDB, got customer-managed")
+	}
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "[platform]") {
+		t.Errorf("expected '[platform]' tag in notes, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "platform-managed PDB(s)") {
+		t.Errorf("expected platform remediation guidance in notes, got: %s", noteStr)
+	}
+}
+
+func TestCheckBlockingPDBs_MixedClassification(t *testing.T) {
+	sn := newNode("stalled-node", nil)
+	customerLabels := map[string]string{"app": "web"}
+	platformLabels := map[string]string{"app": "router"}
+	customerPod := newLabeledPod("web-1", "my-app", "stalled-node", customerLabels, nil)
+	platformPod := newLabeledPod("router-1", "openshift-ingress", "stalled-node", platformLabels, nil)
+	customerPDB := newPDB("web-pdb", "my-app", customerLabels, intstrPtr(2), nil, 0, 2, 2)
+	platformPDB := newPDB("router-pdb", "openshift-ingress", platformLabels, intstrPtr(1), nil, 0, 1, 1)
+
+	k8sClient := newFakeClient(sn, customerPod, platformPod, customerPDB, platformPDB)
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	stalledNodes := []stalledNode{{Node: *sn}}
+	result := inv.checkBlockingPDBs(context.Background(), k8sClient, stalledNodes, notes)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 blocking PDBs, got %d", len(result))
+	}
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "customer-managed PDB(s)") {
+		t.Errorf("expected customer remediation guidance in notes, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "platform-managed PDB(s)") {
+		t.Errorf("expected platform remediation guidance in notes, got: %s", noteStr)
+	}
+}
+
+// --- resolveWorkloadOwner tests ---
+
+func TestResolveWorkloadOwner_DeploymentViaReplicaSet(t *testing.T) {
+	rs := newReplicaSet("deploy-abc-123", "default", "my-deploy")
+	k8sClient := newFakeClient(rs)
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deploy-abc-123-xyz",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "deploy-abc-123", APIVersion: "apps/v1"},
+			},
+		},
+	}
+
+	owner := resolveWorkloadOwner(context.Background(), k8sClient, pod)
+	if owner != "Deployment/my-deploy" {
+		t.Errorf("expected 'Deployment/my-deploy', got %q", owner)
+	}
+}
+
+func TestResolveWorkloadOwner_StandaloneReplicaSet(t *testing.T) {
+	rs := newReplicaSet("standalone-rs", "default", "")
+	k8sClient := newFakeClient(rs)
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "standalone-rs-xyz",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "standalone-rs", APIVersion: "apps/v1"},
+			},
+		},
+	}
+
+	owner := resolveWorkloadOwner(context.Background(), k8sClient, pod)
+	if owner != "ReplicaSet/standalone-rs" {
+		t.Errorf("expected 'ReplicaSet/standalone-rs', got %q", owner)
+	}
+}
+
+func TestResolveWorkloadOwner_StatefulSet(t *testing.T) {
+	k8sClient := newFakeClient()
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db-0",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "StatefulSet", Name: "db", APIVersion: "apps/v1"},
+			},
+		},
+	}
+
+	owner := resolveWorkloadOwner(context.Background(), k8sClient, pod)
+	if owner != "StatefulSet/db" {
+		t.Errorf("expected 'StatefulSet/db', got %q", owner)
+	}
+}
+
+func TestResolveWorkloadOwner_NoneWhenNoOwner(t *testing.T) {
+	k8sClient := newFakeClient()
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "standalone", Namespace: "default"},
+	}
+
+	owner := resolveWorkloadOwner(context.Background(), k8sClient, pod)
+	if owner != ownerNone {
+		t.Errorf("expected 'none', got %q", owner)
+	}
+}
+
+// --- assessScaling tests ---
+
+func TestAssessScaling(t *testing.T) {
+	tests := []struct {
+		name           string
+		bp             blockingPDB
+		expectCanScale bool
+		expectContains string
+	}{
+		{
+			name: "maxUnavailable=0 integer",
+			bp: blockingPDB{
+				MaxUnavailable: "0",
+				ExpectedPods:   3,
+				CurrentHealthy: 3,
+			},
+			expectCanScale: false,
+			expectContains: "maxUnavailable=0 forbids all disruptions",
+		},
+		{
+			name: "maxUnavailable=0%",
+			bp: blockingPDB{
+				MaxUnavailable: "0%",
+				ExpectedPods:   3,
+				CurrentHealthy: 3,
+			},
+			expectCanScale: false,
+			expectContains: "maxUnavailable=0 forbids all disruptions",
+		},
+		{
+			name: "maxUnavailable>0 with unhealthy pods",
+			bp: blockingPDB{
+				MaxUnavailable: "1",
+				ExpectedPods:   3,
+				CurrentHealthy: 2,
+			},
+			expectCanScale: false,
+			expectContains: "unhealthy pods must recover",
+		},
+		{
+			name: "minAvailable=100%",
+			bp: blockingPDB{
+				MinAvailable:   "100%",
+				ExpectedPods:   3,
+				CurrentHealthy: 3,
+			},
+			expectCanScale: false,
+			expectContains: "minAvailable=100%",
+		},
+		{
+			name: "minAvailable all healthy — scaling helps",
+			bp: blockingPDB{
+				MinAvailable:   "2",
+				ExpectedPods:   2,
+				CurrentHealthy: 2,
+			},
+			expectCanScale: true,
+			expectContains: "would unblock the drain",
+		},
+		{
+			name: "minAvailable some unhealthy",
+			bp: blockingPDB{
+				MinAvailable:   "3",
+				ExpectedPods:   4,
+				CurrentHealthy: 3,
+			},
+			expectCanScale: true,
+			expectContains: "1 of 4 pod(s) currently unhealthy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, canScale := assessScaling(tt.bp)
+			if canScale != tt.expectCanScale {
+				t.Errorf("expected canScale=%v, got %v", tt.expectCanScale, canScale)
+			}
+			if !strings.Contains(result, tt.expectContains) {
+				t.Errorf("expected to contain %q, got: %s", tt.expectContains, result)
+			}
+		})
+	}
+}
+
+// --- checkScalingAssessment tests ---
+
+func TestCheckScalingAssessment_NoPDBs(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	inv.checkScalingAssessment(nil, 0, notes)
+
+	if strings.Contains(notes.String(), "Scaling Assessment") {
+		t.Errorf("expected no scaling notes for nil PDBs, got: %s", notes.String())
+	}
+}
+
+func TestCheckScalingAssessment_ScalableAndNotScalable(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	pdbs := []blockingPDB{
+		{
+			Namespace:      "app-ns",
+			Name:           "scalable-pdb",
+			MinAvailable:   "2",
+			ExpectedPods:   2,
+			CurrentHealthy: 2,
+		},
+		{
+			Namespace:      "db-ns",
+			Name:           "stuck-pdb",
+			MaxUnavailable: "0",
+			ExpectedPods:   3,
+			CurrentHealthy: 3,
+		},
+	}
+
+	inv.checkScalingAssessment(pdbs, 0, notes)
+
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "1 PDB(s) can be unblocked by scaling") {
+		t.Errorf("expected scalable note, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "1 PDB(s) cannot be unblocked by scaling") {
+		t.Errorf("expected not-scalable note, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "app-ns/scalable-pdb") {
+		t.Errorf("expected scalable PDB name in notes, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "db-ns/stuck-pdb") {
+		t.Errorf("expected stuck PDB name in notes, got: %s", noteStr)
+	}
+}
+
+func TestCheckScalingAssessment_AllScalable(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	pdbs := []blockingPDB{
+		{
+			Namespace:      "app-ns",
+			Name:           "web-pdb",
+			MinAvailable:   "3",
+			ExpectedPods:   3,
+			CurrentHealthy: 3,
+		},
+	}
+
+	inv.checkScalingAssessment(pdbs, 0, notes)
+
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "1 PDB(s) can be unblocked by scaling") {
+		t.Errorf("expected scalable note, got: %s", noteStr)
+	}
+	if strings.Contains(noteStr, "cannot be unblocked") {
+		t.Errorf("did not expect not-scalable note, got: %s", noteStr)
+	}
+}
+
+func TestCheckScalingAssessment_UnhealthyNodesCaveat(t *testing.T) {
+	notes := newTestNotes()
+	inv := &Investigation{}
+
+	pdbs := []blockingPDB{
+		{
+			Namespace:      "app-ns",
+			Name:           "web-pdb",
+			MinAvailable:   "2",
+			ExpectedPods:   2,
+			CurrentHealthy: 2,
+		},
+	}
+
+	inv.checkScalingAssessment(pdbs, 2, notes)
+
+	noteStr := notes.String()
+	if !strings.Contains(noteStr, "1 PDB(s) can be unblocked by scaling") {
+		t.Errorf("expected scalable note, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "2 non-draining node(s) are unhealthy") {
+		t.Errorf("expected unhealthy node caveat, got: %s", noteStr)
+	}
+	if !strings.Contains(noteStr, "new replicas may not schedule") {
+		t.Errorf("expected scheduling warning, got: %s", noteStr)
+	}
+}

--- a/pkg/investigations/pdbblockingnodedrain/testing/README.md
+++ b/pkg/investigations/pdbblockingnodedrain/testing/README.md
@@ -1,0 +1,184 @@
+# Testing the pdbblockingnodedrain Investigation
+
+This document describes how to test the pdbblockingnodedrain investigation end-to-end in a local environment.
+
+## Overview
+
+This investigation is triggered by the `HCPNodepoolUpgradeDelay` alert and:
+1. Identifies nodes stuck in a draining state (>10 minutes)
+2. Enumerates PDBs with `disruptionsAllowed=0` whose pods are on stalled nodes
+3. Classifies blocking PDBs as customer-managed or platform-managed
+4. Checks non-draining node health (NotReady, resource pressure)
+5. Assesses whether scaling the workload would unblock the drain
+
+## Prerequisites
+
+### Environment Requirements
+- **Cluster**: HCP cluster with at least 2 worker nodes
+- **Access**: Cluster must be accessible via backplane/OCM
+- **Environment Variables**: Set up via `source test/set_stage_env.sh`
+- **Local Backplane API**: Start local backplane instance:
+  ```bash
+  OCM_BACKPLANE_REPO_PATH=<PATH/TO/BACKPLANE>/backplane-api ./test/launch_local_env.sh
+  ```
+
+### Build the Binary
+```bash
+make build
+```
+
+## Unit Testing
+
+```bash
+make test-cadctl
+```
+
+## Manual Testing
+
+### Step 1: Create the Test Workload
+
+Create a deployment with 2 replicas and a PDB that blocks all disruptions:
+
+```bash
+oc new-project pdb-test
+```
+
+```bash
+oc create deployment drain-blocker --image=registry.access.redhat.com/ubi9/ubi-minimal:latest --replicas=2 -- sleep infinity
+```
+
+Wait for pods to be running:
+
+```bash
+oc get pods -n pdb-test -w
+```
+
+### Step 2: Create a Blocking PDB
+
+```bash
+cat <<'EOF' | oc create -f -
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: drain-blocker-pdb
+  namespace: pdb-test
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: drain-blocker
+EOF
+```
+
+Verify the PDB shows `ALLOWED DISRUPTIONS: 0`:
+
+```bash
+oc get pdb -n pdb-test
+```
+
+### Step 3: Cordon a Node to Simulate Drain Stall
+
+Identify the node running the pods:
+
+```bash
+oc get pods -n pdb-test -o wide
+```
+
+Cordon the node (replace with the actual node name):
+
+```bash
+oc cordon <node-name>
+```
+
+Wait at least 10 minutes for the drain stall threshold to be exceeded.
+
+### Step 4: Generate Test Incident
+
+```bash
+./test/generate_incident.sh HCPNodepoolUpgradeDelay <cluster-id>
+```
+
+### Step 5: Run the Investigation
+
+```bash
+source test/set_stage_env.sh
+```
+
+```bash
+BACKPLANE_URL=https://localhost:8443 \
+HTTP_PROXY=http://127.0.0.1:8888 \
+HTTPS_PROXY=http://127.0.0.1:8888 \
+BACKPLANE_PROXY=http://127.0.0.1:8888 \
+./bin/cadctl investigate --payload-path ./payload --log-level debug
+```
+
+### Step 6: Verify Results
+
+The PagerDuty note should contain:
+
+1. **Draining Nodes** — reports the stalled node and drain duration
+2. **Blocking PDBs** — reports `pdb-test/drain-blocker-pdb` as a customer-managed PDB with `disruptionsAllowed=0`, listing the owner workload and pod names
+3. **Node Health** — reports whether non-draining nodes are healthy
+4. **Scaling Assessment** — reports that scaling up by 1 replica would unblock the drain
+5. **Remediation** — suggests the customer should relax the PDB or scale the workload
+
+Example output:
+```
+⚠️ Draining Nodes: 1/1 draining node(s) stalled (>10m0s):
+  <node-name>: draining for <duration>
+⚠️ Blocking PDBs: 1 PDB(s) with disruptionsAllowed=0 affecting pods on stalled nodes:
+  pdb-test/drain-blocker-pdb [customer] (minAvailable: 2, healthy: 2/2)
+    Owner: Deployment/drain-blocker
+    Pods on draining nodes: drain-blocker-xxx, drain-blocker-yyy
+✅ Node Health: all non-draining nodes are Ready with no resource pressure
+⚠️ Scaling Assessment: 1 PDB(s) can be unblocked by scaling:
+  pdb-test/drain-blocker-pdb: scaling up by 1 replica would unblock the drain (healthy: 2, minAvailable: 2)
+⚠️ Remediation: 1 customer-managed PDB(s) — customer should relax the PDB or scale the workload to allow disruptions
+```
+
+### Step 7: Test Scaling Fix
+
+Scale up the deployment to verify the drain unblocks:
+
+```bash
+oc scale deployment/drain-blocker -n pdb-test --replicas=3
+```
+
+Re-run the investigation. The PDB should no longer be reported as blocking.
+
+### Step 8: Cleanup
+
+```bash
+oc delete namespace pdb-test
+```
+
+```bash
+oc uncordon <node-name>
+```
+
+## Testing Variants
+
+### Well-configured PDB (should not block)
+
+Use `maxUnavailable: 1` instead of `minAvailable: 2`:
+
+```bash
+cat <<'EOF' | oc create -f -
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: drain-blocker-pdb
+  namespace: pdb-test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: drain-blocker
+EOF
+```
+
+This PDB allows 1 disruption, so the investigation should report no blocking PDBs.
+
+### Platform-managed PDB
+
+Deploy a workload in an `openshift-*` namespace to test platform classification. The investigation should report it as `[platform]` with guidance to escalate to engineering.

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/mustgather"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/ocmagentresponsefailure"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/pdbblockingnodedrain"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/restartcontrolplane"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/upgradeconfigsyncfailureover4hr"
 )
@@ -40,6 +41,7 @@ var availableInvestigations = []investigation.Investigation{
 	&clusterhealthcheck.Investigation{},
 	&consoleerrorbudgetburn.Investigation{},
 	&expiredcertificates.Investigation{},
+	&pdbblockingnodedrain.Investigation{},
 }
 
 // GetInvestigation returns the first Investigation that applies to the given alert title.

--- a/test/generate_incident.sh
+++ b/test/generate_incident.sh
@@ -17,6 +17,7 @@ declare -A alert_mapping=(
     ["OCMAgentResponseFailureServiceLogsSRE"]="OCMAgentResponseFailureServiceLogsSRE CRITICAL (1)"
     ["ExpiredCertificates"]="expiredcertificates"
     ["FallbackTestAlert"]="FallbackTestAlert"
+    ["HCPNodepoolUpgradeDelay"]="HCPNodepoolUpgradeDelay"
 )
 
 # Function to print help message


### PR DESCRIPTION
What type of PR is this?

feature

### What this PR does / Why we need it?

Adds a new investigation pdbblockingnodedrain for the HCPNodepoolUpgradeDelay alert ([ROSAENG-14105](https://redhat.atlassian.net/browse/ROSAENG-14105)). When a node drain stalls during an HCP cluster upgrade, this investigation automatically identifies which PodDisruptionBudgets are blocking eviction, classifies them as customer-managed or  platform-managed, checks node health, and assesses whether scaling the workload would unblock the drain.
                                                                                                                                                                                                                                                                                                                    
 Investigation steps:                                                                                                                                                                                                                                                                                              
 1. Draining nodes — identifies nodes with the unschedulable taint stalled longer than 10 minutes
 2. Blocking PDBs — enumerates PDBs with disruptionsAllowed=0 whose selected pods are on stalled nodes, resolves owner workloads (Deployment, StatefulSet, etc.), and classifies each as customer or platform-managed                                                                                              
 3. Node health — checks non-draining nodes for NotReady or resource pressure conditions that would prevent rescheduling                                                                                             
 4. Scaling assessment — for each blocking PDB, evaluates whether scaling up the workload would unblock the drain without requiring a PDB change            

### Special notes for your reviewer

 1. Eviction event correlation (ticket step 2) intentionally omitted. These events live on the management cluster. Accessing them requires RHOBS integration (potentially done blocked by [ROSAENG-15920](https://redhat.atlassian.net/browse/ROSAENG-15920)) and MC-to-RHOBS log forwarding on staging (not yet available). The blocking PDB check already provides definitive detection via disruptionsAllowed=0 + pod-to-node correlation, making event correlation supplementary.                                                                         
 2. API server audit log check (also ticket step 2) covered by the same reasoning. Audit logs showing rejected eviction requests would live on the management cluster and require the same RHOBS integration.                                                                                                      
 3. Node health check added (not in original ticket). During testing, I identified that scaling recommendations could be misleading if non-draining nodes are unhealthy. The investigation now checks node health and qualifies the scaling assessment accordingly.                                               
 4. Scheduling constraints not checked (future improvement). Pod scheduling constraints (anti-affinity, node selectors, resource limits) can prevent evicted pods from rescheduling, causing disruptionsAllowed to stay at 0. The investigation catches this state but does not diagnose why rescheduling failed.  
 The scaling assessment messaging hints at possible causes to guide SREs.                                                                                                                                                                                                                                          
 5. Should also run for UpgradeNodeDrainFailedSRE alert. This investigation is equally applicable to that alert. Adding multi-alert support per investigation is feasible once [ROSAENG-59444](https://redhat.atlassian.net/browse/ROSAENG-59444) is done.    

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [x] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR


[ROSAENG-14105]: https://redhat.atlassian.net/browse/ROSAENG-14105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-15920]: https://redhat.atlassian.net/browse/ROSAENG-15920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new investigation to detect node-drain stalls during upgrades by correlating stalled nodes with blocking PodDisruptionBudgets, including scaling-based mitigation guidance.
  * Registered the investigation for discoverability and enabled incident generation for the related upgrade-delay alert.
* **Documentation**
  * Added an end-to-end runbook with escalation guidance and local testing instructions.
* **Tests**
  * Added extensive unit test coverage for drain detection, PDB correlation/classification, node health handling, and scaling assessment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->