### PR TITLE
Fix aiassisted double escalation

### DIFF
--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -57,14 +57,18 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	clusterID := r.Cluster.ID()
 
 	if r.IsHCP {
+		notes.AppendWarning("HCP cluster - skipping AI investigation")
 		result.Actions = []executor.Action{
+			executor.NoteFrom(notes),
 			executor.Escalate("Cluster is HCP - AI investigation not supported"),
 		}
 		return result, nil
 	}
 
 	if r.IsInfrastructureCluster {
+		notes.AppendWarning("Management/Service cluster - skipping AI investigation")
 		result.Actions = []executor.Action{
+			executor.NoteFrom(notes),
 			executor.Escalate("Cluster is a management/service cluster - AI investigation not supported"),
 		}
 		return result, nil

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -215,7 +215,6 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	result.Actions = []executor.Action{
 		executor.NoteFrom(notes), // Send automation message to PagerDuty
 		backplaneReportAction,    // Create cluster report with AI investigation results
-		executor.Escalate("AI investigation completed - see cluster report for details"),
 	}
 	return result, nil
 }

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -57,20 +57,16 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	clusterID := r.Cluster.ID()
 
 	if r.IsHCP {
-		notes.AppendWarning("HCP cluster - skipping AI investigation")
-		result.Actions = append(
-			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
+		result.Actions = []executor.Action{
 			executor.Escalate("Cluster is HCP - AI investigation not supported"),
-		)
+		}
 		return result, nil
 	}
 
 	if r.IsInfrastructureCluster {
-		notes.AppendWarning("Management/Service cluster - skipping AI investigation")
-		result.Actions = append(
-			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
+		result.Actions = []executor.Action{
 			executor.Escalate("Cluster is a management/service cluster - AI investigation not supported"),
-		)
+		}
 		return result, nil
 	}
 


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / Why we need it?
Fixes double paging issue in the AI-assisted investigation and where AI investigation is not supported, removed unnecessary  backplane reports.
### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
