### PR TITLE
Add manual runs graph to cad dashboard

### DIFF
--- a/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
+++ b/dashboards/grafana-dashboard-configuration-anomaly-detection.configmap.yaml
@@ -749,7 +749,106 @@ data:
           ],
           "title": "Must-Gather Success Rate",
           "type": "gauge"
-        }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${cad_ds}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 23,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${cad_ds}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (alert_type, dry_run)( increase(cad_investigate_manual_started_total[7d]) )",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Manual CAD runs",
+          "type": "timeseries"
+        },
       ],
       "refresh": false,
       "schemaVersion": 37,


### PR DESCRIPTION
### What type of PR is this?

Feature, adds new graph to grafana dashboard

### What this PR does / Why we need it?

Add our ability to see how many times CAD was run manually

<img width="743" height="302" alt="image" src="https://github.com/user-attachments/assets/717c2466-2944-474e-9fb4-981f4456e85b" />



Jira: https://redhat.atlassian.net/browse/ROSAENG-14101

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Manual CAD runs" monitoring panel to the Grafana anomaly detection dashboard. This panel visualizes manual anomaly detection execution metrics with customizable line-style display options, enhanced legend configuration, and interactive tooltips to provide better insights into manual detection activities and performance trends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->