### PR TITLE
ROSAENG-15456: add per-investigation-type 'triage acceleration' Grafa…

### DIFF
--- a/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
+++ b/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
@@ -390,6 +390,72 @@ data:
             "type": "prometheus",
             "uid": "${cad_ds}"
           },
+          "description": "Estimated SRE hours saved through triage acceleration by informational investigations. Uses per-investigation manual-time estimates: consoleerrorbudgetburn=25min, expiredcertificates=20min, pdbblockingnodedrain=20min.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 23,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${cad_ds}"
+              },
+              "editorMode": "code",
+              "expr": "((sum(increase(cad_investigate_alerts_total{alert_type=\"consoleerrorbudgetburn\"}[$__range])) OR on() vector(0)) * 25 + (sum(increase(cad_investigate_alerts_total{alert_type=\"expiredcertificates\"}[$__range])) OR on() vector(0)) * 20 + (sum(increase(cad_investigate_alerts_total{alert_type=\"pdbblockingnodedrain\"}[$__range])) OR on() vector(0)) * 20) / 60",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Estimated SRE hours saved (triage acceleration)",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${cad_ds}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -410,7 +476,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 25
           },
           "id": 12,
           "options": {
@@ -482,7 +548,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 25
           },
           "id": 18,
           "options": {
@@ -553,7 +619,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 33
           },
           "id": 13,
           "options": {
@@ -624,7 +690,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 33
           },
           "id": 17,
           "options": {
@@ -717,7 +783,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 41
           },
           "id": 21,
           "options": {


### PR DESCRIPTION
…na dashboard panel

### What type of PR is this?

feature

### What this PR does / Why we need it?

Adds a new Grafana dashboard panel titled "Estimated SRE hours saved (triage acceleration)" to the existing CAD dashboard. The existing "Estimated SRE hours saved" panel only counts prevented alerts (where CAD took a terminal action like setting limited support or sending a service log) using a flat      
  15-minute heuristic. The three new informational investigations from [SREP-4516](https://redhat.atlassian.net/browse/SREP-4516) accelerate triage but don't prevent pages — their value isn't captured by the existing panel.                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  The new panel computes estimated hours saved using per-investigation manual-time estimates:                                                                                                                                                                                                                       
  - consoleerrorbudgetburn — 25 min/alert ([SREP-4517](https://redhat.atlassian.net/browse/ROSAENG-14111))
  - expiredcertificates — 20 min/alert ([SREP-4521](https://redhat.atlassian.net/browse/ROSAENG-5561))                                                                                                                                                                                                                                                                  
  - pdbblockingnodedrain — 20 min/alert ([SREP-4522](https://redhat.atlassian.net/browse/ROSAENG-14105))                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                    
  Each term uses OR on() vector(0) to gracefully handle investigation types that have no metric data yet (e.g., pdbblockingnodedrain is not yet merged).                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
  Resolves https://redhat.atlassian.net/browse/ROSAENG-15456   

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new stat panel, **“Estimated SRE hours saved (triage acceleration)”**, to the anomaly detection dashboard to estimate saved SRE time based on investigation activity.

* **UI Updates**
  * Reorganized existing dashboard panels to make space for the new visualization, adjusting their layout positions accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->