### PR TITLE
ROSAENG-59441: Filter out MCs, SCs, hive shards for ai investigation

### DIFF
--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -65,6 +65,20 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		return result, nil
 	}
 
+	// Check if this is a management cluster (management cluster, service cluster, or hive shard)
+	isManagingCluster, err := r.OcmClient.IsManagingCluster(clusterID)
+	if err != nil {
+		logging.Warnf("Failed to check if cluster is a management cluster: %v", err)
+		// Continue anyway - if we can't determine, we'll proceed with investigation
+	} else if isManagingCluster {
+		notes.AppendWarning("Management/Service cluster - skipping AI investigation")
+		result.Actions = append(
+			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
+			executor.Escalate("Cluster is a management/service cluster - AI investigation not supported"),
+		)
+		return result, nil
+	}
+
 	if c.AIConfig == nil {
 		notes.AppendWarning("AI agent runtime configuration not set (ai_agent section missing from config)")
 		result.Actions = append(

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -65,12 +65,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		return result, nil
 	}
 
-	// Check if this is a management cluster (management cluster, service cluster, or hive shard)
-	isManagingCluster, err := r.OcmClient.IsManagingCluster(clusterID)
-	if err != nil {
-		logging.Warnf("Failed to check if cluster is a management cluster: %v", err)
-		// Continue anyway - if we can't determine, we'll proceed with investigation
-	} else if isManagingCluster {
+	if r.IsInfrastructureCluster {
 		notes.AppendWarning("Management/Service cluster - skipping AI investigation")
 		result.Actions = append(
 			executor.NoteAndReportFrom(notes, clusterID, c.Name()),

--- a/pkg/investigations/aiassisted/aiassisted_test.go
+++ b/pkg/investigations/aiassisted/aiassisted_test.go
@@ -93,10 +93,9 @@ var _ = Describe("aiassisted", func() {
 	Describe("Run", func() {
 		Context("when cluster is a management cluster", func() {
 			It("should skip AI investigation and escalate", func() {
-				mockOcmClient := r.Resources.OcmClient.(*ocmmock.MockClient)
-				mockOcmClient.EXPECT().IsManagingCluster(gomock.Any()).Return(true, nil)
+				r.Resources.IsInfrastructureCluster = true
 
-				inv := Investigation{AIConfig: nil}
+				inv := Investigation{}
 				result, err := inv.Run(r)
 
 				Expect(err).ToNot(HaveOccurred())
@@ -108,10 +107,7 @@ var _ = Describe("aiassisted", func() {
 
 		Context("when AI runtime configuration is nil", func() {
 			It("should escalate with configuration warning", func() {
-				mockOcmClient := r.Resources.OcmClient.(*ocmmock.MockClient)
-				mockOcmClient.EXPECT().IsManagingCluster(gomock.Any()).Return(false, nil)
-
-				inv := Investigation{AIConfig: nil}
+				inv := Investigation{}
 				result, err := inv.Run(r)
 
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/investigations/aiassisted/aiassisted_test.go
+++ b/pkg/investigations/aiassisted/aiassisted_test.go
@@ -91,8 +91,26 @@ var _ = Describe("aiassisted", func() {
 	})
 
 	Describe("Run", func() {
+		Context("when cluster is a management cluster", func() {
+			It("should skip AI investigation and escalate", func() {
+				mockOcmClient := r.Resources.OcmClient.(*ocmmock.MockClient)
+				mockOcmClient.EXPECT().IsManagingCluster(gomock.Any()).Return(true, nil)
+
+				inv := Investigation{AIConfig: nil}
+				result, err := inv.Run(r)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.Actions).NotTo(BeEmpty())
+				Expect(hasEscalateAction(result.Actions)).To(BeTrue())
+				Expect(hasNoteAction(result.Actions)).To(BeTrue())
+			})
+		})
+
 		Context("when AI runtime configuration is nil", func() {
 			It("should escalate with configuration warning", func() {
+				mockOcmClient := r.Resources.OcmClient.(*ocmmock.MockClient)
+				mockOcmClient.EXPECT().IsManagingCluster(gomock.Any()).Return(false, nil)
+
 				inv := Investigation{AIConfig: nil}
 				result, err := inv.Run(r)
 


### PR DESCRIPTION
### What type of PR is this?
bug fix

### What this PR does / Why we need it?
 Prevents AI-assisted investigations from running on infrastructure clusters
  (management clusters, service clusters, and Hive shards).

  AI investigations are designed for customer workloads and can be
  resource-intensive. Infrastructure clusters have different operational
  profiles and should escalate to SRE instead of attempting automated AI
  investigation.

  This PR adds early-exit logic to the `aiassisted` investigation that:
  - Checks if the cluster is an infrastructure cluster using the framework's
  `IsInfrastructureCluster` field
  - Escalates with a warning note instead of running AI investigation
  - Reuses the infrastructure detection already performed by
  `ResourceBuilder.Build()` (avoiding duplicate OCM API calls)

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ x ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ x ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Management/infrastructure clusters now skip AI-assisted investigation analysis and instead trigger an immediate escalation with a “not supported” status, along with the related warning and notification actions.

* **Tests**
  * Added coverage for management cluster handling to confirm escalation and notification actions are produced.
  * Updated the AI configuration nil scenario to use the zero-value investigation setup while preserving existing assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->