### PR TITLE
Remove requirement for aiassisted investigation to have filters

### DIFF
--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -283,7 +283,7 @@ filters:
 			expectResult: true,
 		},
 		{
-			name: "aiassisted with no filter tree — AI disabled (filter required)",
+			name: "aiassisted with no filter tree — AI enabled (no filtering)",
 			filterYAML: `
 ai_agent:
   runtime_arn: "arn:test"
@@ -293,7 +293,7 @@ ai_agent:
 filters:
   - investigation: aiassisted
 `,
-			expectResult: false,
+			expectResult: true,
 		},
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -247,14 +247,7 @@ func (c *Config) Validate(validInvestigations []string) error {
 			if c.AIAgent == nil {
 				return fmt.Errorf("filters[%d]: investigation %q requires ai_agent configuration", i, f.Investigation)
 			}
-			if f.Filter == nil {
-				return fmt.Errorf("filters[%d]: investigation %q requires filters for now", i, f.Investigation)
-			}
 		}
-	}
-
-	if _, ok := seen["aiassisted"]; !ok && c.AIAgent != nil {
-		return fmt.Errorf("aiassisted investigation *must* specify valid filters for now: either add filtering or remove 'ai_agent' config")
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -420,18 +420,14 @@ filters:
       field: CloudProvider
       operator: in
       values: ["aws"]
-  - investigation: aiassisted
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
 				if cfg.AIAgent == nil {
 					t.Fatal("expected ai_agent config, got nil")
 				}
 				f := cfg.GetFilter("aiassisted")
-				if f == nil {
-					t.Fatal("expected aiassisted filter entry, got nil")
-				}
-				if f.Filter != nil {
-					t.Errorf("expected nil filter tree (no filtering), got %+v", f.Filter)
+				if f != nil {
+					t.Errorf("expected nil filter for absent aiassisted entry, got %+v", f)
 				}
 			},
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -383,28 +383,57 @@ filters:
 			wantErr: true,
 		},
 		{
-			name: "aiassisted without filter is invalid",
+			name: "aiassisted without filter is valid now",
 			yaml: `
 ai_agent:
   runtime_arn: "arn:test"
   user_id: "user"
   region: "us-east-1"
+  invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
 filters:
   - investigation: aiassisted
 `,
-			wantErr: true,
+			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
+				if cfg.AIAgent == nil {
+					t.Fatal("expected ai_agent config, got nil")
+				}
+				f := cfg.GetFilter("aiassisted")
+				if f == nil {
+					t.Fatal("expected aiassisted filter entry, got nil")
+				}
+				if f.Filter != nil {
+					t.Errorf("expected nil filter tree (no filtering), got %+v", f.Filter)
+				}
+			},
 		},
 		{
-			name: "ai_agent without aiassisted filter entry is invalid",
+			name: "ai_agent without aiassisted filter entry is valid now",
 			yaml: `
 ai_agent:
   runtime_arn: "arn:test"
   user_id: "user"
   region: "us-east-1"
+  invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
 filters:
   - investigation: mustgather
+    when:
+      field: CloudProvider
+      operator: in
+      values: ["aws"]
+  - investigation: aiassisted
 `,
-			wantErr: true,
+			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
+				if cfg.AIAgent == nil {
+					t.Fatal("expected ai_agent config, got nil")
+				}
+				f := cfg.GetFilter("aiassisted")
+				if f == nil {
+					t.Fatal("expected aiassisted filter entry, got nil")
+				}
+				if f.Filter != nil {
+					t.Errorf("expected nil filter tree (no filtering), got %+v", f.Filter)
+				}
+			},
 		},
 		// --- sample operator tests ---
 		{


### PR DESCRIPTION
Previously, the config validation required aiassisted investigations to always have filters defined. This was a temporary safety measure (noted by "for now" in error messages) that prevented expanding AI coverage.

This change removes two validation checks:
1. The check that aiassisted investigations must have a non-nil filter
2. The check that ai_agent config must have a corresponding aiassisted filter entry

This allows configurations to run AI investigations on ALL alerts without filtering, which is required for expanding CORA coverage to all classic clusters and eventually HCP clusters.

Updated tests to verify that aiassisted without filters is now valid.

Related to: [ROSAENG-60514](https://redhat.atlassian.net/browse/ROSAENG-60514)

### What type of PR is this?

(feature/bug/documentation/other)

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


[ROSAENG-60514]: https://redhat.atlassian.net/browse/ROSAENG-60514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation for AI-assisted investigations.
  * Configurations with an AI agent enabled are now accepted even if the AI-assisted filter entry is missing or incomplete.
  * Existing AI-assisted filter entries still require the AI agent setting to be present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->