### PR TITLE
Multi-investigation support; deprecate registry-based configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ To add a new alert investigation:
   ```
 - The returned `Resources` struct contains initialized clients and cluster objects. See [Integrations](#integrations) for a full list of available resources.
 - Add test objects or scripts used to recreate the alert symptoms to the `pkg/investigations/$INVESTIGATION_NAME/testing/` directory for future use. Be sure to clearly document the testing procedure under the `Testing` section of the investigation-specific README.md file
+- Add an entry for the new investigation to `test/e2e/e2e-investigation-config.yaml` so the e2e tests cover it. This file is embedded into the e2e test binary and defines which alert titles are triggered during end-to-end testing.
 
 ### Graduating an investigation
 

--- a/README.md
+++ b/README.md
@@ -306,4 +306,4 @@ For Red Hat employees, these environment variables can be found in the SRE-P vau
 
 ### Configuration File
 
-CAD now also has a configuration file and over time the environment variables will be moved to this file - for the supported fields at any time see the example configuration with comments in [./docs/investigation-filter-config.example.yaml](./docs/investigation-filter-config.example.yaml "this file").
+CAD now also has a configuration file and over time the environment variables will be moved to this file - for the supported fields at any time see the example configuration with comments in [./docs/investigation-config.example.yaml](./docs/investigation-config.example.yaml "this file").

--- a/cadctl/cmd/investigate/investigate.go
+++ b/cadctl/cmd/investigate/investigate.go
@@ -42,7 +42,7 @@ var (
 func init() {
 	InvestigateCmd.Flags().StringVarP(&payloadPath, "payload-path", "p", payloadPath, "the path to the payload, defaults to './payload.json'")
 	InvestigateCmd.Flags().StringVarP(&logLevelFlag, "log-level", "l", "", "the log level [debug,info,warn,error,fatal], default = info")
-	InvestigateCmd.Flags().StringVar(&configPath, "config", "", "path to investigation filter config file (overrides CAD_INVESTIGATION_CONFIG_PATH)")
+	InvestigateCmd.Flags().StringVar(&configPath, "config", "", "path to investigation config file (overrides CAD_INVESTIGATION_CONFIG_PATH)")
 
 	if envLogLevel, exists := os.LookupEnv("LOG_LEVEL"); exists {
 		logLevelFlag = envLogLevel

--- a/cadctl/cmd/manual/manual.go
+++ b/cadctl/cmd/manual/manual.go
@@ -31,7 +31,7 @@ func NewManualCmd() (*cobra.Command, error) {
 	cmd.Flags().StringVarP(&investigationFlag, "investigation", "i", "", "the investigation to run manually")
 	cmd.Flags().BoolVarP(&dryRunFlag, "dry-run", "d", false, "run investigation without performing any external operations")
 	cmd.Flags().BoolVar(&withFilteringFlag, "with-filtering", false, "evaluate investigation filters during manual runs (default: filters are bypassed)")
-	cmd.Flags().StringVar(&configPath, "config", "", "path to investigation filter config file (overrides CAD_INVESTIGATION_CONFIG_PATH)")
+	cmd.Flags().StringVar(&configPath, "config", "", "path to investigation config file (overrides CAD_INVESTIGATION_CONFIG_PATH)")
 	cmd.Flags().StringArrayVarP(&paramsFlag, "params", "p", nil, "investigation-specific parameters as KEY=VALUE (can be specified multiple times)")
 	err := cmd.MarkFlagRequired("cluster-id")
 	if err != nil {

--- a/docs/investigation-config.example.yaml
+++ b/docs/investigation-config.example.yaml
@@ -100,16 +100,12 @@
 # AI investigation guards:
 #   1. The `ai_agent` section must be present — without it, any alert
 #      referencing `aiassisted` is rejected at config validation time.
-#   2. Every `aiassisted` entry must have a `when` filter — either
-#      on the alert itself or on the entry. This prevents uncontrolled AI
-#      execution. Configs without a filter are rejected at validation time.
-#   3. The `CAD_EXPERIMENTAL_ENABLED=true` env var must be set for the
-#      AI fallback path (unmatched alerts) to trigger. Alerts explicitly
-#      configured do not require this env var unless
-#      they are marked `experimental: true`.
-#   4. At runtime, the `when` filter is evaluated against real cluster data
-#      (org ID, cluster ID, cloud provider, etc.) to decide whether AI
-#      actually runs for a given cluster.
+#   2. The AI fallback path (unmatched alerts) triggers whenever the
+#      `ai_agent` section is configured, without requiring
+#      `CAD_EXPERIMENTAL_ENABLED=true`.
+#   3. At runtime, any `when` filter on the alert or entry is evaluated
+#      against real cluster data (org ID, cluster ID, cloud provider, etc.)
+#      to decide whether AI actually runs for a given cluster.
 #
 # ai_agent:
 #   runtime_arn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/rosasreai_stage-abc123"
@@ -232,8 +228,7 @@ alerts:
 
   # AI-assisted investigation example
   # Requires the ai_agent section above to be configured.
-  # The `when` filter is mandatory for aiassisted — configs without one are
-  # rejected at validation time. The filter controls which clusters/orgs are
+  # A `when` filter can be used to control which clusters/orgs are
   # eligible for AI investigation (allowlisting, sampling, org-scoping).
   #
   # Entry-level filter (filter applies only to the aiassisted step):

--- a/docs/investigation-config.example.yaml
+++ b/docs/investigation-config.example.yaml
@@ -5,8 +5,7 @@
 # loaded from the file path specified in the CAD_INVESTIGATION_CONFIG_PATH
 # environment variable.
 #
-# If the environment variable is not set, no config is loaded and alerts
-# without a matching chain are escalated to SRE.
+# If the environment variable is not set, no config is loaded and CAD exits.
 #
 # Structure:
 #   alerts:                  # List of alert → investigation mappings.

--- a/docs/investigation-config.example.yaml
+++ b/docs/investigation-config.example.yaml
@@ -10,6 +10,9 @@
 # Structure:
 #   alerts:                  # List of alert → investigation mappings.
 #     - alert_title:         # Substring matched against the PagerDuty incident title.
+#       name:                # Short identifier used for metrics labels and backplane remediation RBAC.
+#                            # Must match the investigation directory name so backplane-api can resolve
+#                            # the correct metadata.yaml. Falls back to alert_title if unset.
 #       experimental: false  # Optional. If true, alert only matches when CAD_EXPERIMENTAL_ENABLED=true.
 #       when:                # Optional alert-level filter. If it blocks, the entire alert is skipped
 #                            # and the alert is escalated to PagerDuty.
@@ -121,6 +124,7 @@ alerts:
   # Cluster Has Gone Missing (CHGM)
   # Exclude a specific cluster from the investigation.
   - alert_title: "has gone missing"
+    name: chgm
     when:
       field: ClusterID
       operator: notin
@@ -136,6 +140,7 @@ alerts:
 
   # Cluster Provisioning Delay
   - alert_title: "ClusterProvisioningDelay -"
+    name: cpd
     investigations:
       - precheck
       - ccam
@@ -144,6 +149,7 @@ alerts:
   # Etcd Database Quota Low Space
   # Only run on non-HCP (classic) clusters.
   - alert_title: "etcdDatabaseQuotaLowSpace"
+    name: etcddatabasequotalowspace
     when:
       field: HCP
       operator: in
@@ -155,6 +161,7 @@ alerts:
   # Cluster Monitoring Error Budget Burn
   # Example: sample redhat.com emails at 10%, always run for others.
   # - alert_title: "ClusterMonitoringErrorBudgetBurnSRE"
+  #   name: clustermonitoringerrorbudgetburn
   #   investigations:
   #     - precheck
   #     - ccam
@@ -169,6 +176,7 @@ alerts:
 
   # Insights Operator Down
   - alert_title: "InsightsOperatorDown"
+    name: insightsoperatordown
     investigations:
       - precheck
       - ccam
@@ -176,6 +184,7 @@ alerts:
 
   # Upgrade Config Sync Failure Over 4hr
   - alert_title: "UpgradeConfigSyncFailureOver4HrSRE"
+    name: upgradeconfigsyncfailureover4hr
     investigations:
       - precheck
       - ccam
@@ -183,6 +192,7 @@ alerts:
 
   # Machine Health Check Unterminated Short Circuit SRE
   - alert_title: "MachineHealthCheckUnterminatedShortCircuitSRE"
+    name: machinehealthcheckunterminatedshortcircuitsre
     investigations:
       - precheck
       - ccam
@@ -190,12 +200,14 @@ alerts:
 
   # Restart Control Plane
   - alert_title: "RestartControlPlane"
+    name: restartcontrolplane
     investigations:
       - precheck
       - restartcontrolplane
 
   # Cannot Retrieve Updates SRE
   - alert_title: "CannotRetrieveUpdatesSRE"
+    name: cannotretrieveupdatessre
     investigations:
       - precheck
       - ccam
@@ -203,6 +215,7 @@ alerts:
 
   # Mustgather (standalone, with AWS-only alert-level filter)
   - alert_title: "MustGather"
+    name: mustgather
     when:
       field: CloudProvider
       operator: in
@@ -213,6 +226,7 @@ alerts:
 
   # OCM Agent Response Failure
   - alert_title: "OCMAgentResponseFailure"
+    name: ocmagentresponsefailure
     investigations:
       - precheck
       - ccam

--- a/docs/investigation-config.md
+++ b/docs/investigation-config.md
@@ -1,6 +1,6 @@
-# Investigation Filter Configuration
+# Investigation Configuration
 
-CAD supports a YAML-based configuration file that controls which investigations run and optionally configures the AI agent. This allows you to restrict investigations to specific clusters, cloud providers, organizations, or other attributes — without code changes.
+CAD is configured via a YAML-based configuration file that controls which investigations run and optionally configures the AI agent. This allows you to restrict investigations to specific alerts, clusters, cloud providers, organizations, or other attributes — without code changes.
 
 ## Enabling the config
 
@@ -10,15 +10,15 @@ Set the `CAD_INVESTIGATION_CONFIG_PATH` environment variable to the path of your
 export CAD_INVESTIGATION_CONFIG_PATH=/path/to/config.yaml
 ```
 
-If the variable is not set, no filtering is applied and all investigations run unconditionally.
+If the variable is not set, the program exits.
 
 ## How filtering works
 
-Each investigation can have an optional **filter tree** — a boolean expression evaluated against the current alert and cluster context. If the filter passes, the investigation runs; if it fails, it is skipped.
+Each alert configuration can have an optional **filter tree** — a boolean expression evaluated against the current alert and cluster context. If the filter passes, the alert is investigated by CAD by running its configured set of investigations; Each investigation can, in turn, have its own filter tree.
 
-Investigations that have **no entry** in the config always run. An alert entry with no `when` key also always runs.
+Investigations that have **no `when` entry** in the config always run for a given alert.
 
-The one exception is `aiassisted`: it only runs if it has an entry in the config. Without an entry, the AI investigation is entirely disabled.
+The `aiassisted` investigation can run in two ways: explicitly listed in an alert's investigation chain, or as an automatic fallback when no alert title matches (or when the alert-level filter rejects). The fallback path triggers whenever the `ai_agent` section is configured, even without an explicit `aiassisted` entry in `alerts`.
 
 ## Filter tree structure
 
@@ -90,7 +90,7 @@ Only run an investigation on AWS clusters in `ready` state:
 
 ```yaml
 alerts:
-  - investigation: mustgather
+  - alert_title: "MustGather"
     when:
       and:
         - field: CloudProvider
@@ -99,47 +99,62 @@ alerts:
         - field: ClusterState
           operator: in
           values: ["ready"]
+    investigations:
+      - precheck
+      - mustgather
 ```
 
 Exclude a specific cluster:
 
 ```yaml
 alerts:
-  - investigation: chgm
+  - alert_title: "has gone missing"
     when:
       field: ClusterID
       operator: notin
       values: ["2pr3e91qrgdje312keq8denphqs70tlr"]
+    investigations:
+      - precheck
+      - ccam
+      - chgm
 ```
 
-Sample 10% of internal (`@redhat.com`) traffic, always run for external customers:
+Sample 10% of internal (`@redhat.com`) traffic for a specific investigation step, always run for external customers:
 
 ```yaml
 alerts:
-  - investigation: clustermonitoringerrorbudgetburn
-    when:
-      or:
-        - field: OwnerEmail
-          operator: notmatches
-          values: [".*@redhat\\.com$"]
-        - operator: sample
-          values: ["0.10"]
+  - alert_title: "ClusterMonitoringErrorBudgetBurnSRE"
+    investigations:
+      - precheck
+      - ccam
+      - name: clustermonitoringerrorbudgetburn
+        when:
+          or:
+            - field: OwnerEmail
+              operator: notmatches
+              values: [".*@redhat\\.com$"]
+            - operator: sample
+              values: ["0.10"]
 ```
 
 ## AI agent configuration
 
-When using the `aiassisted` investigation, the `ai_agent` section must be present:
+When using the `aiassisted` investigation, the `ai_agent` section must be present and all required fields must be set:
 
 ```yaml
 ai_agent:
-  runtime_arn: "arn:aws:bedrock:us-east-1:123456789012:agent-runtime/EXAMPLE"
-  user_id: "cad-agent"
+  runtime_arn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/agent-abc123"
+  user_id: "cad-service-account"
   region: "us-east-1"
-  timeout_seconds: 900   # optional, defaults to 900
+  invoker_role_arn: "arn:aws:iam::123456789012:role/agent-invoker"
+  timeout_seconds: 900              # optional, defaults to 900
+  version: "v1.0.0"                 # optional, audit trail only
+  ops_sop_version: "v2.0.0"         # optional, audit trail only
+  rosa_plugins_version: "v3.0.0"    # optional, audit trail only
 ```
 
-The `aiassisted` investigation must also have an entry in `alerts`. Without it, AI investigation is disabled even if `ai_agent` is configured.
+When the `ai_agent` section is configured, `aiassisted` also acts as a fallback: if no alert title matches the incoming incident (or the matched alert's `when` filter rejects), CAD automatically runs `precheck` followed by `aiassisted`. This fallback does not require an explicit `aiassisted` entry in `alerts`.
 
 ## Full reference
 
-See [`docs/investigation-filter-config.example.yaml`](investigation-filter-config.example.yaml) for a fully commented example covering all operators, field types, and composition patterns.
+See [`docs/investigation-config.example.yaml`](investigation-config.example.yaml) for a fully commented example covering all operators, field types, and composition patterns.

--- a/docs/investigation-filter-config.example.yaml
+++ b/docs/investigation-filter-config.example.yaml
@@ -1,16 +1,22 @@
-# Investigation Filter Configuration
+# Investigation Chain Configuration
 #
-# This file controls which investigations are allowed to run based on
-# cluster and alert attributes. It is loaded from the file path specified
-# in the CAD_INVESTIGATION_CONFIG_PATH environment variable.
+# This file defines which investigations run for each alert, and
+# optionally filters them based on cluster and alert attributes. It is
+# loaded from the file path specified in the CAD_INVESTIGATION_CONFIG_PATH
+# environment variable.
 #
-# If the environment variable is not set, no filtering is applied and all
-# investigations run unconditionally.
+# If the environment variable is not set, no config is loaded and alerts
+# without a matching chain are escalated to SRE.
 #
 # Structure:
-#   filters:             # Top-level list of per-investigation filters.
-#     - investigation:   # Investigation name (must match a registered name, see below).
-#       when:          # Root of a recursive filter tree. Optional (nil = always run).
+#   investigations:          # List of alert → chain mappings.
+#     - alert_title:         # Substring matched against the PagerDuty incident title.
+#       experimental: false  # Optional. If true, chain only matches when CAD_EXPERIMENTAL_ENABLED=true.
+#       when:                # Optional chain-level filter. If it blocks, the entire chain is skipped
+#                            # and the alert is escalated to PagerDuty.
+#       chain:               # Ordered list of investigations to run.
+#                            # Each entry is either a bare string (investigation name) or an object
+#                            # with `name` and optional `when` filter.
 #
 # Filter Tree:
 #   A filter node is either a branch (AND/OR) or a leaf (comparison/sampling).
@@ -30,15 +36,15 @@
 #     operator: sample   # Probabilistic sampling — no field required.
 #     values: ["0.10"]   # Single value: probability between 0 and 1.
 #
-# Behavior:
-#   - Investigations WITHOUT a filter entry here always run (no restrictions).
-#   - A filter entry with no `when` tree (just the investigation name) always runs.
-#   - An empty filters list (filters: []) means no filtering — all investigations run.
-#   - A node cannot have both `and` and `or`, or be both a branch and a leaf.
-#   - The `aiassisted` investigation is special: it only runs when it has an entry
-#     in this config. Without an entry, AI investigation is disabled entirely.
+# Filtering levels:
+#   - Chain-level `when`: evaluated before any chain entry runs. If blocked, the
+#     entire chain is skipped and the alert is escalated to PagerDuty with a note.
+#   - Entry-level `when`: evaluated per step. If blocked, that step is skipped and
+#     the chain continues with the next entry.
 #
 # Valid investigation names:
+#   - precheck
+#   - ccam
 #   - aiassisted
 #   - Cluster Has Gone Missing (CHGM)
 #   - ClusterProvisioningDelay
@@ -50,6 +56,8 @@
 #   - restartcontrolplane
 #   - cannotretrieveupdatessre
 #   - mustgather
+#   - ocmagentresponsefailure
+#   - describenodes
 #
 # Valid input fields (from FilterContext):
 #
@@ -78,7 +86,7 @@
 # Notes:
 #   - The HCP field is a boolean internally but is compared as a string
 #     ("true" / "false") in filter values.
-#   - Each investigation name may only appear once in the filters list.
+#   - Each alert_title must be unique across all investigation entries.
 #   - Not all FilterContext fields are guaranteed to be populated in every
 #     context. For example, PagerDuty fields are empty when running via the
 #     manual CLI. An empty field will not match any "in" value (except an
@@ -88,7 +96,21 @@
 #
 # This section configures the AgentCore runtime used by the `aiassisted`
 # investigation. All fields except the version metadata are required when
-# AI investigation is enabled.
+# AI investigation is enabled (i.e., when any chain references `aiassisted`).
+#
+# AI investigation guards:
+#   1. The `ai_agent` section must be present — without it, any chain
+#      referencing `aiassisted` is rejected at config validation time.
+#   2. Every `aiassisted` chain entry must have a `when` filter — either
+#      on the chain itself or on the entry. This prevents uncontrolled AI
+#      execution. Configs without a filter are rejected at validation time.
+#   3. The `CAD_EXPERIMENTAL_ENABLED=true` env var must be set for the
+#      AI fallback path (unmatched alerts) to trigger. Chains explicitly
+#      configured for specific alerts do not require this env var unless
+#      they are marked `experimental: true`.
+#   4. At runtime, the `when` filter is evaluated against real cluster data
+#      (org ID, cluster ID, cloud provider, etc.) to decide whether AI
+#      actually runs for a given cluster.
 #
 # ai_agent:
 #   runtime_arn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/rosasreai_stage-abc123"
@@ -100,85 +122,141 @@
 #   ops_sop_version: "v2.0.0"         # Optional, audit trail only
 #   rosa_plugins_version: "v3.0.0"    # Optional, audit trail only
 
-filters:
-  # Enable AI investigation for specific clusters or organizations.
-  # The presence of this entry enables AI investigation; remove it to disable.
-  # Uses OR logic: the cluster OR the organization must match.
-  # - investigation: aiassisted
-  #   when:
-  #     or:
-  #       - field: ClusterID
-  #         operator: in
-  #         values: ["cluster-id-1", "cluster-id-2"]
-  #       - field: OrganizationID
-  #         operator: in
-  #         values: ["org-id-1", "org-id-2"]
-
-  # Only run the mustgather investigation on AWS clusters that are in "ready" state.
-  # Uses AND logic: both conditions must pass.
-  - investigation: mustgather
+investigations:
+  # Cluster Has Gone Missing (CHGM)
+  # Exclude a specific cluster from the investigation chain.
+  - alert_title: "has gone missing"
     when:
-      and:
-        - field: CloudProvider
-          operator: in
-          values: ["aws"]
-        - field: ClusterState
-          operator: in
-          values: ["ready"]
+      field: ClusterID
+      operator: notin
+      values: ["2pr3e91qrgdje312keq8denphqs70tlr"]
+    chain:
+      - precheck
+      - ccam
+      - "Cluster Has Gone Missing (CHGM)"
+      - name: mustgather
+        when:
+          operator: sample
+          values: ["0.10"]
 
-  # Only run the etcd investigation on non-HCP (classic) clusters.
-  - investigation: etcddatabasequotalowspace
+  # Cluster Provisioning Delay
+  - alert_title: "ClusterProvisioningDelay -"
+    chain:
+      - precheck
+      - ccam
+      - ClusterProvisioningDelay
+
+  # Etcd Database Quota Low Space
+  # Only run on non-HCP (classic) clusters.
+  - alert_title: "etcdDatabaseQuotaLowSpace"
     when:
       field: HCP
       operator: in
       values: ["false"]
+    chain:
+      - precheck
+      - etcddatabasequotalowspace
 
-  # Exclude a specific organization from the CHGM investigation.
-  - investigation: "Cluster Has Gone Missing (CHGM)"
+  # Cluster Monitoring Error Budget Burn
+  # Example: sample redhat.com emails at 10%, always run for others.
+  # - alert_title: "ClusterMonitoringErrorBudgetBurnSRE"
+  #   chain:
+  #     - precheck
+  #     - ccam
+  #     - name: clustermonitoringerrorbudgetburn
+  #       when:
+  #         or:
+  #           - field: OwnerEmail
+  #             operator: notmatches
+  #             values: [".*@redhat\\.com$"]
+  #           - operator: sample
+  #             values: ["0.10"]
+
+  # Insights Operator Down
+  - alert_title: "InsightsOperatorDown"
+    chain:
+      - precheck
+      - ccam
+      - insightsoperatordown
+
+  # Upgrade Config Sync Failure Over 4hr
+  - alert_title: "UpgradeConfigSyncFailureOver4HrSRE"
+    chain:
+      - precheck
+      - ccam
+      - upgradeconfigsyncfailureover4hr
+
+  # Machine Health Check Unterminated Short Circuit SRE
+  - alert_title: "MachineHealthCheckUnterminatedShortCircuitSRE"
+    chain:
+      - precheck
+      - ccam
+      - machinehealthcheckunterminatedshortcircuitsre
+
+  # Restart Control Plane
+  - alert_title: "RestartControlPlane"
+    chain:
+      - precheck
+      - restartcontrolplane
+
+  # Cannot Retrieve Updates SRE
+  - alert_title: "CannotRetrieveUpdatesSRE"
+    chain:
+      - precheck
+      - ccam
+      - cannotretrieveupdatessre
+
+  # Mustgather (standalone, with AWS-only chain-level filter)
+  - alert_title: "MustGather"
     when:
-      and:
-        - field: ClusterID
-          operator: notin
-          values: ["2pr3e91qrgdje312keq8denphqs70tlr"]
+      field: CloudProvider
+      operator: in
+      values: ["aws"]
+    chain:
+      - precheck
+      - mustgather
 
-  # Conditional sampling: sample redhat.com emails at 10%, always run for others.
-  # Logic: NOT(@redhat.com) OR sample(0.10)
-  #   - Non-redhat emails: notmatches passes (true), short-circuits OR → runs
-  #   - Redhat emails: notmatches fails (false), falls through to sample(0.10) → 10% chance
-  # - investigation: clustermonitoringerrorbudgetburn
-  #   when:
-  #     or:
-  #       - field: OwnerEmail
-  #         operator: notmatches
-  #         values: [".*@redhat\\.com$"]
-  #       - operator: sample
-  #         values: ["0.10"]
+  # OCM Agent Response Failure
+  - alert_title: "OCMAgentResponseFailure"
+    chain:
+      - precheck
+      - ccam
+      - ocmagentresponsefailure
 
-  # Combining AND and OR: AWS clusters where the cluster or org is allowlisted.
-  # - investigation: insightsoperatordown
-  #   when:
-  #     and:
-  #       - field: CloudProvider
-  #         operator: in
-  #         values: ["aws"]
-  #       - or:
-  #           - field: ClusterID
-  #             operator: in
-  #             values: ["abc123", "def456"]
+  # Experimental investigation example
+  # Only matched when CAD_EXPERIMENTAL_ENABLED=true.
+  # - alert_title: "SomeNewAlert"
+  #   experimental: true
+  #   chain:
+  #     - precheck
+  #     - somenewcheck
+
+  # AI-assisted investigation example
+  # Requires the ai_agent section above to be configured.
+  # The `when` filter is mandatory for aiassisted — configs without one are
+  # rejected at validation time. The filter controls which clusters/orgs are
+  # eligible for AI investigation (allowlisting, sampling, org-scoping).
+  #
+  # Entry-level filter (filter applies only to the aiassisted step):
+  # - alert_title: "SomeAlert"
+  #   chain:
+  #     - precheck
+  #     - name: aiassisted
+  #       when:
+  #         or:
   #           - field: OrganizationID
   #             operator: in
-  #             values: ["org-abc"]
-
-  # Exclude clusters that are being uninstalled.
-  # - investigation: restartcontrolplane
+  #             values: ["org-id-1"]
+  #           - field: ClusterID
+  #             operator: in
+  #             values: ["cluster-id-1"]
+  #
+  # Chain-level filter (filter applies to the entire chain including aiassisted):
+  # - alert_title: "AnotherAlert"
   #   when:
-  #     field: ClusterState
-  #     operator: notin
-  #     values: ["uninstalling"]
-
-  # Match alert titles with a regex pattern.
-  # - investigation: cannotretrieveupdatessre
-  #   when:
-  #     field: AlertTitle
-  #     operator: matches
-  #     values: [".*CRITICAL.*", ".*WARNING.*"]
+  #     field: CloudProvider
+  #     operator: in
+  #     values: ["aws"]
+  #   chain:
+  #     - precheck
+  #     - aiassisted

--- a/docs/investigation-filter-config.example.yaml
+++ b/docs/investigation-filter-config.example.yaml
@@ -46,8 +46,8 @@
 #   - precheck
 #   - ccam
 #   - aiassisted
-#   - Cluster Has Gone Missing (CHGM)
-#   - ClusterProvisioningDelay
+#   - chgm
+#   - cpd
 #   - clustermonitoringerrorbudgetburn
 #   - etcddatabasequotalowspace
 #   - insightsoperatordown
@@ -133,7 +133,7 @@ alerts:
     investigations:
       - precheck
       - ccam
-      - "Cluster Has Gone Missing (CHGM)"
+      - chgm
       - name: mustgather
         when:
           operator: sample
@@ -144,7 +144,7 @@ alerts:
     investigations:
       - precheck
       - ccam
-      - ClusterProvisioningDelay
+      - cpd
 
   # Etcd Database Quota Low Space
   # Only run on non-HCP (classic) clusters.

--- a/docs/investigation-filter-config.example.yaml
+++ b/docs/investigation-filter-config.example.yaml
@@ -9,12 +9,12 @@
 # without a matching chain are escalated to SRE.
 #
 # Structure:
-#   investigations:          # List of alert → chain mappings.
+#   alerts:                  # List of alert → investigation mappings.
 #     - alert_title:         # Substring matched against the PagerDuty incident title.
-#       experimental: false  # Optional. If true, chain only matches when CAD_EXPERIMENTAL_ENABLED=true.
-#       when:                # Optional chain-level filter. If it blocks, the entire chain is skipped
+#       experimental: false  # Optional. If true, alert only matches when CAD_EXPERIMENTAL_ENABLED=true.
+#       when:                # Optional alert-level filter. If it blocks, the entire alert is skipped
 #                            # and the alert is escalated to PagerDuty.
-#       chain:               # Ordered list of investigations to run.
+#       investigations:      # Ordered list of investigations to run.
 #                            # Each entry is either a bare string (investigation name) or an object
 #                            # with `name` and optional `when` filter.
 #
@@ -37,10 +37,10 @@
 #     values: ["0.10"]   # Single value: probability between 0 and 1.
 #
 # Filtering levels:
-#   - Chain-level `when`: evaluated before any chain entry runs. If blocked, the
-#     entire chain is skipped and the alert is escalated to PagerDuty with a note.
-#   - Entry-level `when`: evaluated per step. If blocked, that step is skipped and
-#     the chain continues with the next entry.
+#   - Alert-level `when`: evaluated before any investigation runs. If blocked, the
+#     entire alert is skipped and escalated to PagerDuty with a note.
+#   - Entry-level `when`: evaluated per investigation. If blocked, that investigation
+#     is skipped and execution continues with the next entry.
 #
 # Valid investigation names:
 #   - precheck
@@ -86,7 +86,7 @@
 # Notes:
 #   - The HCP field is a boolean internally but is compared as a string
 #     ("true" / "false") in filter values.
-#   - Each alert_title must be unique across all investigation entries.
+#   - Each alert_title must be unique across all alert entries.
 #   - Not all FilterContext fields are guaranteed to be populated in every
 #     context. For example, PagerDuty fields are empty when running via the
 #     manual CLI. An empty field will not match any "in" value (except an
@@ -99,14 +99,14 @@
 # AI investigation is enabled (i.e., when any chain references `aiassisted`).
 #
 # AI investigation guards:
-#   1. The `ai_agent` section must be present — without it, any chain
+#   1. The `ai_agent` section must be present — without it, any alert
 #      referencing `aiassisted` is rejected at config validation time.
-#   2. Every `aiassisted` chain entry must have a `when` filter — either
-#      on the chain itself or on the entry. This prevents uncontrolled AI
+#   2. Every `aiassisted` entry must have a `when` filter — either
+#      on the alert itself or on the entry. This prevents uncontrolled AI
 #      execution. Configs without a filter are rejected at validation time.
 #   3. The `CAD_EXPERIMENTAL_ENABLED=true` env var must be set for the
-#      AI fallback path (unmatched alerts) to trigger. Chains explicitly
-#      configured for specific alerts do not require this env var unless
+#      AI fallback path (unmatched alerts) to trigger. Alerts explicitly
+#      configured do not require this env var unless
 #      they are marked `experimental: true`.
 #   4. At runtime, the `when` filter is evaluated against real cluster data
 #      (org ID, cluster ID, cloud provider, etc.) to decide whether AI
@@ -122,15 +122,15 @@
 #   ops_sop_version: "v2.0.0"         # Optional, audit trail only
 #   rosa_plugins_version: "v3.0.0"    # Optional, audit trail only
 
-investigations:
+alerts:
   # Cluster Has Gone Missing (CHGM)
-  # Exclude a specific cluster from the investigation chain.
+  # Exclude a specific cluster from the investigation.
   - alert_title: "has gone missing"
     when:
       field: ClusterID
       operator: notin
       values: ["2pr3e91qrgdje312keq8denphqs70tlr"]
-    chain:
+    investigations:
       - precheck
       - ccam
       - "Cluster Has Gone Missing (CHGM)"
@@ -141,7 +141,7 @@ investigations:
 
   # Cluster Provisioning Delay
   - alert_title: "ClusterProvisioningDelay -"
-    chain:
+    investigations:
       - precheck
       - ccam
       - ClusterProvisioningDelay
@@ -153,14 +153,14 @@ investigations:
       field: HCP
       operator: in
       values: ["false"]
-    chain:
+    investigations:
       - precheck
       - etcddatabasequotalowspace
 
   # Cluster Monitoring Error Budget Burn
   # Example: sample redhat.com emails at 10%, always run for others.
   # - alert_title: "ClusterMonitoringErrorBudgetBurnSRE"
-  #   chain:
+  #   investigations:
   #     - precheck
   #     - ccam
   #     - name: clustermonitoringerrorbudgetburn
@@ -174,51 +174,51 @@ investigations:
 
   # Insights Operator Down
   - alert_title: "InsightsOperatorDown"
-    chain:
+    investigations:
       - precheck
       - ccam
       - insightsoperatordown
 
   # Upgrade Config Sync Failure Over 4hr
   - alert_title: "UpgradeConfigSyncFailureOver4HrSRE"
-    chain:
+    investigations:
       - precheck
       - ccam
       - upgradeconfigsyncfailureover4hr
 
   # Machine Health Check Unterminated Short Circuit SRE
   - alert_title: "MachineHealthCheckUnterminatedShortCircuitSRE"
-    chain:
+    investigations:
       - precheck
       - ccam
       - machinehealthcheckunterminatedshortcircuitsre
 
   # Restart Control Plane
   - alert_title: "RestartControlPlane"
-    chain:
+    investigations:
       - precheck
       - restartcontrolplane
 
   # Cannot Retrieve Updates SRE
   - alert_title: "CannotRetrieveUpdatesSRE"
-    chain:
+    investigations:
       - precheck
       - ccam
       - cannotretrieveupdatessre
 
-  # Mustgather (standalone, with AWS-only chain-level filter)
+  # Mustgather (standalone, with AWS-only alert-level filter)
   - alert_title: "MustGather"
     when:
       field: CloudProvider
       operator: in
       values: ["aws"]
-    chain:
+    investigations:
       - precheck
       - mustgather
 
   # OCM Agent Response Failure
   - alert_title: "OCMAgentResponseFailure"
-    chain:
+    investigations:
       - precheck
       - ccam
       - ocmagentresponsefailure
@@ -227,7 +227,7 @@ investigations:
   # Only matched when CAD_EXPERIMENTAL_ENABLED=true.
   # - alert_title: "SomeNewAlert"
   #   experimental: true
-  #   chain:
+  #   investigations:
   #     - precheck
   #     - somenewcheck
 
@@ -239,7 +239,7 @@ investigations:
   #
   # Entry-level filter (filter applies only to the aiassisted step):
   # - alert_title: "SomeAlert"
-  #   chain:
+  #   investigations:
   #     - precheck
   #     - name: aiassisted
   #       when:
@@ -251,12 +251,12 @@ investigations:
   #             operator: in
   #             values: ["cluster-id-1"]
   #
-  # Chain-level filter (filter applies to the entire chain including aiassisted):
+  # Alert-level filter (filter applies to all investigations including aiassisted):
   # - alert_title: "AnotherAlert"
   #   when:
   #     field: CloudProvider
   #     operator: in
   #     values: ["aws"]
-  #   chain:
+  #   investigations:
   #     - precheck
   #     - aiassisted

--- a/docs/investigation-filter-config.md
+++ b/docs/investigation-filter-config.md
@@ -105,7 +105,7 @@ Exclude a specific cluster:
 
 ```yaml
 alerts:
-  - investigation: "Cluster Has Gone Missing (CHGM)"
+  - investigation: chgm
     when:
       field: ClusterID
       operator: notin

--- a/docs/investigation-filter-config.md
+++ b/docs/investigation-filter-config.md
@@ -16,7 +16,7 @@ If the variable is not set, no filtering is applied and all investigations run u
 
 Each investigation can have an optional **filter tree** — a boolean expression evaluated against the current alert and cluster context. If the filter passes, the investigation runs; if it fails, it is skipped.
 
-Investigations that have **no entry** in the config always run. An investigation entry with no `when` key also always runs.
+Investigations that have **no entry** in the config always run. An alert entry with no `when` key also always runs.
 
 The one exception is `aiassisted`: it only runs if it has an entry in the config. Without an entry, the AI investigation is entirely disabled.
 
@@ -89,7 +89,7 @@ Note: Not all fields are guaranteed to be populated in every context. PagerDuty 
 Only run an investigation on AWS clusters in `ready` state:
 
 ```yaml
-filters:
+alerts:
   - investigation: mustgather
     when:
       and:
@@ -104,7 +104,7 @@ filters:
 Exclude a specific cluster:
 
 ```yaml
-filters:
+alerts:
   - investigation: "Cluster Has Gone Missing (CHGM)"
     when:
       field: ClusterID
@@ -115,7 +115,7 @@ filters:
 Sample 10% of internal (`@redhat.com`) traffic, always run for external customers:
 
 ```yaml
-filters:
+alerts:
   - investigation: clustermonitoringerrorbudgetburn
     when:
       or:
@@ -138,7 +138,7 @@ ai_agent:
   timeout_seconds: 900   # optional, defaults to 900
 ```
 
-The `aiassisted` investigation must also have an entry in `filters`. Without it, AI investigation is disabled even if `ai_agent` is configured.
+The `aiassisted` investigation must also have an entry in `alerts`. Without it, AI investigation is disabled even if `ai_agent` is configured.
 
 ## Full reference
 

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -48,7 +48,11 @@ func main() {
 	ctx := signals.NewContext()
 
 	mux := http.NewServeMux()
-	mux.Handle("/", interceptor.CreateInterceptorHandler(signatures))
+	handler, err := interceptor.CreateInterceptorHandler(signatures)
+	if err != nil {
+		logger.Fatalf("failed to create interceptor handler: %v", err)
+	}
+	mux.Handle("/", handler)
 	mux.HandleFunc("/ready", readinessHandler)
 	mux.Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{Registry: metrics.Registry}))
 

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -100,12 +100,14 @@ func readinessHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func loadPDSignatures() ([]string, error) {
-	var signatures []string
 	tokens := os.Getenv("PD_SIGNATURE")
 	if tokens == "" {
-		return signatures, errors.New("PD_SIGNATURE environment variable missing")
+		return nil, errors.New("PD_SIGNATURE environment variable missing")
 	}
-	for _, sig := range strings.Split(tokens, ",") {
+	parts := strings.Split(tokens, ",")
+
+	signatures := make([]string, 0, len(parts))
+	for _, sig := range parts {
 		trim := strings.TrimSpace(sig)
 		signatures = append(signatures, trim)
 	}

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -48,7 +48,8 @@ func main() {
 	ctx := signals.NewContext()
 
 	mux := http.NewServeMux()
-	handler, err := interceptor.CreateInterceptorHandler(signatures)
+	configPath := os.Getenv("CAD_INVESTIGATION_CONFIG_PATH")
+	handler, err := interceptor.CreateInterceptorHandler(signatures, configPath)
 	if err != nil {
 		logger.Fatalf("failed to create interceptor handler: %v", err)
 	}

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -206,21 +206,21 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 	experimentalEnabledVar := os.Getenv("CAD_EXPERIMENTAL_ENABLED")
 	experimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
 
-	// Check if a chain is configured for this alert (config loaded at handler creation)
+	// Check if an alert config exists for this alert (config loaded at handler creation)
 	if pdi.configErr != nil {
 		logging.Warnf("Investigation config load error: %v", pdi.configErr)
 	}
 
-	hasChain := pdi.filterConfig != nil && pdi.filterConfig.GetChain(pdClient.GetTitle(), experimentalEnabled) != nil
+	hasAlert := pdi.filterConfig != nil && pdi.filterConfig.GetAlert(pdClient.GetTitle(), experimentalEnabled) != nil
 
-	if hasChain {
-		logging.Infof("Incident %s has a configured chain, returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID())
+	if hasAlert {
+		logging.Infof("Incident %s has a configured alert, returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID())
 		return &triggersv1.InterceptorResponse{Continue: true}
 	}
 
 	// AI fallback: if ai_agent is configured, allow the pipeline to run for AI investigation
 	if experimentalEnabled && pdi.filterConfig != nil && pdi.filterConfig.AIAgent != nil {
-		logging.Infof("No chain match, but AI agent configured — checking cluster existence")
+		logging.Infof("No alert match, but AI agent configured — checking cluster existence")
 		resp := clusterExists(pdClient, ocmClient)
 		if resp != nil {
 			return resp

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -217,7 +217,7 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 	}
 
 	// AI fallback: if ai_agent is configured, allow the pipeline to run for AI investigation
-	if experimentalEnabled && pdi.cfg != nil && pdi.cfg.AIAgent != nil {
+	if pdi.cfg != nil && pdi.cfg.AIAgent != nil {
 		logging.Infof("No alert match, but AI agent configured — checking cluster existence")
 		resp := clusterExists(pdClient, ocmClient)
 		if resp != nil {

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -3,7 +3,6 @@ package interceptor
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -58,11 +57,14 @@ type Organization struct {
 }
 
 type interceptorHandler struct {
-	PDTokens []string
+	PDTokens     []string
+	filterConfig *config.Config
+	configErr    error
 }
 
 func CreateInterceptorHandler(pdTokens []string) http.Handler {
-	return &interceptorHandler{PDTokens: pdTokens}
+	cfg, err := config.LoadConfig("", investigations.GetAvailableInvestigationsNames())
+	return &interceptorHandler{PDTokens: pdTokens, filterConfig: cfg, configErr: err}
 }
 
 func (pdi interceptorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -202,45 +204,37 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 	}
 
 	experimentalEnabledVar := os.Getenv("CAD_EXPERIMENTAL_ENABLED")
-	cadExperimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
+	experimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
 
-	investigation := investigations.GetInvestigation(pdClient.GetTitle(), cadExperimentalEnabled)
+	// Check if a chain is configured for this alert (config loaded at handler creation)
+	if pdi.configErr != nil {
+		logging.Warnf("Investigation config load error: %v", pdi.configErr)
+	}
 
-	// If no formal investigation found, check if AI investigation should run
-	if investigation == nil {
-		logging.Warnf("Checking pagerduty incident: %s", pdClient.GetIncidentRef())
+	hasChain := pdi.filterConfig != nil && pdi.filterConfig.GetChain(pdClient.GetTitle(), experimentalEnabled) != nil
+
+	if hasChain {
+		logging.Infof("Incident %s has a configured chain, returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID())
+		return &triggersv1.InterceptorResponse{Continue: true}
+	}
+
+	// AI fallback: if ai_agent is configured, allow the pipeline to run for AI investigation
+	if experimentalEnabled && pdi.filterConfig != nil && pdi.filterConfig.AIAgent != nil {
+		logging.Infof("No chain match, but AI agent configured — checking cluster existence")
 		resp := clusterExists(pdClient, ocmClient)
 		if resp != nil {
 			return resp
 		}
-
-		if shouldRunAIInvestigation() {
-			logging.Infof("Launching AI investigation")
-			return continueWithEncodedPayload(r.Body)
-		}
-
-		// No formal investigation and AI not enabled/allowed — escalate to SRE
-		logging.Infof("Incident %s is not mapped to an investigation, escalating incident and returning InterceptorResponse `Continue: false`.", pdClient.GetIncidentID())
-		if err = pdClient.EscalateIncidentWithNote("🤖 No automation implemented for this alert; escalated to SRE. 🤖"); err != nil {
-			logging.Errorf("failed to escalate incident '%s': %w", pdClient.GetIncidentID(), err)
-		}
-		return &triggersv1.InterceptorResponse{Continue: false}
+		logging.Infof("Launching AI investigation for incident %s", pdClient.GetIncidentID())
+		return &triggersv1.InterceptorResponse{Continue: true}
 	}
 
-	logging.Infof("Incident %s is mapped to investigation '%s', returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID(), investigation.Name())
-	return continueWithEncodedPayload(r.Body)
-}
-
-// continueWithEncodedPayload returns a Continue response with the webhook payload
-// base64-encoded as an extension. The TriggerBinding references this extension so
-// the payload reaches the Tekton task without shell metacharacter issues.
-func continueWithEncodedPayload(body string) *triggersv1.InterceptorResponse {
-	return &triggersv1.InterceptorResponse{
-		Continue: true,
-		Extensions: map[string]interface{}{
-			"payload_base64": base64.StdEncoding.EncodeToString([]byte(body)),
-		},
+	// No chain and no AI — escalate to SRE
+	logging.Infof("Incident %s is not mapped to an investigation, escalating incident and returning InterceptorResponse `Continue: false`.", pdClient.GetIncidentID())
+	if err = pdClient.EscalateIncidentWithNote("🤖 No automation implemented for this alert; escalated to SRE. 🤖"); err != nil {
+		logging.Errorf("failed to escalate incident '%s': %w", pdClient.GetIncidentID(), err)
 	}
+	return &triggersv1.InterceptorResponse{Continue: false}
 }
 
 // clusterExists retrieves the cluster ID from PagerDuty and verifies it
@@ -260,26 +254,6 @@ func clusterExists(pdClient pagerduty.Client, ocmClient ocm.Client) *triggersv1.
 	}
 
 	return nil
-}
-
-// shouldRunAIInvestigation checks whether AI investigation is configured at all.
-// The actual filter evaluation (allowlist, sampling, etc.) is done by the controller.
-func shouldRunAIInvestigation() bool {
-	filterConfig, err := config.LoadConfig("", investigations.GetAvailableInvestigationsNames())
-	if err != nil {
-		logging.Warnf("Failed to load investigation filter config: %v", err)
-		return false
-	}
-
-	if filterConfig.GetAIAgentConfig() == nil {
-		return false
-	}
-
-	if filterConfig.GetFilter("aiassisted") == nil {
-		return false
-	}
-
-	return true
 }
 
 func loadOrgEscalationMapping() (map[string]string, error) {

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -3,6 +3,7 @@ package interceptor
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -213,7 +214,7 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 
 	if hasAlert {
 		logging.Infof("Incident %s has a configured alert, returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID())
-		return &triggersv1.InterceptorResponse{Continue: true}
+		return continueWithEncodedPayload(r.Body)
 	}
 
 	// AI fallback: if ai_agent is configured, allow the pipeline to run for AI investigation
@@ -224,7 +225,7 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 			return resp
 		}
 		logging.Infof("Launching AI investigation for incident %s", pdClient.GetIncidentID())
-		return &triggersv1.InterceptorResponse{Continue: true}
+		return continueWithEncodedPayload(r.Body)
 	}
 
 	// No chain and no AI — escalate to SRE
@@ -233,6 +234,18 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 		logging.Errorf("failed to escalate incident '%s': %v", pdClient.GetIncidentID(), err)
 	}
 	return &triggersv1.InterceptorResponse{Continue: false}
+}
+
+// continueWithEncodedPayload returns a Continue response with the webhook payload
+// base64-encoded as an extension. The TriggerBinding references this extension so
+// the payload reaches the Tekton task without shell metacharacter issues.
+func continueWithEncodedPayload(body string) *triggersv1.InterceptorResponse {
+	return &triggersv1.InterceptorResponse{
+		Continue: true,
+		Extensions: map[string]interface{}{
+			"payload_base64": base64.StdEncoding.EncodeToString([]byte(body)),
+		},
+	}
 }
 
 // clusterExists retrieves the cluster ID from PagerDuty and verifies it

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -57,8 +57,8 @@ type Organization struct {
 }
 
 type interceptorHandler struct {
-	PDTokens     []string
-	cfg   *config.Config
+	PDTokens []string
+	cfg      *config.Config
 }
 
 func CreateInterceptorHandler(pdTokens []string) (http.Handler, error) {
@@ -230,7 +230,7 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 	// No chain and no AI — escalate to SRE
 	logging.Infof("Incident %s is not mapped to an investigation, escalating incident and returning InterceptorResponse `Continue: false`.", pdClient.GetIncidentID())
 	if err = pdClient.EscalateIncidentWithNote("🤖 No automation implemented for this alert; escalated to SRE. 🤖"); err != nil {
-		logging.Errorf("failed to escalate incident '%s': %w", pdClient.GetIncidentID(), err)
+		logging.Errorf("failed to escalate incident '%s': %v", pdClient.GetIncidentID(), err)
 	}
 	return &triggersv1.InterceptorResponse{Continue: false}
 }

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -58,7 +58,7 @@ type Organization struct {
 
 type interceptorHandler struct {
 	PDTokens     []string
-	filterConfig *config.Config
+	cfg   *config.Config
 }
 
 func CreateInterceptorHandler(pdTokens []string) (http.Handler, error) {
@@ -66,7 +66,7 @@ func CreateInterceptorHandler(pdTokens []string) (http.Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading investigation config: %w", err)
 	}
-	return &interceptorHandler{PDTokens: pdTokens, filterConfig: cfg}, nil
+	return &interceptorHandler{PDTokens: pdTokens, cfg: cfg}, nil
 }
 
 func (pdi interceptorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -209,7 +209,7 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 	experimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
 
 	// Check if an alert config exists for this alert (config loaded at handler creation)
-	hasAlert := pdi.filterConfig != nil && pdi.filterConfig.GetAlert(pdClient.GetTitle(), experimentalEnabled) != nil
+	hasAlert := pdi.cfg != nil && pdi.cfg.GetAlert(pdClient.GetTitle(), experimentalEnabled) != nil
 
 	if hasAlert {
 		logging.Infof("Incident %s has a configured alert, returning InterceptorResponse `Continue: true`.", pdClient.GetIncidentID())
@@ -217,7 +217,7 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 	}
 
 	// AI fallback: if ai_agent is configured, allow the pipeline to run for AI investigation
-	if experimentalEnabled && pdi.filterConfig != nil && pdi.filterConfig.AIAgent != nil {
+	if experimentalEnabled && pdi.cfg != nil && pdi.cfg.AIAgent != nil {
 		logging.Infof("No alert match, but AI agent configured — checking cluster existence")
 		resp := clusterExists(pdClient, ocmClient)
 		if resp != nil {

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -62,8 +62,8 @@ type interceptorHandler struct {
 	cfg      *config.Config
 }
 
-func CreateInterceptorHandler(pdTokens []string) (http.Handler, error) {
-	cfg, err := config.LoadConfig("", investigations.GetAvailableInvestigationsNames())
+func CreateInterceptorHandler(pdTokens []string, configPath string) (http.Handler, error) {
+	cfg, err := config.LoadConfig(configPath, investigations.GetAvailableInvestigationsNames())
 	if err != nil {
 		return nil, fmt.Errorf("loading investigation config: %w", err)
 	}

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -59,12 +59,14 @@ type Organization struct {
 type interceptorHandler struct {
 	PDTokens     []string
 	filterConfig *config.Config
-	configErr    error
 }
 
-func CreateInterceptorHandler(pdTokens []string) http.Handler {
+func CreateInterceptorHandler(pdTokens []string) (http.Handler, error) {
 	cfg, err := config.LoadConfig("", investigations.GetAvailableInvestigationsNames())
-	return &interceptorHandler{PDTokens: pdTokens, filterConfig: cfg, configErr: err}
+	if err != nil {
+		return nil, fmt.Errorf("loading investigation config: %w", err)
+	}
+	return &interceptorHandler{PDTokens: pdTokens, filterConfig: cfg}, nil
 }
 
 func (pdi interceptorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -207,10 +209,6 @@ func (pdi *interceptorHandler) process(ctx context.Context, r *triggersv1.Interc
 	experimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
 
 	// Check if an alert config exists for this alert (config loaded at handler creation)
-	if pdi.configErr != nil {
-		logging.Warnf("Investigation config load error: %v", pdi.configErr)
-	}
-
 	hasAlert := pdi.filterConfig != nil && pdi.filterConfig.GetAlert(pdClient.GetTitle(), experimentalEnabled) != nil
 
 	if hasAlert {

--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -223,13 +223,11 @@ func stringContains(s, substr string) bool {
 }
 
 func TestOversizedRequestBodyIsRejected(t *testing.T) {
-	t.Setenv("CAD_INVESTIGATION_CONFIG_PATH", "testdata/minimal-config.yaml")
-
 	oversizedBody := bytes.Repeat([]byte("A"), 10*1024*1024) // 10 MiB
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader(oversizedBody))
 	rec := httptest.NewRecorder()
 
-	handler, err := CreateInterceptorHandler([]string{"TEST"})
+	handler, err := CreateInterceptorHandler([]string{"TEST"}, "testdata/minimal-config.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +354,7 @@ func TestSignatureVerification(t *testing.T) {
 			req := makeSignedRequest(t, innerBody, tt.signingSecret)
 			rec := httptest.NewRecorder()
 
-			handler, err := CreateInterceptorHandler(tt.tokens)
+			handler, err := CreateInterceptorHandler(tt.tokens, "testdata/minimal-config.yaml")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -2,6 +2,7 @@ package interceptor
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -225,7 +226,7 @@ func TestOversizedRequestBodyIsRejected(t *testing.T) {
 	t.Setenv("CAD_INVESTIGATION_CONFIG_PATH", "testdata/minimal-config.yaml")
 
 	oversizedBody := bytes.Repeat([]byte("A"), 10*1024*1024) // 10 MiB
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(oversizedBody))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader(oversizedBody))
 	rec := httptest.NewRecorder()
 
 	handler, err := CreateInterceptorHandler([]string{"TEST"})
@@ -288,6 +289,8 @@ func makeSignedRequest(t *testing.T, innerBody, signingSecret string) *http.Requ
 // Note: webhookv3.VerifySignature restores r.Body after reading it, so
 // iterating the same extractedRequest over multiple tokens is safe.
 func TestSignatureVerification(t *testing.T) {
+	t.Setenv("CAD_INVESTIGATION_CONFIG_PATH", "testdata/minimal-config.yaml")
+
 	const (
 		secret1   = "signing-secret-one"
 		secret2   = "signing-secret-two"

--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
+
 	"testing"
 
 	ocmmock "github.com/openshift/configuration-anomaly-detection/pkg/ocm/mock"
@@ -356,101 +356,6 @@ func TestSignatureVerification(t *testing.T) {
 			}
 			if tt.wantBodyContains != "" && !stringContains(rec.Body.String(), tt.wantBodyContains) {
 				t.Errorf("body = %q, want it to contain %q", rec.Body.String(), tt.wantBodyContains)
-			}
-		})
-	}
-}
-
-func TestShouldRunAIInvestigation(t *testing.T) {
-	// Helper to write a filter config file and set the env var.
-	setupFilterConfig := func(t *testing.T, yaml string) {
-		t.Helper()
-		path := t.TempDir() + "/filter.yaml"
-		if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		t.Setenv("CAD_INVESTIGATION_CONFIG_PATH", path)
-	}
-
-	tests := []struct {
-		name         string
-		filterYAML   string // empty = no filter config
-		expectResult bool
-	}{
-		{
-			name:         "no filter config — AI disabled",
-			filterYAML:   "",
-			expectResult: false,
-		},
-		{
-			name: "filter config without aiassisted entry — AI disabled",
-			filterYAML: `
-filters:
-  - investigation: mustgather
-    when:
-      field: CloudProvider
-      operator: in
-      values: ["aws"]
-`,
-			expectResult: false,
-		},
-		{
-			name: "no ai_agent config — AI disabled",
-			filterYAML: `
-filters:
-  - investigation: mustgather
-    when:
-      field: CloudProvider
-      operator: in
-      values: ["aws"]
-`,
-			expectResult: false,
-		},
-		{
-			name: "ai_agent and aiassisted filter present — AI enabled",
-			filterYAML: `
-ai_agent:
-  runtime_arn: "arn:test"
-  user_id: "test"
-  region: "us-east-1"
-  invoker_role_arn: "arn:aws:iam::123456789012:role/test"
-filters:
-  - investigation: aiassisted
-    when:
-      or:
-        - field: ClusterID
-          operator: in
-          values: ["cluster-1"]
-`,
-			expectResult: true,
-		},
-		{
-			name: "aiassisted with no filter tree — AI enabled (no filtering)",
-			filterYAML: `
-ai_agent:
-  runtime_arn: "arn:test"
-  user_id: "test"
-  region: "us-east-1"
-  invoker_role_arn: "arn:aws:iam::123456789012:role/test"
-filters:
-  - investigation: aiassisted
-`,
-			expectResult: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.filterYAML != "" {
-				setupFilterConfig(t, tt.filterYAML)
-			} else {
-				t.Setenv("CAD_INVESTIGATION_CONFIG_PATH", "")
-			}
-
-			result := shouldRunAIInvestigation()
-
-			if result != tt.expectResult {
-				t.Errorf("shouldRunAIInvestigation() = %v, want %v", result, tt.expectResult)
 			}
 		})
 	}

--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-
 	"testing"
 
 	ocmmock "github.com/openshift/configuration-anomaly-detection/pkg/ocm/mock"
@@ -223,6 +222,8 @@ func stringContains(s, substr string) bool {
 }
 
 func TestOversizedRequestBodyIsRejected(t *testing.T) {
+	t.Setenv("CAD_INVESTIGATION_CONFIG_PATH", "testdata/minimal-config.yaml")
+
 	oversizedBody := bytes.Repeat([]byte("A"), 10*1024*1024) // 10 MiB
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(oversizedBody))
 	rec := httptest.NewRecorder()

--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -227,7 +227,10 @@ func TestOversizedRequestBodyIsRejected(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(oversizedBody))
 	rec := httptest.NewRecorder()
 
-	handler := CreateInterceptorHandler([]string{"TEST"})
+	handler, err := CreateInterceptorHandler([]string{"TEST"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusRequestEntityTooLarge {
@@ -349,7 +352,12 @@ func TestSignatureVerification(t *testing.T) {
 			req := makeSignedRequest(t, innerBody, tt.signingSecret)
 			rec := httptest.NewRecorder()
 
-			CreateInterceptorHandler(tt.tokens).ServeHTTP(rec, req)
+			handler, err := CreateInterceptorHandler(tt.tokens)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			handler.ServeHTTP(rec, req)
 
 			if rec.Code != tt.wantStatus {
 				t.Errorf("status = %d, want %d (body: %s)", rec.Code, tt.wantStatus, rec.Body.String())

--- a/interceptor/pkg/interceptor/testdata/minimal-config.yaml
+++ b/interceptor/pkg/interceptor/testdata/minimal-config.yaml
@@ -1,0 +1,4 @@
+alerts:
+  - alert_title: test
+    investigations:
+      - precheck

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
@@ -14,11 +15,6 @@ import (
 const (
 	// ConfigEnvVar is the environment variable that holds the path to the investigation filter config file.
 	ConfigEnvVar = "CAD_INVESTIGATION_CONFIG_PATH"
-
-	// LegacyAIConfigEnvVar is the legacy environment variable that holds the AI agent config as JSON.
-	//
-	// Deprecated: use the ai_agent section in the config file instead.
-	LegacyAIConfigEnvVar = "CAD_AI_AGENT_CONFIG"
 )
 
 // AIAgentConfig holds runtime configuration for AgentCore AI investigations.
@@ -41,142 +37,68 @@ func (c *AIAgentConfig) GetTimeout() time.Duration {
 	return time.Duration(c.TimeoutSeconds) * time.Second
 }
 
-// Config holds the complete investigation filter configuration.
+// Config holds the complete investigation configuration.
 type Config struct {
-	AIAgent *AIAgentConfig        `yaml:"ai_agent,omitempty"`
-	Filters []InvestigationFilter `yaml:"filters"`
+	AIAgent        *AIAgentConfig        `yaml:"ai_agent,omitempty"`
+	Investigations []InvestigationConfig `yaml:"investigations"`
 }
 
-// LoadConfig reads and parses the investigation filter configuration.
+// InvestigationConfig defines which chain of investigations to run for a given alert.
+type InvestigationConfig struct {
+	AlertTitle   string       `yaml:"alert_title"`
+	Experimental bool         `yaml:"experimental,omitempty"`
+	When         *FilterNode  `yaml:"when,omitempty"`
+	Chain        []ChainEntry `yaml:"chain"`
+}
+
+// ChainEntry is a single step in an investigation chain.
+// In YAML it can be a bare string (investigation name) or an object with name + optional when filter.
+type ChainEntry struct {
+	Name string      `yaml:"name"`
+	When *FilterNode `yaml:"when,omitempty"`
+}
+
+// UnmarshalYAML allows ChainEntry to be specified as either a bare string or a mapping.
+func (e *ChainEntry) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		e.Name = value.Value
+		return nil
+	}
+	type raw ChainEntry
+	return value.Decode((*raw)(e))
+}
+
+// LoadConfig reads and parses the investigation configuration.
 // If pathOverride is non-empty, it is used as the config file path.
 // Otherwise, the path is read from the CAD_INVESTIGATION_CONFIG_PATH environment variable.
-// If neither is set, falls back to the legacy CAD_AI_AGENT_CONFIG JSON env var for
-// backwards compatibility.
-// Returns nil (no config) if no source is available.
+// Returns nil if no config file is found (optional ConfigMap mount).
 // The validInvestigations parameter is the list of known investigation names used to
-// validate that each filter references a real investigation.
+// validate that each chain entry references a real investigation.
 func LoadConfig(pathOverride string, validInvestigations []string) (*Config, error) {
 	path := pathOverride
 	if path == "" {
 		path = os.Getenv(ConfigEnvVar)
 	}
-	if path != "" {
-		data, err := os.ReadFile(path) //nolint:gosec // path is from a trusted env var, not user input
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				// The config file is optional (e.g. mounted from an optional ConfigMap).
-				// Treat a missing file the same as "no config".
-				logging.Infof("Config file %q not found, continuing without config", path)
-				return nil, nil //nolint:nilnil // no config means "no filtering configured"
-			}
-			return nil, fmt.Errorf("failed to read config file %q: %w", path, err)
+	if path == "" {
+		return nil, nil //nolint:nilnil // no config path means "no config"
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // path is from a trusted env var, not user input
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// The config file is optional (e.g. mounted from an optional ConfigMap).
+			// Treat a missing file the same as "no config".
+			logging.Infof("Config file %q not found, continuing without config", path)
+			return nil, nil //nolint:nilnil // no config means "no filtering configured"
 		}
-		return ParseConfig(data, validInvestigations)
+		return nil, fmt.Errorf("failed to read config file %q: %w", path, err)
 	}
-
-	// Fall back to legacy CAD_AI_AGENT_CONFIG env var.
-	return loadLegacyAIConfig()
-}
-
-// legacyAIAgentConfig is the old JSON-based AI agent configuration from CAD_AI_AGENT_CONFIG.
-type legacyAIAgentConfig struct {
-	RuntimeARN         string   `json:"runtime_arn"`
-	UserID             string   `json:"user_id"`
-	Region             string   `json:"region"`
-	InvokerRoleArn     string   `json:"invoker_role_arn,omitempty"`
-	Version            string   `json:"version,omitempty"`
-	OpsSopVersion      string   `json:"ops_sop_version,omitempty"`
-	RosaPluginsVersion string   `json:"rosa_plugins_version,omitempty"`
-	Organizations      []string `json:"organizations"`
-	Clusters           []string `json:"clusters"`
-	Enabled            bool     `json:"enabled"`
-	TimeoutSeconds     int      `json:"timeout_seconds,omitempty"`
-}
-
-// loadLegacyAIConfig parses the legacy CAD_AI_AGENT_CONFIG JSON env var and converts it
-// into a Config with a synthesized aiassisted filter entry built from the old allowlists.
-// Returns nil if the env var is not set or enabled is false.
-func loadLegacyAIConfig() (*Config, error) {
-	configJSON := os.Getenv(LegacyAIConfigEnvVar)
-	if configJSON == "" {
-		return nil, nil //nolint:nilnil // no config means "no filtering configured"
-	}
-
-	var legacy legacyAIAgentConfig
-	if err := json.Unmarshal([]byte(configJSON), &legacy); err != nil {
-		return nil, fmt.Errorf("failed to parse %s: %w", LegacyAIConfigEnvVar, err)
-	}
-
-	if !legacy.Enabled {
-		return nil, nil //nolint:nilnil // disabled means no AI config
-	}
-
-	logging.Warnf("Using deprecated %s env var — migrate to a config file via %s", LegacyAIConfigEnvVar, ConfigEnvVar)
-
-	timeout := legacy.TimeoutSeconds
-	if timeout == 0 {
-		timeout = 900
-	}
-
-	// Build an OR filter from the old cluster/org allowlists.
-	filter := buildLegacyAllowlistFilter(legacy.Clusters, legacy.Organizations)
-	if filter == nil {
-		return nil, fmt.Errorf("%s: enabled but no clusters or organizations in allowlist", LegacyAIConfigEnvVar)
-	}
-
-	return &Config{
-		AIAgent: &AIAgentConfig{
-			RuntimeARN:         legacy.RuntimeARN,
-			UserID:             legacy.UserID,
-			Region:             legacy.Region,
-			InvokerRoleArn:     legacy.InvokerRoleArn,
-			Version:            legacy.Version,
-			OpsSopVersion:      legacy.OpsSopVersion,
-			RosaPluginsVersion: legacy.RosaPluginsVersion,
-			TimeoutSeconds:     timeout,
-		},
-		Filters: []InvestigationFilter{
-			{
-				Investigation: "aiassisted",
-				Filter:        filter,
-			},
-		},
-	}, nil
-}
-
-// buildLegacyAllowlistFilter converts the old clusters/organizations allowlists
-// into a filter tree. Returns nil if both lists are empty.
-func buildLegacyAllowlistFilter(clusters, organizations []string) *FilterNode {
-	var children []FilterNode
-
-	if len(clusters) > 0 {
-		children = append(children, FilterNode{
-			Field:    FieldClusterID,
-			Operator: OperatorIn,
-			Values:   clusters,
-		})
-	}
-
-	if len(organizations) > 0 {
-		children = append(children, FilterNode{
-			Field:    FieldOrganizationID,
-			Operator: OperatorIn,
-			Values:   organizations,
-		})
-	}
-
-	if len(children) == 0 {
-		return nil
-	}
-	if len(children) == 1 {
-		return &children[0]
-	}
-	return &FilterNode{Or: children}
+	return ParseConfig(data, validInvestigations)
 }
 
 // ParseConfig parses and validates a YAML config from raw bytes.
 // The validInvestigations parameter is the list of known investigation names used to
-// validate that each filter references a real investigation.
+// validate that each chain entry references a real investigation.
 func ParseConfig(data []byte, validInvestigations []string) (*Config, error) {
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
@@ -195,6 +117,23 @@ func ParseConfig(data []byte, validInvestigations []string) (*Config, error) {
 	return &cfg, nil
 }
 
+// GetChain returns the first InvestigationConfig whose AlertTitle is contained in the given alert title.
+// Chains marked experimental are only returned when experimentalEnabled is true.
+func (c *Config) GetChain(alertTitle string, experimentalEnabled bool) *InvestigationConfig {
+	if c == nil {
+		return nil
+	}
+	for i := range c.Investigations {
+		if strings.Contains(alertTitle, c.Investigations[i].AlertTitle) {
+			if c.Investigations[i].Experimental && !experimentalEnabled {
+				continue
+			}
+			return &c.Investigations[i]
+		}
+	}
+	return nil
+}
+
 // GetAIAgentConfig returns the AI agent runtime configuration, or nil if not set.
 func (c *Config) GetAIAgentConfig() *AIAgentConfig {
 	if c == nil {
@@ -203,8 +142,8 @@ func (c *Config) GetAIAgentConfig() *AIAgentConfig {
 	return c.AIAgent
 }
 
-// Validate checks that all investigation names are known and all filter expressions
-// reference valid FilterContext fields.
+// Validate checks that all investigation names are known, all filter expressions
+// reference valid FilterContext fields, and chain-level/entry-level when clauses are valid.
 func (c *Config) Validate(validInvestigations []string) error {
 	if c.AIAgent != nil {
 		if c.AIAgent.RuntimeARN == "" {
@@ -222,56 +161,65 @@ func (c *Config) Validate(validInvestigations []string) error {
 	}
 
 	seen := make(map[string]bool)
+	hasAIAssisted := false
 
-	for i, f := range c.Filters {
-		if f.Investigation == "" {
-			return fmt.Errorf("filters[%d]: investigation name must not be empty", i)
+	for i, ic := range c.Investigations {
+		if ic.AlertTitle == "" {
+			return fmt.Errorf("investigations[%d]: alert_title must not be empty", i)
 		}
 
-		if seen[f.Investigation] {
-			return fmt.Errorf("filters[%d]: duplicate investigation %q", i, f.Investigation)
+		if seen[ic.AlertTitle] {
+			return fmt.Errorf("investigations[%d]: duplicate alert_title %q", i, ic.AlertTitle)
 		}
-		seen[f.Investigation] = true
+		seen[ic.AlertTitle] = true
 
-		if !isValidInvestigation(f.Investigation, validInvestigations) {
-			return fmt.Errorf("filters[%d]: unknown investigation %q; valid investigations: %v", i, f.Investigation, validInvestigations)
+		if len(ic.Chain) == 0 {
+			return fmt.Errorf("investigations[%d] (alert_title %q): chain must not be empty", i, ic.AlertTitle)
 		}
 
-		if f.Filter != nil {
-			if err := f.Filter.validate(fmt.Sprintf("filters[%d].when", i)); err != nil {
-				return fmt.Errorf("filters[%d] (investigation %q): %w", i, f.Investigation, err)
+		// Validate chain-level when clause
+		if ic.When != nil {
+			if err := ic.When.validate(fmt.Sprintf("investigations[%d].when", i)); err != nil {
+				return fmt.Errorf("investigations[%d] (alert_title %q): %w", i, ic.AlertTitle, err)
 			}
 		}
 
-		if f.Investigation == "aiassisted" {
-			if c.AIAgent == nil {
-				return fmt.Errorf("filters[%d]: investigation %q requires ai_agent configuration", i, f.Investigation)
+		for j, entry := range ic.Chain {
+			if entry.Name == "" {
+				return fmt.Errorf("investigations[%d].chain[%d]: name must not be empty", i, j)
+			}
+
+			if !isValidInvestigation(entry.Name, validInvestigations) {
+				return fmt.Errorf("investigations[%d].chain[%d]: unknown investigation %q; valid investigations: %v", i, j, entry.Name, validInvestigations)
+			}
+
+			if entry.Name == "aiassisted" {
+				hasAIAssisted = true
+				// aiassisted must always be gated by a filter to prevent uncontrolled
+				// AI execution. Either a chain-level or entry-level when clause satisfies this.
+				if ic.When == nil && entry.When == nil {
+					return fmt.Errorf(
+						"investigations[%d].chain[%d]: aiassisted requires a 'when' filter "+
+							"(on the chain or entry level) to control execution", i, j)
+				}
+			}
+
+			// Validate entry-level when clause
+			if entry.When != nil {
+				if err := entry.When.validate(fmt.Sprintf("investigations[%d].chain[%d].when", i, j)); err != nil {
+					return fmt.Errorf("investigations[%d].chain[%d] (investigation %q): %w", i, j, entry.Name, err)
+				}
 			}
 		}
 	}
 
-	return nil
-}
+	if hasAIAssisted && c.AIAgent == nil {
+		return fmt.Errorf("aiassisted investigation requires ai_agent configuration")
+	}
 
-// GetFilter returns the filter for the given investigation name, or nil if no filter
-// is configured. A nil return means the investigation should always run.
-func (c *Config) GetFilter(investigationName string) *InvestigationFilter {
-	if c == nil {
-		return nil
-	}
-	for i := range c.Filters {
-		if c.Filters[i].Investigation == investigationName {
-			return &c.Filters[i]
-		}
-	}
 	return nil
 }
 
 func isValidInvestigation(name string, valid []string) bool {
-	for _, v := range valid {
-		if v == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(valid, name)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,14 +1,12 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"slices"
 	"strings"
 	"time"
 
-	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"gopkg.in/yaml.v3"
 )
 
@@ -71,7 +69,7 @@ func (e *ChainEntry) UnmarshalYAML(value *yaml.Node) error {
 // LoadConfig reads and parses the investigation configuration.
 // If pathOverride is non-empty, it is used as the config file path.
 // Otherwise, the path is read from the CAD_INVESTIGATION_CONFIG_PATH environment variable.
-// Returns nil if no config file is found (optional ConfigMap mount).
+// Returns an error if no config path is provided or the file cannot be read.
 // The validInvestigations parameter is the list of known investigation names used to
 // validate that each chain entry references a real investigation.
 func LoadConfig(pathOverride string, validInvestigations []string) (*Config, error) {
@@ -80,17 +78,11 @@ func LoadConfig(pathOverride string, validInvestigations []string) (*Config, err
 		path = os.Getenv(ConfigEnvVar)
 	}
 	if path == "" {
-		return nil, nil //nolint:nilnil // no config path means "no config"
+		return nil, fmt.Errorf("investigation config path not provided: set %s or pass a path override", ConfigEnvVar)
 	}
 
 	data, err := os.ReadFile(path) //nolint:gosec // path is from a trusted env var, not user input
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// The config file is optional (e.g. mounted from an optional ConfigMap).
-			// Treat a missing file the same as "no config".
-			logging.Infof("Config file %q not found, continuing without config", path)
-			return nil, nil //nolint:nilnil // no config means "no filtering configured"
-		}
 		return nil, fmt.Errorf("failed to read config file %q: %w", path, err)
 	}
 	return ParseConfig(data, validInvestigations)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,7 +167,7 @@ func (c *Config) Validate(validInvestigations []string) error {
 	hasAIAssisted := false
 
 	for i, ac := range c.Alerts {
-		if ac.AlertTitle == "" {
+		if strings.TrimSpace(ac.AlertTitle) == "" {
 			return fmt.Errorf("alerts[%d]: alert_title must not be empty", i)
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,43 +37,43 @@ func (c *AIAgentConfig) GetTimeout() time.Duration {
 
 // Config holds the complete investigation configuration.
 type Config struct {
-	AIAgent        *AIAgentConfig        `yaml:"ai_agent,omitempty"`
-	Investigations []InvestigationConfig `yaml:"investigations"`
+	AIAgent *AIAgentConfig `yaml:"ai_agent,omitempty"`
+	Alerts  []AlertConfig  `yaml:"alerts"`
 }
 
-// InvestigationConfig defines which chain of investigations to run for a given alert.
-type InvestigationConfig struct {
-	AlertTitle   string       `yaml:"alert_title"`
-	Name         string       `yaml:"name,omitempty"`
-	Experimental bool         `yaml:"experimental,omitempty"`
-	When         *FilterNode  `yaml:"when,omitempty"`
-	Chain        []ChainEntry `yaml:"chain"`
+// AlertConfig defines which investigations to run for a given alert.
+type AlertConfig struct {
+	AlertTitle     string               `yaml:"alert_title"`
+	Name           string               `yaml:"name,omitempty"`
+	Experimental   bool                 `yaml:"experimental,omitempty"`
+	When           *FilterNode          `yaml:"when,omitempty"`
+	Investigations []InvestigationEntry `yaml:"investigations"`
 }
 
-// GetName returns the chain's investigation name, falling back to AlertTitle
+// GetName returns the alert's investigation name, falling back to AlertTitle
 // when Name is not set. This preserves backward compatibility with configs
 // that predate the name field.
-func (ic *InvestigationConfig) GetName() string {
-	if ic.Name != "" {
-		return ic.Name
+func (ac *AlertConfig) GetName() string {
+	if ac.Name != "" {
+		return ac.Name
 	}
-	return ic.AlertTitle
+	return ac.AlertTitle
 }
 
-// ChainEntry is a single step in an investigation chain.
+// InvestigationEntry is a single investigation step within an alert's investigation list.
 // In YAML it can be a bare string (investigation name) or an object with name + optional when filter.
-type ChainEntry struct {
+type InvestigationEntry struct {
 	Name string      `yaml:"name"`
 	When *FilterNode `yaml:"when,omitempty"`
 }
 
-// UnmarshalYAML allows ChainEntry to be specified as either a bare string or a mapping.
-func (e *ChainEntry) UnmarshalYAML(value *yaml.Node) error {
+// UnmarshalYAML allows InvestigationEntry to be specified as either a bare string or a mapping.
+func (e *InvestigationEntry) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind == yaml.ScalarNode {
 		e.Name = value.Value
 		return nil
 	}
-	type raw ChainEntry
+	type raw InvestigationEntry
 	return value.Decode((*raw)(e))
 }
 
@@ -120,18 +120,18 @@ func ParseConfig(data []byte, validInvestigations []string) (*Config, error) {
 	return &cfg, nil
 }
 
-// GetChain returns the first InvestigationConfig whose AlertTitle is contained in the given alert title.
-// Chains marked experimental are only returned when experimentalEnabled is true.
-func (c *Config) GetChain(alertTitle string, experimentalEnabled bool) *InvestigationConfig {
+// GetAlert returns the first AlertConfig whose AlertTitle is contained in the given alert title.
+// Alerts marked experimental are only returned when experimentalEnabled is true.
+func (c *Config) GetAlert(alertTitle string, experimentalEnabled bool) *AlertConfig {
 	if c == nil {
 		return nil
 	}
-	for i := range c.Investigations {
-		if strings.Contains(alertTitle, c.Investigations[i].AlertTitle) {
-			if c.Investigations[i].Experimental && !experimentalEnabled {
+	for i := range c.Alerts {
+		if strings.Contains(alertTitle, c.Alerts[i].AlertTitle) {
+			if c.Alerts[i].Experimental && !experimentalEnabled {
 				continue
 			}
-			return &c.Investigations[i]
+			return &c.Alerts[i]
 		}
 	}
 	return nil
@@ -166,51 +166,51 @@ func (c *Config) Validate(validInvestigations []string) error {
 	seen := make(map[string]bool)
 	hasAIAssisted := false
 
-	for i, ic := range c.Investigations {
-		if ic.AlertTitle == "" {
-			return fmt.Errorf("investigations[%d]: alert_title must not be empty", i)
+	for i, ac := range c.Alerts {
+		if ac.AlertTitle == "" {
+			return fmt.Errorf("alerts[%d]: alert_title must not be empty", i)
 		}
 
-		if seen[ic.AlertTitle] {
-			return fmt.Errorf("investigations[%d]: duplicate alert_title %q", i, ic.AlertTitle)
+		if seen[ac.AlertTitle] {
+			return fmt.Errorf("alerts[%d]: duplicate alert_title %q", i, ac.AlertTitle)
 		}
-		seen[ic.AlertTitle] = true
+		seen[ac.AlertTitle] = true
 
-		if len(ic.Chain) == 0 {
-			return fmt.Errorf("investigations[%d] (alert_title %q): chain must not be empty", i, ic.AlertTitle)
+		if len(ac.Investigations) == 0 {
+			return fmt.Errorf("alerts[%d] (alert_title %q): investigations must not be empty", i, ac.AlertTitle)
 		}
 
-		// Validate chain-level when clause
-		if ic.When != nil {
-			if err := ic.When.validate(fmt.Sprintf("investigations[%d].when", i)); err != nil {
-				return fmt.Errorf("investigations[%d] (alert_title %q): %w", i, ic.AlertTitle, err)
+		// Validate alert-level when clause
+		if ac.When != nil {
+			if err := ac.When.validate(fmt.Sprintf("alerts[%d].when", i)); err != nil {
+				return fmt.Errorf("alerts[%d] (alert_title %q): %w", i, ac.AlertTitle, err)
 			}
 		}
 
-		for j, entry := range ic.Chain {
+		for j, entry := range ac.Investigations {
 			if entry.Name == "" {
-				return fmt.Errorf("investigations[%d].chain[%d]: name must not be empty", i, j)
+				return fmt.Errorf("alerts[%d].investigations[%d]: name must not be empty", i, j)
 			}
 
 			if !isValidInvestigation(entry.Name, validInvestigations) {
-				return fmt.Errorf("investigations[%d].chain[%d]: unknown investigation %q; valid investigations: %v", i, j, entry.Name, validInvestigations)
+				return fmt.Errorf("alerts[%d].investigations[%d]: unknown investigation %q; valid investigations: %v", i, j, entry.Name, validInvestigations)
 			}
 
 			if entry.Name == "aiassisted" {
 				hasAIAssisted = true
 				// aiassisted must always be gated by a filter to prevent uncontrolled
-				// AI execution. Either a chain-level or entry-level when clause satisfies this.
-				if ic.When == nil && entry.When == nil {
+				// AI execution. Either an alert-level or entry-level when clause satisfies this.
+				if ac.When == nil && entry.When == nil {
 					return fmt.Errorf(
-						"investigations[%d].chain[%d]: aiassisted requires a 'when' filter "+
-							"(on the chain or entry level) to control execution", i, j)
+						"alerts[%d].investigations[%d]: aiassisted requires a 'when' filter "+
+							"(on the alert or entry level) to control execution", i, j)
 				}
 			}
 
 			// Validate entry-level when clause
 			if entry.When != nil {
-				if err := entry.When.validate(fmt.Sprintf("investigations[%d].chain[%d].when", i, j)); err != nil {
-					return fmt.Errorf("investigations[%d].chain[%d] (investigation %q): %w", i, j, entry.Name, err)
+				if err := entry.When.validate(fmt.Sprintf("alerts[%d].investigations[%d].when", i, j)); err != nil {
+					return fmt.Errorf("alerts[%d].investigations[%d] (investigation %q): %w", i, j, entry.Name, err)
 				}
 			}
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -198,13 +198,6 @@ func (c *Config) Validate(validInvestigations []string) error {
 
 			if entry.Name == "aiassisted" {
 				hasAIAssisted = true
-				// aiassisted must always be gated by a filter to prevent uncontrolled
-				// AI execution. Either an alert-level or entry-level when clause satisfies this.
-				if ac.When == nil && entry.When == nil {
-					return fmt.Errorf(
-						"alerts[%d].investigations[%d]: aiassisted requires a 'when' filter "+
-							"(on the alert or entry level) to control execution", i, j)
-				}
 			}
 
 			// Validate entry-level when clause

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,11 +10,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	// ConfigEnvVar is the environment variable that holds the path to the investigation filter config file.
-	ConfigEnvVar = "CAD_INVESTIGATION_CONFIG_PATH"
-)
-
 // AIAgentConfig holds runtime configuration for AgentCore AI investigations.
 type AIAgentConfig struct {
 	RuntimeARN     string `yaml:"runtime_arn"`      // AWS ARN of the agent runtime to invoke
@@ -77,22 +72,16 @@ func (e *InvestigationEntry) UnmarshalYAML(value *yaml.Node) error {
 	return value.Decode((*raw)(e))
 }
 
-// LoadConfig reads and parses the investigation configuration.
-// If pathOverride is non-empty, it is used as the config file path.
-// Otherwise, the path is read from the CAD_INVESTIGATION_CONFIG_PATH environment variable.
-// Returns an error if no config path is provided or the file cannot be read.
+// LoadConfig reads and parses the investigation configuration from the given path.
+// Returns an error if the path is empty or the file cannot be read.
 // The validInvestigations parameter is the list of known investigation names used to
 // validate that each chain entry references a real investigation.
-func LoadConfig(pathOverride string, validInvestigations []string) (*Config, error) {
-	path := pathOverride
+func LoadConfig(path string, validInvestigations []string) (*Config, error) {
 	if path == "" {
-		path = os.Getenv(ConfigEnvVar)
-	}
-	if path == "" {
-		return nil, fmt.Errorf("investigation config path not provided: set %s or pass a path override", ConfigEnvVar)
+		return nil, fmt.Errorf("investigation config path must not be empty")
 	}
 
-	data, err := os.ReadFile(path) //nolint:gosec // path is from a trusted env var, not user input
+	data, err := os.ReadFile(path) //nolint:gosec // path is from a trusted source, not user input
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file %q: %w", path, err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,9 +44,20 @@ type Config struct {
 // InvestigationConfig defines which chain of investigations to run for a given alert.
 type InvestigationConfig struct {
 	AlertTitle   string       `yaml:"alert_title"`
+	Name         string       `yaml:"name,omitempty"`
 	Experimental bool         `yaml:"experimental,omitempty"`
 	When         *FilterNode  `yaml:"when,omitempty"`
 	Chain        []ChainEntry `yaml:"chain"`
+}
+
+// GetName returns the chain's investigation name, falling back to AlertTitle
+// when Name is not set. This preserves backward compatibility with configs
+// that predate the name field.
+func (ic *InvestigationConfig) GetName() string {
+	if ic.Name != "" {
+		return ic.Name
+	}
+	return ic.AlertTitle
 }
 
 // ChainEntry is a single step in an investigation chain.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,16 +7,16 @@ import (
 	"time"
 )
 
-const testMustgatherFilterYAML = `
-filters:
-  - investigation: mustgather
-    when:
-      field: CloudProvider
-      operator: in
-      values: ["aws"]
+const testMustgatherChainYAML = `
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - mustgather
 `
 
 var testInvestigations = []string{
+	"precheck",
+	"ccam",
 	"aiassisted",
 	"Cluster Has Gone Missing (CHGM)",
 	"clustermonitoringerrorbudgetburn",
@@ -28,6 +28,8 @@ var testInvestigations = []string{
 	"restartcontrolplane",
 	"cannotretrieveupdatessre",
 	"mustgather",
+	"ocmagentresponsefailure",
+	"describenodes",
 }
 
 func TestParseConfig(t *testing.T) { //nolint:maintidx,gocyclo // table-driven test with many cases
@@ -38,214 +40,200 @@ func TestParseConfig(t *testing.T) { //nolint:maintidx,gocyclo // table-driven t
 		check   func(t *testing.T, cfg *Config)
 	}{
 		{
-			name: "valid config with one filter",
-			yaml: testMustgatherFilterYAML,
+			name: "valid config with one chain",
+			yaml: testMustgatherChainYAML,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if len(cfg.Filters) != 1 {
-					t.Fatalf("expected 1 filter, got %d", len(cfg.Filters))
+				if len(cfg.Investigations) != 1 {
+					t.Fatalf("expected 1 investigation, got %d", len(cfg.Investigations))
 				}
-				if cfg.Filters[0].Investigation != "mustgather" {
-					t.Errorf("expected investigation mustgather, got %q", cfg.Filters[0].Investigation)
+				if cfg.Investigations[0].AlertTitle != "TestAlert" {
+					t.Errorf("expected alert_title TestAlert, got %q", cfg.Investigations[0].AlertTitle)
 				}
-				if cfg.Filters[0].Filter == nil {
-					t.Fatal("expected filter node, got nil")
+				if len(cfg.Investigations[0].Chain) != 1 {
+					t.Fatalf("expected 1 chain entry, got %d", len(cfg.Investigations[0].Chain))
+				}
+				if cfg.Investigations[0].Chain[0].Name != "mustgather" {
+					t.Errorf("expected chain entry mustgather, got %q", cfg.Investigations[0].Chain[0].Name)
 				}
 			},
 		},
 		{
-			name: "valid config with multiple filters",
+			name: "valid config with multiple chain entries and bare strings",
 			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      and:
-        - field: CloudProvider
-          operator: in
-          values: ["aws"]
-        - field: ClusterState
-          operator: in
-          values: ["ready"]
-  - investigation: etcddatabasequotalowspace
-    when:
-      field: HCP
-      operator: in
-      values: ["false"]
+investigations:
+  - alert_title: "has gone missing"
+    chain:
+      - precheck
+      - ccam
+      - "Cluster Has Gone Missing (CHGM)"
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if len(cfg.Filters) != 2 {
-					t.Fatalf("expected 2 filters, got %d", len(cfg.Filters))
+				if len(cfg.Investigations[0].Chain) != 3 {
+					t.Fatalf("expected 3 chain entries, got %d", len(cfg.Investigations[0].Chain))
 				}
-				f := cfg.GetFilter("mustgather")
-				if f == nil || f.Filter == nil {
-					t.Fatal("expected filter for mustgather")
+				if cfg.Investigations[0].Chain[0].Name != "precheck" {
+					t.Errorf("chain[0] = %q, want precheck", cfg.Investigations[0].Chain[0].Name)
 				}
-				if len(f.Filter.And) != 2 {
-					t.Errorf("mustgather: expected 2 AND children, got %d", len(f.Filter.And))
-				}
-				f = cfg.GetFilter("etcddatabasequotalowspace")
-				if f == nil || f.Filter == nil {
-					t.Fatal("expected filter for etcddatabasequotalowspace")
-				}
-				if f.Filter.Field != "HCP" {
-					t.Errorf("etcddatabasequotalowspace: expected field HCP, got %q", f.Filter.Field)
+				if cfg.Investigations[0].Chain[2].Name != "Cluster Has Gone Missing (CHGM)" {
+					t.Errorf("chain[2] = %q", cfg.Investigations[0].Chain[2].Name)
 				}
 			},
 		},
 		{
-			name: "empty filters list is valid",
+			name: "chain entry with when filter (object form)",
 			yaml: `
-filters: []
+investigations:
+  - alert_title: "has gone missing"
+    chain:
+      - precheck
+      - name: mustgather
+        when:
+          operator: sample
+          values: ["0.10"]
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if len(cfg.Filters) != 0 {
-					t.Fatalf("expected 0 filters, got %d", len(cfg.Filters))
+				entry := cfg.Investigations[0].Chain[1]
+				if entry.Name != "mustgather" {
+					t.Errorf("entry name = %q, want mustgather", entry.Name)
+				}
+				if entry.When == nil {
+					t.Fatal("expected when filter on mustgather entry")
+				}
+				if entry.When.Operator != OperatorSample {
+					t.Errorf("operator = %q, want sample", entry.When.Operator)
 				}
 			},
 		},
 		{
-			name: "valid config with OR filter",
+			name: "chain-level when filter",
 			yaml: `
-filters:
-  - investigation: mustgather
+investigations:
+  - alert_title: "ClusterProvisioningDelay -"
     when:
-      or:
-        - field: ClusterID
-          operator: in
-          values: ["abc-123"]
-        - field: OrganizationID
-          operator: in
-          values: ["org-456"]
+      field: OrganizationID
+      operator: notin
+      values: ["org-exclude"]
+    chain:
+      - precheck
+      - ccam
+      - ClusterProvisioningDelay
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if len(cfg.Filters) != 1 {
-					t.Fatalf("expected 1 filter, got %d", len(cfg.Filters))
+				ic := cfg.Investigations[0]
+				if ic.When == nil {
+					t.Fatal("expected chain-level when filter")
 				}
-				f := cfg.GetFilter("mustgather")
-				if f == nil || f.Filter == nil {
-					t.Fatal("expected filter for mustgather, got nil")
+				if ic.When.Field != FieldOrganizationID {
+					t.Errorf("when field = %q, want OrganizationID", ic.When.Field)
 				}
-				if len(f.Filter.Or) != 2 {
-					t.Fatalf("expected 2 OR children, got %d", len(f.Filter.Or))
+				if ic.When.Operator != OperatorNotIn {
+					t.Errorf("when operator = %q, want notin", ic.When.Operator)
 				}
 			},
 		},
 		{
-			name: "valid config with AND+OR combined",
+			name: "experimental flag",
 			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      and:
-        - field: CloudProvider
-          operator: in
-          values: ["aws"]
-        - or:
-            - field: ClusterID
-              operator: in
-              values: ["abc-123"]
-            - field: OrganizationID
-              operator: in
-              values: ["org-456"]
+investigations:
+  - alert_title: "TestExperimental"
+    experimental: true
+    chain:
+      - mustgather
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				f := cfg.GetFilter("mustgather")
-				if f == nil || f.Filter == nil {
-					t.Fatal("expected filter for mustgather, got nil")
-				}
-				if len(f.Filter.And) != 2 {
-					t.Errorf("expected 2 AND children, got %d", len(f.Filter.And))
-				}
-				if len(f.Filter.And[1].Or) != 2 {
-					t.Errorf("expected 2 OR children in second AND child, got %d", len(f.Filter.And[1].Or))
+				if !cfg.Investigations[0].Experimental {
+					t.Error("expected experimental=true")
 				}
 			},
 		},
 		{
-			name: "invalid filter with bad field",
+			name: "empty investigations list is valid",
 			yaml: `
-filters:
-  - investigation: mustgather
+investigations: []
+`,
+			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
+				if len(cfg.Investigations) != 0 {
+					t.Fatalf("expected 0 investigations, got %d", len(cfg.Investigations))
+				}
+			},
+		},
+		{
+			name: "empty chain is invalid",
+			yaml: `
+investigations:
+  - alert_title: "TestAlert"
+    chain: []
+`,
+			wantErr: true,
+		},
+		{
+			name: "empty alert_title is invalid",
+			yaml: `
+investigations:
+  - alert_title: ""
+    chain:
+      - mustgather
+`,
+			wantErr: true,
+		},
+		{
+			name: "duplicate alert_title is invalid",
+			yaml: `
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - mustgather
+  - alert_title: "TestAlert"
+    chain:
+      - precheck
+`,
+			wantErr: true,
+		},
+		{
+			name: "unknown investigation name in chain is invalid",
+			yaml: `
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - nonexistent
+`,
+			wantErr: true,
+		},
+		{
+			name: "empty chain entry name is invalid",
+			yaml: `
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - name: ""
+`,
+			wantErr: true,
+		},
+		{
+			name: "invalid when filter field is invalid",
+			yaml: `
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - name: mustgather
+        when:
+          field: BadField
+          operator: in
+          values: ["x"]
+`,
+			wantErr: true,
+		},
+		{
+			name: "invalid chain-level when filter is invalid",
+			yaml: `
+investigations:
+  - alert_title: "TestAlert"
     when:
       field: BadField
       operator: in
       values: ["x"]
-`,
-			wantErr: true,
-		},
-		{
-			name: "unknown investigation name",
-			yaml: `
-filters:
-  - investigation: nonexistent
-    when:
-      field: CloudProvider
-      operator: in
-      values: ["aws"]
-`,
-			wantErr: true,
-		},
-		{
-			name: "empty investigation name",
-			yaml: `
-filters:
-  - investigation: ""
-    when:
-      field: CloudProvider
-      operator: in
-      values: ["aws"]
-`,
-			wantErr: true,
-		},
-		{
-			name: "duplicate investigation name",
-			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      field: CloudProvider
-      operator: in
-      values: ["aws"]
-  - investigation: mustgather
-    when:
-      field: ClusterState
-      operator: in
-      values: ["ready"]
-`,
-			wantErr: true,
-		},
-		{
-			name: "invalid filter field name",
-			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      field: BadFieldName
-      operator: in
-      values: ["aws"]
-`,
-			wantErr: true,
-		},
-		{
-			name: "invalid operator",
-			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      field: CloudProvider
-      operator: equals
-      values: ["aws"]
-`,
-			wantErr: true,
-		},
-		{
-			name: "empty values",
-			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      field: CloudProvider
-      operator: in
-      values: []
+    chain:
+      - mustgather
 `,
 			wantErr: true,
 		},
@@ -267,12 +255,14 @@ ai_agent:
   version: "v1.0.0"
   ops_sop_version: "v2.0.0"
   rosa_plugins_version: "v3.0.0"
-filters:
-  - investigation: aiassisted
+investigations:
+  - alert_title: "TestAI"
     when:
       field: ClusterID
       operator: in
-      values: ["test-cluster"]
+      values: ["cluster-1"]
+    chain:
+      - aiassisted
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
 				if cfg.AIAgent == nil {
@@ -303,12 +293,14 @@ ai_agent:
   user_id: "user"
   region: "us-east-1"
   invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
-filters:
-  - investigation: aiassisted
+investigations:
+  - alert_title: "TestAI"
     when:
       field: ClusterID
       operator: in
-      values: ["test-cluster"]
+      values: ["cluster-1"]
+    chain:
+      - aiassisted
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
 				if cfg.AIAgent == nil {
@@ -325,7 +317,7 @@ filters:
 ai_agent:
   user_id: "user"
   region: "us-east-1"
-filters: []
+investigations: []
 `,
 			wantErr: true,
 		},
@@ -335,7 +327,7 @@ filters: []
 ai_agent:
   runtime_arn: "arn:test"
   user_id: "user"
-filters: []
+investigations: []
 `,
 			wantErr: true,
 		},
@@ -345,7 +337,7 @@ filters: []
 ai_agent:
   runtime_arn: "arn:test"
   region: "us-east-1"
-filters: []
+investigations: []
 `,
 			wantErr: true,
 		},
@@ -362,7 +354,7 @@ filters: []
 		},
 		{
 			name: "config without ai_agent is valid",
-			yaml: testMustgatherFilterYAML,
+			yaml: testMustgatherChainYAML,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
 				if cfg.AIAgent != nil {
 					t.Errorf("expected nil ai_agent, got %+v", cfg.AIAgent)
@@ -370,156 +362,147 @@ filters: []
 			},
 		},
 		{
-			name: "aiassisted filter without ai_agent is invalid",
+			name: "aiassisted in chain without ai_agent is invalid",
 			yaml: `
-filters:
-  - investigation: aiassisted
-    when:
-      or:
-        - field: ClusterID
-          operator: in
-          values: ["cluster-1"]
+investigations:
+  - alert_title: "TestAI"
+    chain:
+      - aiassisted
 `,
 			wantErr: true,
 		},
 		{
-			name: "aiassisted without filter is valid now",
+			name: "ai_agent without aiassisted in any chain is valid",
 			yaml: `
 ai_agent:
   runtime_arn: "arn:test"
   user_id: "user"
   region: "us-east-1"
   invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
-filters:
-  - investigation: aiassisted
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - mustgather
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
 				if cfg.AIAgent == nil {
-					t.Fatal("expected ai_agent config, got nil")
-				}
-				f := cfg.GetFilter("aiassisted")
-				if f == nil {
-					t.Fatal("expected aiassisted filter entry, got nil")
-				}
-				if f.Filter != nil {
-					t.Errorf("expected nil filter tree (no filtering), got %+v", f.Filter)
+					t.Fatal("expected ai_agent config")
 				}
 			},
 		},
+		// --- aiassisted filter requirement ---
 		{
-			name: "ai_agent without aiassisted filter entry is valid now",
+			name: "aiassisted without any when filter is invalid",
 			yaml: `
 ai_agent:
   runtime_arn: "arn:test"
   user_id: "user"
   region: "us-east-1"
   invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
-filters:
-  - investigation: mustgather
+investigations:
+  - alert_title: "TestAI"
+    chain:
+      - precheck
+      - aiassisted
+`,
+			wantErr: true,
+		},
+		{
+			name: "aiassisted with chain-level when is valid",
+			yaml: `
+ai_agent:
+  runtime_arn: "arn:test"
+  user_id: "user"
+  region: "us-east-1"
+  invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
+investigations:
+  - alert_title: "TestAI"
     when:
-      field: CloudProvider
+      field: OrganizationID
       operator: in
-      values: ["aws"]
+      values: ["org-1"]
+    chain:
+      - precheck
+      - aiassisted
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if cfg.AIAgent == nil {
-					t.Fatal("expected ai_agent config, got nil")
-				}
-				f := cfg.GetFilter("aiassisted")
-				if f != nil {
-					t.Errorf("expected nil filter for absent aiassisted entry, got %+v", f)
-				}
-			},
-		},
-		// --- sample operator tests ---
-		{
-			name: "valid sample operator",
-			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      operator: sample
-      values: ["0.10"]
-`,
-			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				f := cfg.GetFilter("mustgather")
-				if f == nil || f.Filter == nil {
-					t.Fatal("expected filter for mustgather, got nil")
-				}
-				if f.Filter.Operator != OperatorSample {
-					t.Errorf("expected operator sample, got %q", f.Filter.Operator)
+				if cfg.Investigations[0].When == nil {
+					t.Fatal("expected chain-level when filter")
 				}
 			},
 		},
 		{
-			name: "sample rate 0 is valid",
+			name: "aiassisted with entry-level when is valid",
 			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      operator: sample
-      values: ["0"]
+ai_agent:
+  runtime_arn: "arn:test"
+  user_id: "user"
+  region: "us-east-1"
+  invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
+investigations:
+  - alert_title: "TestAI"
+    chain:
+      - precheck
+      - name: aiassisted
+        when:
+          field: ClusterID
+          operator: in
+          values: ["cluster-1"]
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				f := cfg.GetFilter("mustgather")
-				if f == nil || f.Filter == nil {
-					t.Fatal("expected filter for mustgather, got nil")
+				entry := cfg.Investigations[0].Chain[1]
+				if entry.When == nil {
+					t.Fatal("expected entry-level when filter on aiassisted")
 				}
 			},
 		},
+		// --- sample operator in chain entry ---
 		{
-			name: "sample rate 1 is valid",
+			name: "valid sample operator in chain entry",
 			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      operator: sample
-      values: ["1"]
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - name: mustgather
+        when:
+          operator: sample
+          values: ["0.10"]
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				f := cfg.GetFilter("mustgather")
-				if f == nil || f.Filter == nil {
-					t.Fatal("expected filter for mustgather, got nil")
+				entry := cfg.Investigations[0].Chain[0]
+				if entry.When == nil {
+					t.Fatal("expected when filter")
+				}
+				if entry.When.Operator != OperatorSample {
+					t.Errorf("operator = %q, want sample", entry.When.Operator)
 				}
 			},
 		},
 		{
 			name: "sample rate negative is invalid",
 			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      operator: sample
-      values: ["-0.1"]
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - name: mustgather
+        when:
+          operator: sample
+          values: ["-0.1"]
 `,
 			wantErr: true,
 		},
 		{
 			name: "sample rate greater than 1 is invalid",
 			yaml: `
-filters:
-  - investigation: mustgather
-    when:
-      operator: sample
-      values: ["1.5"]
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - name: mustgather
+        when:
+          operator: sample
+          values: ["1.5"]
 `,
 			wantErr: true,
-		},
-		{
-			name: "no filter leaves it nil",
-			yaml: `
-filters:
-  - investigation: mustgather
-`,
-			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				f := cfg.GetFilter("mustgather")
-				if f == nil {
-					t.Fatal("expected filter for mustgather, got nil")
-				}
-				if f.Filter != nil {
-					t.Errorf("expected nil filter tree, got %+v", f.Filter)
-				}
-			},
 		},
 	}
 
@@ -536,35 +519,58 @@ filters:
 	}
 }
 
-func TestGetFilter(t *testing.T) {
-	cfg, err := ParseConfig([]byte(testMustgatherFilterYAML), testInvestigations)
+func TestGetChain(t *testing.T) {
+	cfg, err := ParseConfig([]byte(`
+investigations:
+  - alert_title: "has gone missing"
+    chain:
+      - precheck
+      - ccam
+      - "Cluster Has Gone Missing (CHGM)"
+  - alert_title: "ExperimentalAlert"
+    experimental: true
+    chain:
+      - mustgather
+`), testInvestigations)
 	if err != nil {
 		t.Fatalf("ParseConfig() error = %v", err)
 	}
 
-	// Configured investigation returns its filter.
-	f := cfg.GetFilter("mustgather")
-	if f == nil {
-		t.Fatal("expected filter for mustgather, got nil")
+	// Matching alert title returns the chain.
+	ic := cfg.GetChain("Cluster xyz has gone missing", false)
+	if ic == nil {
+		t.Fatal("expected chain for 'has gone missing'")
 	}
-	if f.Filter == nil {
-		t.Fatal("expected filter tree, got nil")
+	if ic.AlertTitle != "has gone missing" {
+		t.Errorf("AlertTitle = %q", ic.AlertTitle)
 	}
-	if f.Filter.Field != "CloudProvider" {
-		t.Fatalf("expected field CloudProvider, got %q", f.Filter.Field)
+	if len(ic.Chain) != 3 {
+		t.Fatalf("expected 3 chain entries, got %d", len(ic.Chain))
 	}
 
-	// Unconfigured investigation returns nil (always runs).
-	f = cfg.GetFilter("etcddatabasequotalowspace")
-	if f != nil {
-		t.Fatalf("expected nil filter for unconfigured investigation, got %v", f)
+	// No match returns nil.
+	ic = cfg.GetChain("UnknownAlert", false)
+	if ic != nil {
+		t.Fatalf("expected nil for unmatched alert, got %+v", ic)
+	}
+
+	// Experimental chain is hidden when experimentalEnabled=false.
+	ic = cfg.GetChain("ExperimentalAlert fired", false)
+	if ic != nil {
+		t.Fatal("expected nil for experimental chain with experimental=false")
+	}
+
+	// Experimental chain is visible when experimentalEnabled=true.
+	ic = cfg.GetChain("ExperimentalAlert fired", true)
+	if ic == nil {
+		t.Fatal("expected chain for experimental alert with experimental=true")
 	}
 
 	// Nil config returns nil.
 	var nilCfg *Config
-	f = nilCfg.GetFilter("mustgather")
-	if f != nil {
-		t.Fatalf("expected nil filter from nil config, got %v", f)
+	ic = nilCfg.GetChain("has gone missing", false)
+	if ic != nil {
+		t.Fatalf("expected nil from nil config, got %+v", ic)
 	}
 }
 
@@ -598,10 +604,9 @@ func TestAIAgentConfigGetTimeout(t *testing.T) {
 	}
 }
 
-func TestLoadConfig(t *testing.T) { //nolint:gocyclo,maintidx // many sub-cases for config loading paths
+func TestLoadConfig(t *testing.T) {
 	t.Run("env var not set returns nil", func(t *testing.T) {
 		t.Setenv(ConfigEnvVar, "")
-		t.Setenv(LegacyAIConfigEnvVar, "")
 		cfg, err := LoadConfig("", testInvestigations)
 		if err != nil {
 			t.Fatalf("LoadConfig() error = %v", err)
@@ -613,7 +618,7 @@ func TestLoadConfig(t *testing.T) { //nolint:gocyclo,maintidx // many sub-cases 
 
 	t.Run("valid file loads successfully", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "config.yaml")
-		if err := os.WriteFile(path, []byte(testMustgatherFilterYAML), 0o600); err != nil {
+		if err := os.WriteFile(path, []byte(testMustgatherChainYAML), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		t.Setenv(ConfigEnvVar, path)
@@ -622,8 +627,8 @@ func TestLoadConfig(t *testing.T) { //nolint:gocyclo,maintidx // many sub-cases 
 		if err != nil {
 			t.Fatalf("LoadConfig() error = %v", err)
 		}
-		if cfg == nil || len(cfg.Filters) != 1 {
-			t.Fatal("expected config with 1 filter")
+		if cfg == nil || len(cfg.Investigations) != 1 {
+			t.Fatal("expected config with 1 investigation")
 		}
 	})
 
@@ -640,7 +645,7 @@ func TestLoadConfig(t *testing.T) { //nolint:gocyclo,maintidx // many sub-cases 
 
 	t.Run("invalid content returns error", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "bad.yaml")
-		if err := os.WriteFile(path, []byte(`filters: [{investigation: fake}]`), 0o600); err != nil {
+		if err := os.WriteFile(path, []byte(`investigations: [{alert_title: "X", chain: [{name: fake}]}]`), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		t.Setenv(ConfigEnvVar, path)
@@ -652,11 +657,10 @@ func TestLoadConfig(t *testing.T) { //nolint:gocyclo,maintidx // many sub-cases 
 	})
 
 	t.Run("path override takes precedence over env var", func(t *testing.T) {
-		// Set env var to a nonexistent file — if it were used, LoadConfig would fail.
 		t.Setenv(ConfigEnvVar, "/nonexistent/should-not-be-used.yaml")
 
 		path := filepath.Join(t.TempDir(), "override.yaml")
-		if err := os.WriteFile(path, []byte(testMustgatherFilterYAML), 0o600); err != nil {
+		if err := os.WriteFile(path, []byte(testMustgatherChainYAML), 0o600); err != nil {
 			t.Fatal(err)
 		}
 
@@ -664,15 +668,17 @@ func TestLoadConfig(t *testing.T) { //nolint:gocyclo,maintidx // many sub-cases 
 		if err != nil {
 			t.Fatalf("LoadConfig() error = %v", err)
 		}
-		if cfg == nil || len(cfg.Filters) != 1 {
-			t.Fatal("expected config with 1 filter from override path")
+		if cfg == nil || len(cfg.Investigations) != 1 {
+			t.Fatal("expected config with 1 investigation from override path")
 		}
 	})
 
 	t.Run("empty override falls back to env var", func(t *testing.T) {
 		content := `
-filters:
-  - investigation: mustgather
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - mustgather
 `
 		path := filepath.Join(t.TempDir(), "envvar.yaml")
 		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
@@ -684,160 +690,47 @@ filters:
 		if err != nil {
 			t.Fatalf("LoadConfig() error = %v", err)
 		}
-		if cfg == nil || len(cfg.Filters) != 1 {
-			t.Fatal("expected config with 1 filter from env var path")
+		if cfg == nil || len(cfg.Investigations) != 1 {
+			t.Fatal("expected config with 1 investigation from env var path")
 		}
 	})
+}
 
-	// --- Legacy CAD_AI_AGENT_CONFIG fallback tests ---
+func TestChainEntryUnmarshal(t *testing.T) {
+	yaml := `
+investigations:
+  - alert_title: "TestAlert"
+    chain:
+      - precheck
+      - name: mustgather
+        when:
+          operator: sample
+          values: ["0.50"]
+`
+	cfg, err := ParseConfig([]byte(yaml), testInvestigations)
+	if err != nil {
+		t.Fatalf("ParseConfig() error = %v", err)
+	}
+	if len(cfg.Investigations[0].Chain) != 2 {
+		t.Fatalf("expected 2 chain entries, got %d", len(cfg.Investigations[0].Chain))
+	}
 
-	t.Run("legacy env var with clusters and orgs", func(t *testing.T) {
-		t.Setenv(ConfigEnvVar, "")
-		t.Setenv(LegacyAIConfigEnvVar, `{
-			"runtime_arn": "arn:test",
-			"user_id": "user",
-			"region": "us-east-1",
-			"organizations": ["org1"],
-			"clusters": ["cluster1"],
-			"enabled": true,
-			"timeout_seconds": 600
-		}`)
+	// First entry: bare string
+	if cfg.Investigations[0].Chain[0].Name != "precheck" {
+		t.Errorf("chain[0].Name = %q, want precheck", cfg.Investigations[0].Chain[0].Name)
+	}
+	if cfg.Investigations[0].Chain[0].When != nil {
+		t.Error("chain[0].When should be nil for bare string entry")
+	}
 
-		cfg, err := LoadConfig("", testInvestigations)
-		if err != nil {
-			t.Fatalf("LoadConfig() error = %v", err)
-		}
-		if cfg == nil {
-			t.Fatal("expected config from legacy env var")
-		}
-		if cfg.AIAgent == nil {
-			t.Fatal("expected ai_agent config")
-		}
-		if cfg.AIAgent.RuntimeARN != "arn:test" {
-			t.Errorf("RuntimeARN = %q", cfg.AIAgent.RuntimeARN)
-		}
-		if cfg.AIAgent.TimeoutSeconds != 600 {
-			t.Errorf("TimeoutSeconds = %d, want 600", cfg.AIAgent.TimeoutSeconds)
-		}
-
-		f := cfg.GetFilter("aiassisted")
-		if f == nil || f.Filter == nil {
-			t.Fatal("expected synthesized aiassisted filter")
-		}
-		// Should be OR of ClusterID + OrganizationID
-		if len(f.Filter.Or) != 2 {
-			t.Fatalf("expected 2 OR children, got %d", len(f.Filter.Or))
-		}
-	})
-
-	t.Run("legacy env var with clusters only", func(t *testing.T) {
-		t.Setenv(ConfigEnvVar, "")
-		t.Setenv(LegacyAIConfigEnvVar, `{
-			"runtime_arn": "arn:test",
-			"user_id": "user",
-			"region": "us-east-1",
-			"organizations": [],
-			"clusters": ["c1", "c2"],
-			"enabled": true
-		}`)
-
-		cfg, err := LoadConfig("", testInvestigations)
-		if err != nil {
-			t.Fatalf("LoadConfig() error = %v", err)
-		}
-		f := cfg.GetFilter("aiassisted")
-		if f == nil || f.Filter == nil {
-			t.Fatal("expected synthesized aiassisted filter")
-		}
-		// Single leaf, not OR
-		if f.Filter.Field != FieldClusterID {
-			t.Errorf("expected ClusterID leaf, got field %q", f.Filter.Field)
-		}
-		if len(f.Filter.Values) != 2 {
-			t.Errorf("expected 2 cluster values, got %d", len(f.Filter.Values))
-		}
-	})
-
-	t.Run("legacy env var disabled returns nil", func(t *testing.T) {
-		t.Setenv(ConfigEnvVar, "")
-		t.Setenv(LegacyAIConfigEnvVar, `{
-			"runtime_arn": "arn:test",
-			"user_id": "user",
-			"region": "us-east-1",
-			"enabled": false
-		}`)
-
-		cfg, err := LoadConfig("", testInvestigations)
-		if err != nil {
-			t.Fatalf("LoadConfig() error = %v", err)
-		}
-		if cfg != nil {
-			t.Fatal("expected nil config when legacy enabled=false")
-		}
-	})
-
-	t.Run("legacy env var empty allowlists returns error", func(t *testing.T) {
-		t.Setenv(ConfigEnvVar, "")
-		t.Setenv(LegacyAIConfigEnvVar, `{
-			"runtime_arn": "arn:test",
-			"user_id": "user",
-			"region": "us-east-1",
-			"organizations": [],
-			"clusters": [],
-			"enabled": true
-		}`)
-
-		_, err := LoadConfig("", testInvestigations)
-		if err == nil {
-			t.Fatal("expected error when enabled but no allowlists")
-		}
-	})
-
-	t.Run("legacy env var invalid JSON returns error", func(t *testing.T) {
-		t.Setenv(ConfigEnvVar, "")
-		t.Setenv(LegacyAIConfigEnvVar, `{invalid}`)
-
-		_, err := LoadConfig("", testInvestigations)
-		if err == nil {
-			t.Fatal("expected error for invalid JSON")
-		}
-	})
-
-	t.Run("legacy env var default timeout", func(t *testing.T) {
-		t.Setenv(ConfigEnvVar, "")
-		t.Setenv(LegacyAIConfigEnvVar, `{
-			"runtime_arn": "arn:test",
-			"user_id": "user",
-			"region": "us-east-1",
-			"clusters": ["c1"],
-			"enabled": true
-		}`)
-
-		cfg, err := LoadConfig("", testInvestigations)
-		if err != nil {
-			t.Fatalf("LoadConfig() error = %v", err)
-		}
-		if cfg.AIAgent.TimeoutSeconds != 900 {
-			t.Errorf("TimeoutSeconds = %d, want 900 (default)", cfg.AIAgent.TimeoutSeconds)
-		}
-	})
-
-	t.Run("config file takes precedence over legacy env var", func(t *testing.T) {
-		// Legacy env var has invalid JSON — if used, LoadConfig would fail.
-		t.Setenv(LegacyAIConfigEnvVar, `{invalid}`)
-
-		path := filepath.Join(t.TempDir(), "config.yaml")
-		if err := os.WriteFile(path, []byte(testMustgatherFilterYAML), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		t.Setenv(ConfigEnvVar, path)
-
-		cfg, err := LoadConfig("", testInvestigations)
-		if err != nil {
-			t.Fatalf("LoadConfig() error = %v", err)
-		}
-		if cfg == nil || len(cfg.Filters) != 1 {
-			t.Fatal("expected config from file, not legacy env var")
-		}
-	})
+	// Second entry: object with when
+	if cfg.Investigations[0].Chain[1].Name != "mustgather" {
+		t.Errorf("chain[1].Name = %q, want mustgather", cfg.Investigations[0].Chain[1].Name)
+	}
+	if cfg.Investigations[0].Chain[1].When == nil {
+		t.Fatal("chain[1].When should not be nil")
+	}
+	if cfg.Investigations[0].Chain[1].When.Operator != OperatorSample {
+		t.Errorf("chain[1].When.Operator = %q, want sample", cfg.Investigations[0].Chain[1].When.Operator)
+	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -605,14 +605,11 @@ func TestAIAgentConfigGetTimeout(t *testing.T) {
 }
 
 func TestLoadConfig(t *testing.T) {
-	t.Run("env var not set returns nil", func(t *testing.T) {
+	t.Run("env var not set returns error", func(t *testing.T) {
 		t.Setenv(ConfigEnvVar, "")
-		cfg, err := LoadConfig("", testInvestigations)
-		if err != nil {
-			t.Fatalf("LoadConfig() error = %v", err)
-		}
-		if cfg != nil {
-			t.Fatal("expected nil config when env var is not set")
+		_, err := LoadConfig("", testInvestigations)
+		if err == nil {
+			t.Fatal("expected error when config path is not provided")
 		}
 	})
 
@@ -632,14 +629,11 @@ func TestLoadConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("nonexistent file returns nil config", func(t *testing.T) {
+	t.Run("nonexistent file returns error", func(t *testing.T) {
 		t.Setenv(ConfigEnvVar, "/nonexistent/path.yaml")
-		cfg, err := LoadConfig("", testInvestigations)
-		if err != nil {
-			t.Fatalf("expected no error for nonexistent file, got: %v", err)
-		}
-		if cfg != nil {
-			t.Fatal("expected nil config for nonexistent file")
+		_, err := LoadConfig("", testInvestigations)
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
 		}
 	})
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -611,11 +611,10 @@ func TestAIAgentConfigGetTimeout(t *testing.T) {
 }
 
 func TestLoadConfig(t *testing.T) {
-	t.Run("env var not set returns error", func(t *testing.T) {
-		t.Setenv(ConfigEnvVar, "")
+	t.Run("empty path returns error", func(t *testing.T) {
 		_, err := LoadConfig("", testInvestigations)
 		if err == nil {
-			t.Fatal("expected error when config path is not provided")
+			t.Fatal("expected error when config path is empty")
 		}
 	})
 
@@ -624,9 +623,8 @@ func TestLoadConfig(t *testing.T) {
 		if err := os.WriteFile(path, []byte(testMustgatherChainYAML), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		t.Setenv(ConfigEnvVar, path)
 
-		cfg, err := LoadConfig("", testInvestigations)
+		cfg, err := LoadConfig(path, testInvestigations)
 		if err != nil {
 			t.Fatalf("LoadConfig() error = %v", err)
 		}
@@ -636,8 +634,7 @@ func TestLoadConfig(t *testing.T) {
 	})
 
 	t.Run("nonexistent file returns error", func(t *testing.T) {
-		t.Setenv(ConfigEnvVar, "/nonexistent/path.yaml")
-		_, err := LoadConfig("", testInvestigations)
+		_, err := LoadConfig("/nonexistent/path.yaml", testInvestigations)
 		if err == nil {
 			t.Fatal("expected error for nonexistent file")
 		}
@@ -648,53 +645,17 @@ func TestLoadConfig(t *testing.T) {
 		if err := os.WriteFile(path, []byte(`alerts: [{alert_title: "X", investigations: [{name: fake}]}]`), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		t.Setenv(ConfigEnvVar, path)
 
-		_, err := LoadConfig("", testInvestigations)
+		_, err := LoadConfig(path, testInvestigations)
 		if err == nil {
 			t.Fatal("expected error for invalid investigation name")
 		}
 	})
-
-	t.Run("path override takes precedence over env var", func(t *testing.T) {
-		t.Setenv(ConfigEnvVar, "/nonexistent/should-not-be-used.yaml")
-
-		path := filepath.Join(t.TempDir(), "override.yaml")
-		if err := os.WriteFile(path, []byte(testMustgatherChainYAML), 0o600); err != nil {
-			t.Fatal(err)
-		}
-
-		cfg, err := LoadConfig(path, testInvestigations)
-		if err != nil {
-			t.Fatalf("LoadConfig() error = %v", err)
-		}
-		if cfg == nil || len(cfg.Alerts) != 1 {
-			t.Fatal("expected config with 1 investigation from override path")
-		}
-	})
-
-	t.Run("empty override falls back to env var", func(t *testing.T) {
-		content := `
-alerts:
-  - alert_title: "TestAlert"
-    investigations:
-      - mustgather
-`
-		path := filepath.Join(t.TempDir(), "envvar.yaml")
-		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		t.Setenv(ConfigEnvVar, path)
-
-		cfg, err := LoadConfig("", testInvestigations)
-		if err != nil {
-			t.Fatalf("LoadConfig() error = %v", err)
-		}
-		if cfg == nil || len(cfg.Alerts) != 1 {
-			t.Fatal("expected config with 1 investigation from env var path")
-		}
-	})
 }
+
+// NOTE: The env var fallback (CAD_INVESTIGATION_CONFIG_PATH) is handled by
+// callers (controller.initializeDependencies, interceptor main) before calling
+// LoadConfig. Tests for that behavior belong with those callers.
 
 func TestInvestigationEntryUnmarshal(t *testing.T) {
 	yaml := `

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -392,7 +392,7 @@ alerts:
 		},
 		// --- aiassisted filter requirement ---
 		{
-			name: "aiassisted without any when filter is invalid",
+			name: "aiassisted without when filter is valid",
 			yaml: `
 ai_agent:
   runtime_arn: "arn:test"
@@ -405,7 +405,11 @@ alerts:
       - precheck
       - aiassisted
 `,
-			wantErr: true,
+			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
+				if len(cfg.Alerts[0].Investigations) != 2 {
+					t.Fatalf("expected 2 investigations, got %d", len(cfg.Alerts[0].Investigations))
+				}
+			},
 		},
 		{
 			name: "aiassisted with chain-level when is valid",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,9 +18,9 @@ var testInvestigations = []string{
 	"precheck",
 	"ccam",
 	"aiassisted",
-	"Cluster Has Gone Missing (CHGM)",
+	"chgm",
 	"clustermonitoringerrorbudgetburn",
-	"ClusterProvisioningDelay",
+	"cpd",
 	"etcddatabasequotalowspace",
 	"insightsoperatordown",
 	"upgradeconfigsyncfailureover4hr",
@@ -65,7 +65,7 @@ alerts:
     investigations:
       - precheck
       - ccam
-      - "Cluster Has Gone Missing (CHGM)"
+      - "chgm"
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
 				if len(cfg.Alerts[0].Investigations) != 3 {
@@ -74,7 +74,7 @@ alerts:
 				if cfg.Alerts[0].Investigations[0].Name != "precheck" {
 					t.Errorf("chain[0] = %q, want precheck", cfg.Alerts[0].Investigations[0].Name)
 				}
-				if cfg.Alerts[0].Investigations[2].Name != "Cluster Has Gone Missing (CHGM)" {
+				if cfg.Alerts[0].Investigations[2].Name != "chgm" {
 					t.Errorf("chain[2] = %q", cfg.Alerts[0].Investigations[2].Name)
 				}
 			},
@@ -116,7 +116,7 @@ alerts:
     investigations:
       - precheck
       - ccam
-      - ClusterProvisioningDelay
+      - cpd
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
 				ic := cfg.Alerts[0]
@@ -530,7 +530,7 @@ alerts:
     investigations:
       - precheck
       - ccam
-      - "Cluster Has Gone Missing (CHGM)"
+      - "chgm"
   - alert_title: "ExperimentalAlert"
     experimental: true
     investigations:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,6 +14,8 @@ alerts:
       - mustgather
 `
 
+const alertName = "mustgather"
+
 var testInvestigations = []string{
 	"precheck",
 	"ccam",
@@ -52,7 +54,7 @@ func TestParseConfig(t *testing.T) { //nolint:maintidx,gocyclo // table-driven t
 				if len(cfg.Alerts[0].Investigations) != 1 {
 					t.Fatalf("expected 1 chain entry, got %d", len(cfg.Alerts[0].Investigations))
 				}
-				if cfg.Alerts[0].Investigations[0].Name != "mustgather" {
+				if cfg.Alerts[0].Investigations[0].Name != alertName {
 					t.Errorf("expected chain entry mustgather, got %q", cfg.Alerts[0].Investigations[0].Name)
 				}
 			},
@@ -93,7 +95,7 @@ alerts:
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
 				entry := cfg.Alerts[0].Investigations[1]
-				if entry.Name != "mustgather" {
+				if entry.Name != alertName {
 					t.Errorf("entry name = %q, want mustgather", entry.Name)
 				}
 				if entry.When == nil {
@@ -722,7 +724,7 @@ alerts:
 	}
 
 	// Second entry: object with when
-	if cfg.Alerts[0].Investigations[1].Name != "mustgather" {
+	if cfg.Alerts[0].Investigations[1].Name != alertName {
 		t.Errorf("chain[1].Name = %q, want mustgather", cfg.Alerts[0].Investigations[1].Name)
 	}
 	if cfg.Alerts[0].Investigations[1].When == nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 const testMustgatherChainYAML = `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - mustgather
 `
 
@@ -43,48 +43,48 @@ func TestParseConfig(t *testing.T) { //nolint:maintidx,gocyclo // table-driven t
 			name: "valid config with one chain",
 			yaml: testMustgatherChainYAML,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if len(cfg.Investigations) != 1 {
-					t.Fatalf("expected 1 investigation, got %d", len(cfg.Investigations))
+				if len(cfg.Alerts) != 1 {
+					t.Fatalf("expected 1 investigation, got %d", len(cfg.Alerts))
 				}
-				if cfg.Investigations[0].AlertTitle != "TestAlert" {
-					t.Errorf("expected alert_title TestAlert, got %q", cfg.Investigations[0].AlertTitle)
+				if cfg.Alerts[0].AlertTitle != "TestAlert" {
+					t.Errorf("expected alert_title TestAlert, got %q", cfg.Alerts[0].AlertTitle)
 				}
-				if len(cfg.Investigations[0].Chain) != 1 {
-					t.Fatalf("expected 1 chain entry, got %d", len(cfg.Investigations[0].Chain))
+				if len(cfg.Alerts[0].Investigations) != 1 {
+					t.Fatalf("expected 1 chain entry, got %d", len(cfg.Alerts[0].Investigations))
 				}
-				if cfg.Investigations[0].Chain[0].Name != "mustgather" {
-					t.Errorf("expected chain entry mustgather, got %q", cfg.Investigations[0].Chain[0].Name)
+				if cfg.Alerts[0].Investigations[0].Name != "mustgather" {
+					t.Errorf("expected chain entry mustgather, got %q", cfg.Alerts[0].Investigations[0].Name)
 				}
 			},
 		},
 		{
 			name: "valid config with multiple chain entries and bare strings",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "has gone missing"
-    chain:
+    investigations:
       - precheck
       - ccam
       - "Cluster Has Gone Missing (CHGM)"
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if len(cfg.Investigations[0].Chain) != 3 {
-					t.Fatalf("expected 3 chain entries, got %d", len(cfg.Investigations[0].Chain))
+				if len(cfg.Alerts[0].Investigations) != 3 {
+					t.Fatalf("expected 3 chain entries, got %d", len(cfg.Alerts[0].Investigations))
 				}
-				if cfg.Investigations[0].Chain[0].Name != "precheck" {
-					t.Errorf("chain[0] = %q, want precheck", cfg.Investigations[0].Chain[0].Name)
+				if cfg.Alerts[0].Investigations[0].Name != "precheck" {
+					t.Errorf("chain[0] = %q, want precheck", cfg.Alerts[0].Investigations[0].Name)
 				}
-				if cfg.Investigations[0].Chain[2].Name != "Cluster Has Gone Missing (CHGM)" {
-					t.Errorf("chain[2] = %q", cfg.Investigations[0].Chain[2].Name)
+				if cfg.Alerts[0].Investigations[2].Name != "Cluster Has Gone Missing (CHGM)" {
+					t.Errorf("chain[2] = %q", cfg.Alerts[0].Investigations[2].Name)
 				}
 			},
 		},
 		{
 			name: "chain entry with when filter (object form)",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "has gone missing"
-    chain:
+    investigations:
       - precheck
       - name: mustgather
         when:
@@ -92,7 +92,7 @@ investigations:
           values: ["0.10"]
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				entry := cfg.Investigations[0].Chain[1]
+				entry := cfg.Alerts[0].Investigations[1]
 				if entry.Name != "mustgather" {
 					t.Errorf("entry name = %q, want mustgather", entry.Name)
 				}
@@ -107,19 +107,19 @@ investigations:
 		{
 			name: "chain-level when filter",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "ClusterProvisioningDelay -"
     when:
       field: OrganizationID
       operator: notin
       values: ["org-exclude"]
-    chain:
+    investigations:
       - precheck
       - ccam
       - ClusterProvisioningDelay
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				ic := cfg.Investigations[0]
+				ic := cfg.Alerts[0]
 				if ic.When == nil {
 					t.Fatal("expected chain-level when filter")
 				}
@@ -134,14 +134,14 @@ investigations:
 		{
 			name: "experimental flag",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestExperimental"
     experimental: true
-    chain:
+    investigations:
       - mustgather
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if !cfg.Investigations[0].Experimental {
+				if !cfg.Alerts[0].Experimental {
 					t.Error("expected experimental=true")
 				}
 			},
@@ -149,29 +149,29 @@ investigations:
 		{
 			name: "empty investigations list is valid",
 			yaml: `
-investigations: []
+alerts: []
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if len(cfg.Investigations) != 0 {
-					t.Fatalf("expected 0 investigations, got %d", len(cfg.Investigations))
+				if len(cfg.Alerts) != 0 {
+					t.Fatalf("expected 0 investigations, got %d", len(cfg.Alerts))
 				}
 			},
 		},
 		{
 			name: "empty chain is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain: []
+    investigations: []
 `,
 			wantErr: true,
 		},
 		{
 			name: "empty alert_title is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: ""
-    chain:
+    investigations:
       - mustgather
 `,
 			wantErr: true,
@@ -179,12 +179,12 @@ investigations:
 		{
 			name: "duplicate alert_title is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - mustgather
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - precheck
 `,
 			wantErr: true,
@@ -192,9 +192,9 @@ investigations:
 		{
 			name: "unknown investigation name in chain is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - nonexistent
 `,
 			wantErr: true,
@@ -202,9 +202,9 @@ investigations:
 		{
 			name: "empty chain entry name is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - name: ""
 `,
 			wantErr: true,
@@ -212,9 +212,9 @@ investigations:
 		{
 			name: "invalid when filter field is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - name: mustgather
         when:
           field: BadField
@@ -226,13 +226,13 @@ investigations:
 		{
 			name: "invalid chain-level when filter is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAlert"
     when:
       field: BadField
       operator: in
       values: ["x"]
-    chain:
+    investigations:
       - mustgather
 `,
 			wantErr: true,
@@ -255,13 +255,13 @@ ai_agent:
   version: "v1.0.0"
   ops_sop_version: "v2.0.0"
   rosa_plugins_version: "v3.0.0"
-investigations:
+alerts:
   - alert_title: "TestAI"
     when:
       field: ClusterID
       operator: in
       values: ["cluster-1"]
-    chain:
+    investigations:
       - aiassisted
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
@@ -293,13 +293,13 @@ ai_agent:
   user_id: "user"
   region: "us-east-1"
   invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
-investigations:
+alerts:
   - alert_title: "TestAI"
     when:
       field: ClusterID
       operator: in
       values: ["cluster-1"]
-    chain:
+    investigations:
       - aiassisted
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
@@ -317,7 +317,7 @@ investigations:
 ai_agent:
   user_id: "user"
   region: "us-east-1"
-investigations: []
+alerts: []
 `,
 			wantErr: true,
 		},
@@ -327,7 +327,7 @@ investigations: []
 ai_agent:
   runtime_arn: "arn:test"
   user_id: "user"
-investigations: []
+alerts: []
 `,
 			wantErr: true,
 		},
@@ -337,7 +337,7 @@ investigations: []
 ai_agent:
   runtime_arn: "arn:test"
   region: "us-east-1"
-investigations: []
+alerts: []
 `,
 			wantErr: true,
 		},
@@ -364,9 +364,9 @@ filters: []
 		{
 			name: "aiassisted in chain without ai_agent is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAI"
-    chain:
+    investigations:
       - aiassisted
 `,
 			wantErr: true,
@@ -379,9 +379,9 @@ ai_agent:
   user_id: "user"
   region: "us-east-1"
   invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - mustgather
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
@@ -399,9 +399,9 @@ ai_agent:
   user_id: "user"
   region: "us-east-1"
   invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
-investigations:
+alerts:
   - alert_title: "TestAI"
-    chain:
+    investigations:
       - precheck
       - aiassisted
 `,
@@ -415,18 +415,18 @@ ai_agent:
   user_id: "user"
   region: "us-east-1"
   invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
-investigations:
+alerts:
   - alert_title: "TestAI"
     when:
       field: OrganizationID
       operator: in
       values: ["org-1"]
-    chain:
+    investigations:
       - precheck
       - aiassisted
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				if cfg.Investigations[0].When == nil {
+				if cfg.Alerts[0].When == nil {
 					t.Fatal("expected chain-level when filter")
 				}
 			},
@@ -439,9 +439,9 @@ ai_agent:
   user_id: "user"
   region: "us-east-1"
   invoker_role_arn: "arn:aws:iam::123456789012:role/cad-invoker"
-investigations:
+alerts:
   - alert_title: "TestAI"
-    chain:
+    investigations:
       - precheck
       - name: aiassisted
         when:
@@ -450,7 +450,7 @@ investigations:
           values: ["cluster-1"]
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				entry := cfg.Investigations[0].Chain[1]
+				entry := cfg.Alerts[0].Investigations[1]
 				if entry.When == nil {
 					t.Fatal("expected entry-level when filter on aiassisted")
 				}
@@ -460,16 +460,16 @@ investigations:
 		{
 			name: "valid sample operator in chain entry",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - name: mustgather
         when:
           operator: sample
           values: ["0.10"]
 `,
 			check: func(t *testing.T, cfg *Config) { //nolint:thelper // not a helper, inline check
-				entry := cfg.Investigations[0].Chain[0]
+				entry := cfg.Alerts[0].Investigations[0]
 				if entry.When == nil {
 					t.Fatal("expected when filter")
 				}
@@ -481,9 +481,9 @@ investigations:
 		{
 			name: "sample rate negative is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - name: mustgather
         when:
           operator: sample
@@ -494,9 +494,9 @@ investigations:
 		{
 			name: "sample rate greater than 1 is invalid",
 			yaml: `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - name: mustgather
         when:
           operator: sample
@@ -519,17 +519,17 @@ investigations:
 	}
 }
 
-func TestGetChain(t *testing.T) {
+func TestGetAlert(t *testing.T) {
 	cfg, err := ParseConfig([]byte(`
-investigations:
+alerts:
   - alert_title: "has gone missing"
-    chain:
+    investigations:
       - precheck
       - ccam
       - "Cluster Has Gone Missing (CHGM)"
   - alert_title: "ExperimentalAlert"
     experimental: true
-    chain:
+    investigations:
       - mustgather
 `), testInvestigations)
 	if err != nil {
@@ -537,38 +537,38 @@ investigations:
 	}
 
 	// Matching alert title returns the chain.
-	ic := cfg.GetChain("Cluster xyz has gone missing", false)
+	ic := cfg.GetAlert("Cluster xyz has gone missing", false)
 	if ic == nil {
 		t.Fatal("expected chain for 'has gone missing'")
 	}
 	if ic.AlertTitle != "has gone missing" {
 		t.Errorf("AlertTitle = %q", ic.AlertTitle)
 	}
-	if len(ic.Chain) != 3 {
-		t.Fatalf("expected 3 chain entries, got %d", len(ic.Chain))
+	if len(ic.Investigations) != 3 {
+		t.Fatalf("expected 3 chain entries, got %d", len(ic.Investigations))
 	}
 
 	// No match returns nil.
-	ic = cfg.GetChain("UnknownAlert", false)
+	ic = cfg.GetAlert("UnknownAlert", false)
 	if ic != nil {
 		t.Fatalf("expected nil for unmatched alert, got %+v", ic)
 	}
 
 	// Experimental chain is hidden when experimentalEnabled=false.
-	ic = cfg.GetChain("ExperimentalAlert fired", false)
+	ic = cfg.GetAlert("ExperimentalAlert fired", false)
 	if ic != nil {
 		t.Fatal("expected nil for experimental chain with experimental=false")
 	}
 
 	// Experimental chain is visible when experimentalEnabled=true.
-	ic = cfg.GetChain("ExperimentalAlert fired", true)
+	ic = cfg.GetAlert("ExperimentalAlert fired", true)
 	if ic == nil {
 		t.Fatal("expected chain for experimental alert with experimental=true")
 	}
 
 	// Nil config returns nil.
 	var nilCfg *Config
-	ic = nilCfg.GetChain("has gone missing", false)
+	ic = nilCfg.GetAlert("has gone missing", false)
 	if ic != nil {
 		t.Fatalf("expected nil from nil config, got %+v", ic)
 	}
@@ -624,7 +624,7 @@ func TestLoadConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadConfig() error = %v", err)
 		}
-		if cfg == nil || len(cfg.Investigations) != 1 {
+		if cfg == nil || len(cfg.Alerts) != 1 {
 			t.Fatal("expected config with 1 investigation")
 		}
 	})
@@ -639,7 +639,7 @@ func TestLoadConfig(t *testing.T) {
 
 	t.Run("invalid content returns error", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "bad.yaml")
-		if err := os.WriteFile(path, []byte(`investigations: [{alert_title: "X", chain: [{name: fake}]}]`), 0o600); err != nil {
+		if err := os.WriteFile(path, []byte(`alerts: [{alert_title: "X", investigations: [{name: fake}]}]`), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		t.Setenv(ConfigEnvVar, path)
@@ -662,16 +662,16 @@ func TestLoadConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadConfig() error = %v", err)
 		}
-		if cfg == nil || len(cfg.Investigations) != 1 {
+		if cfg == nil || len(cfg.Alerts) != 1 {
 			t.Fatal("expected config with 1 investigation from override path")
 		}
 	})
 
 	t.Run("empty override falls back to env var", func(t *testing.T) {
 		content := `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - mustgather
 `
 		path := filepath.Join(t.TempDir(), "envvar.yaml")
@@ -684,17 +684,17 @@ investigations:
 		if err != nil {
 			t.Fatalf("LoadConfig() error = %v", err)
 		}
-		if cfg == nil || len(cfg.Investigations) != 1 {
+		if cfg == nil || len(cfg.Alerts) != 1 {
 			t.Fatal("expected config with 1 investigation from env var path")
 		}
 	})
 }
 
-func TestChainEntryUnmarshal(t *testing.T) {
+func TestInvestigationEntryUnmarshal(t *testing.T) {
 	yaml := `
-investigations:
+alerts:
   - alert_title: "TestAlert"
-    chain:
+    investigations:
       - precheck
       - name: mustgather
         when:
@@ -705,26 +705,26 @@ investigations:
 	if err != nil {
 		t.Fatalf("ParseConfig() error = %v", err)
 	}
-	if len(cfg.Investigations[0].Chain) != 2 {
-		t.Fatalf("expected 2 chain entries, got %d", len(cfg.Investigations[0].Chain))
+	if len(cfg.Alerts[0].Investigations) != 2 {
+		t.Fatalf("expected 2 chain entries, got %d", len(cfg.Alerts[0].Investigations))
 	}
 
 	// First entry: bare string
-	if cfg.Investigations[0].Chain[0].Name != "precheck" {
-		t.Errorf("chain[0].Name = %q, want precheck", cfg.Investigations[0].Chain[0].Name)
+	if cfg.Alerts[0].Investigations[0].Name != "precheck" {
+		t.Errorf("chain[0].Name = %q, want precheck", cfg.Alerts[0].Investigations[0].Name)
 	}
-	if cfg.Investigations[0].Chain[0].When != nil {
+	if cfg.Alerts[0].Investigations[0].When != nil {
 		t.Error("chain[0].When should be nil for bare string entry")
 	}
 
 	// Second entry: object with when
-	if cfg.Investigations[0].Chain[1].Name != "mustgather" {
-		t.Errorf("chain[1].Name = %q, want mustgather", cfg.Investigations[0].Chain[1].Name)
+	if cfg.Alerts[0].Investigations[1].Name != "mustgather" {
+		t.Errorf("chain[1].Name = %q, want mustgather", cfg.Alerts[0].Investigations[1].Name)
 	}
-	if cfg.Investigations[0].Chain[1].When == nil {
+	if cfg.Alerts[0].Investigations[1].When == nil {
 		t.Fatal("chain[1].When should not be nil")
 	}
-	if cfg.Investigations[0].Chain[1].When.Operator != OperatorSample {
-		t.Errorf("chain[1].When.Operator = %q, want sample", cfg.Investigations[0].Chain[1].When.Operator)
+	if cfg.Alerts[0].Investigations[1].When.Operator != OperatorSample {
+		t.Errorf("chain[1].When.Operator = %q, want sample", cfg.Alerts[0].Investigations[1].When.Operator)
 	}
 }

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -87,36 +87,38 @@ type FilterNode struct {
 	Values   []string `yaml:"values,omitempty"`
 }
 
-// InvestigationFilter associates a filter tree with an investigation by name.
-// A nil Filter means the investigation always runs (no restrictions).
-type InvestigationFilter struct {
-	// Investigation is the investigation name, matching Investigation.Name() or a short name
-	// from the manual controller's shortNameToInvestigation map.
-	Investigation string `yaml:"investigation"`
-	// Filter is the root of the filter tree. nil means always run.
-	Filter *FilterNode `yaml:"when,omitempty"`
+// ShouldRun evaluates the chain-level filter for an investigation config.
+// Returns (result, reason, error). A nil When always returns true.
+// A nil FilterContext always returns true (manual mode bypass).
+func (ic *InvestigationConfig) ShouldRun(ctx *types.FilterContext) (bool, string, error) {
+	if ic.When == nil {
+		return true, "no chain-level filter configured", nil
+	}
+	if ctx == nil {
+		return true, "no filter context (manual mode)", nil
+	}
+	return ic.When.evaluate(ctx)
 }
 
-// Evaluate checks the filter tree for an investigation.
-// Returns (result, reason, error) where reason describes which leaf determined the outcome.
-// A nil InvestigationFilter or nil Filter always returns true.
+// ShouldRun evaluates the entry-level filter for a chain entry.
+// Returns (result, reason, error). A nil When always returns true.
 // A nil FilterContext always returns true (manual mode bypass).
-func (f *InvestigationFilter) Evaluate(ctx *types.FilterContext) (bool, string, error) {
-	if f == nil || f.Filter == nil {
+func (e *ChainEntry) ShouldRun(ctx *types.FilterContext) (bool, string, error) {
+	if e.When == nil {
 		return true, "no filter configured", nil
 	}
 	if ctx == nil {
 		return true, "no filter context (manual mode)", nil
 	}
-	return f.Filter.evaluate(ctx)
+	return e.When.evaluate(ctx)
 }
 
 // Keys returns all field names referenced by leaf nodes in the filter tree.
 // Used to determine which FilterContext fields need to be populated.
-func (f InvestigationFilter) Keys() []string {
+func (e *ChainEntry) Keys() []string {
 	keys := make([]string, 0)
-	if f.Filter != nil {
-		f.Filter.keys(&keys)
+	if e.When != nil {
+		e.When.Keys(&keys)
 	}
 	return keys
 }
@@ -235,17 +237,17 @@ func passOrReject(passed bool) string {
 	return "reject"
 }
 
-// keys recursively collects all field names referenced by leaf nodes.
-func (n *FilterNode) keys(out *[]string) {
+// Keys recursively collects all field names referenced by leaf nodes.
+func (n *FilterNode) Keys(out *[]string) {
 	if len(n.And) > 0 {
 		for i := range n.And {
-			n.And[i].keys(out)
+			n.And[i].Keys(out)
 		}
 		return
 	}
 	if len(n.Or) > 0 {
 		for i := range n.Or {
-			n.Or[i].keys(out)
+			n.Or[i].Keys(out)
 		}
 		return
 	}

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -87,23 +87,23 @@ type FilterNode struct {
 	Values   []string `yaml:"values,omitempty"`
 }
 
-// ShouldRun evaluates the chain-level filter for an investigation config.
+// ShouldRun evaluates the alert-level filter for an alert config.
 // Returns (result, reason, error). A nil When always returns true.
 // A nil FilterContext always returns true (manual mode bypass).
-func (ic *InvestigationConfig) ShouldRun(ctx *types.FilterContext) (bool, string, error) {
-	if ic.When == nil {
-		return true, "no chain-level filter configured", nil
+func (ac *AlertConfig) ShouldRun(ctx *types.FilterContext) (bool, string, error) {
+	if ac.When == nil {
+		return true, "no alert-level filter configured", nil
 	}
 	if ctx == nil {
 		return true, "no filter context (manual mode)", nil
 	}
-	return ic.When.evaluate(ctx)
+	return ac.When.evaluate(ctx)
 }
 
-// ShouldRun evaluates the entry-level filter for a chain entry.
+// ShouldRun evaluates the entry-level filter for an investigation entry.
 // Returns (result, reason, error). A nil When always returns true.
 // A nil FilterContext always returns true (manual mode bypass).
-func (e *ChainEntry) ShouldRun(ctx *types.FilterContext) (bool, string, error) {
+func (e *InvestigationEntry) ShouldRun(ctx *types.FilterContext) (bool, string, error) {
 	if e.When == nil {
 		return true, "no filter configured", nil
 	}
@@ -115,7 +115,7 @@ func (e *ChainEntry) ShouldRun(ctx *types.FilterContext) (bool, string, error) {
 
 // Keys returns all field names referenced by leaf nodes in the filter tree.
 // Used to determine which FilterContext fields need to be populated.
-func (e *ChainEntry) Keys() []string {
+func (e *InvestigationEntry) Keys() []string {
 	keys := make([]string, 0)
 	if e.When != nil {
 		e.When.Keys(&keys)

--- a/pkg/config/filter_test.go
+++ b/pkg/config/filter_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 )
 
-func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test with many cases
+func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven test with many cases
 	baseCtx := &types.FilterContext{
 		ClusterID:      "abc-123",
 		ClusterName:    "my-cluster",
@@ -23,28 +23,29 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 
 	tests := []struct {
 		name    string
-		filter  *InvestigationFilter
+		entry   *ChainEntry
 		ctx     *types.FilterContext
 		want    bool
 		wantErr bool
 	}{
 		// --- nil / empty ---
 		{
-			name:   "nil filter passes",
-			filter: nil,
-			ctx:    baseCtx,
-			want:   true,
+			name:  "nil when passes",
+			entry: &ChainEntry{Name: "test"},
+			ctx:   baseCtx,
+			want:  true,
 		},
 		{
-			name:   "empty filter (nil tree) passes",
-			filter: &InvestigationFilter{},
-			ctx:    baseCtx,
-			want:   true,
+			name:  "nil when with nil filter node passes",
+			entry: &ChainEntry{Name: "test", When: nil},
+			ctx:   baseCtx,
+			want:  true,
 		},
 		{
 			name: "nil context passes",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "AlertName", Operator: OperatorIn, Values: []string{"chgm"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldAlertName, Operator: OperatorIn, Values: []string{"chgm"}},
 			},
 			ctx:  nil,
 			want: true,
@@ -52,16 +53,18 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- single leaf: in ---
 		{
 			name: "in operator matches",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"aws", "gcp"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws", "gcp"}},
 			},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "in operator does not match",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"gcp", "azure"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"gcp", "azure"}},
 			},
 			ctx:  baseCtx,
 			want: false,
@@ -69,16 +72,18 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- single leaf: notin ---
 		{
 			name: "notin operator matches",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "CloudProvider", Operator: OperatorNotIn, Values: []string{"gcp"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorNotIn, Values: []string{"gcp"}},
 			},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "notin operator does not match",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "CloudProvider", Operator: OperatorNotIn, Values: []string{"aws"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorNotIn, Values: []string{"aws"}},
 			},
 			ctx:  baseCtx,
 			want: false,
@@ -86,24 +91,27 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- single leaf: matches ---
 		{
 			name: "matches operator matches",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "OwnerEmail", Operator: OperatorMatches, Values: []string{".*@redhat\\.com$"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorMatches, Values: []string{".*@redhat\\.com$"}},
 			},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "matches operator does not match",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "OwnerEmail", Operator: OperatorMatches, Values: []string{".*@ibm\\.com$"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorMatches, Values: []string{".*@ibm\\.com$"}},
 			},
 			ctx:  baseCtx,
 			want: false,
 		},
 		{
 			name: "matches with multiple patterns matches second",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "OwnerEmail", Operator: OperatorMatches, Values: []string{".*@ibm\\.com$", ".*@redhat\\.com$"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorMatches, Values: []string{".*@ibm\\.com$", ".*@redhat\\.com$"}},
 			},
 			ctx:  baseCtx,
 			want: true,
@@ -111,16 +119,18 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- single leaf: notmatches ---
 		{
 			name: "notmatches operator matches (no regex match = true)",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "OwnerEmail", Operator: OperatorNotMatches, Values: []string{".*@ibm\\.com$"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorNotMatches, Values: []string{".*@ibm\\.com$"}},
 			},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "notmatches operator does not match (regex matches = false)",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "OwnerEmail", Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
 			},
 			ctx:  baseCtx,
 			want: false,
@@ -128,12 +138,13 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- AND branch ---
 		{
 			name: "AND all pass",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					And: []FilterNode{
-						{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"aws"}},
-						{Field: "ClusterState", Operator: OperatorIn, Values: []string{"ready"}},
-						{Field: "AlertName", Operator: OperatorIn, Values: []string{"ClusterHasGoneMissing", "cpd"}},
+						{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
+						{Field: FieldClusterState, Operator: OperatorIn, Values: []string{"ready"}},
+						{Field: FieldAlertName, Operator: OperatorIn, Values: []string{"ClusterHasGoneMissing", "cpd"}},
 					},
 				},
 			},
@@ -142,11 +153,12 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		},
 		{
 			name: "AND one fails",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					And: []FilterNode{
-						{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"aws"}},
-						{Field: "ClusterState", Operator: OperatorIn, Values: []string{"uninstalling"}},
+						{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
+						{Field: FieldClusterState, Operator: OperatorIn, Values: []string{"uninstalling"}},
 					},
 				},
 			},
@@ -156,11 +168,12 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- OR branch ---
 		{
 			name: "OR one matches",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					Or: []FilterNode{
-						{Field: "ClusterID", Operator: OperatorIn, Values: []string{"abc-123"}},
-						{Field: "ClusterID", Operator: OperatorIn, Values: []string{"other"}},
+						{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"abc-123"}},
+						{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"other"}},
 					},
 				},
 			},
@@ -169,11 +182,12 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		},
 		{
 			name: "OR none match",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					Or: []FilterNode{
-						{Field: "ClusterID", Operator: OperatorIn, Values: []string{"other1"}},
-						{Field: "ClusterID", Operator: OperatorIn, Values: []string{"other2"}},
+						{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"other1"}},
+						{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"other2"}},
 					},
 				},
 			},
@@ -182,11 +196,12 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		},
 		{
 			name: "OR second matches",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					Or: []FilterNode{
-						{Field: "ClusterID", Operator: OperatorIn, Values: []string{"no-match"}},
-						{Field: "OrganizationID", Operator: OperatorIn, Values: []string{"org-456"}},
+						{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"no-match"}},
+						{Field: FieldOrganizationID, Operator: OperatorIn, Values: []string{"org-456"}},
 					},
 				},
 			},
@@ -196,12 +211,13 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- nested AND + OR ---
 		{
 			name: "AND+OR both pass",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					And: []FilterNode{
-						{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"aws"}},
+						{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
 						{Or: []FilterNode{
-							{Field: "ClusterID", Operator: OperatorIn, Values: []string{"abc-123"}},
+							{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"abc-123"}},
 						}},
 					},
 				},
@@ -211,12 +227,13 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		},
 		{
 			name: "AND+OR AND fails",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					And: []FilterNode{
-						{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"gcp"}},
+						{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"gcp"}},
 						{Or: []FilterNode{
-							{Field: "ClusterID", Operator: OperatorIn, Values: []string{"abc-123"}},
+							{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"abc-123"}},
 						}},
 					},
 				},
@@ -226,12 +243,13 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		},
 		{
 			name: "AND+OR OR fails",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					And: []FilterNode{
-						{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"aws"}},
+						{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
 						{Or: []FilterNode{
-							{Field: "ClusterID", Operator: OperatorIn, Values: []string{"no-match"}},
+							{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"no-match"}},
 						}},
 					},
 				},
@@ -242,16 +260,17 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- deeply nested (3 levels) ---
 		{
 			name: "3-level nesting",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					And: []FilterNode{
-						{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"aws"}},
+						{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
 						{Or: []FilterNode{
 							{And: []FilterNode{
-								{Field: "ClusterID", Operator: OperatorIn, Values: []string{"abc-123"}},
-								{Field: "ClusterState", Operator: OperatorIn, Values: []string{"ready"}},
+								{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"abc-123"}},
+								{Field: FieldClusterState, Operator: OperatorIn, Values: []string{"ready"}},
 							}},
-							{Field: "OrganizationID", Operator: OperatorIn, Values: []string{"other-org"}},
+							{Field: FieldOrganizationID, Operator: OperatorIn, Values: []string{"other-org"}},
 						}},
 					},
 				},
@@ -262,56 +281,63 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- field types ---
 		{
 			name: "HCP bool field false",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "HCP", Operator: OperatorIn, Values: []string{"false"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldHCP, Operator: OperatorIn, Values: []string{"false"}},
 			},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "HCP bool field true",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "HCP", Operator: OperatorIn, Values: []string{"true"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldHCP, Operator: OperatorIn, Values: []string{"true"}},
 			},
 			ctx:  &types.FilterContext{HCP: true},
 			want: true,
 		},
 		{
 			name: "OwnerEmail field",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "OwnerEmail", Operator: OperatorIn, Values: []string{"user@redhat.com"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorIn, Values: []string{"user@redhat.com"}},
 			},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "OrganizationID field",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "OrganizationID", Operator: OperatorIn, Values: []string{"org-456"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldOrganizationID, Operator: OperatorIn, Values: []string{"org-456"}},
 			},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "ServiceName field",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "ServiceName", Operator: OperatorIn, Values: []string{"prod-osd"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldServiceName, Operator: OperatorIn, Values: []string{"prod-osd"}},
 			},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "empty context field does not match in",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "OwnerEmail", Operator: OperatorIn, Values: []string{"user@redhat.com"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorIn, Values: []string{"user@redhat.com"}},
 			},
 			ctx:  &types.FilterContext{},
 			want: false,
 		},
 		{
 			name: "empty context field matches notin",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "OwnerEmail", Operator: OperatorNotIn, Values: []string{"user@redhat.com"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorNotIn, Values: []string{"user@redhat.com"}},
 			},
 			ctx:  &types.FilterContext{},
 			want: true,
@@ -319,16 +345,18 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- sample operator ---
 		{
 			name: "sample 1.0 always passes",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Operator: OperatorSample, Values: []string{"1.0"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Operator: OperatorSample, Values: []string{"1.0"}},
 			},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "sample 0 always fails",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Operator: OperatorSample, Values: []string{"0"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Operator: OperatorSample, Values: []string{"0"}},
 			},
 			ctx:  baseCtx,
 			want: false,
@@ -336,10 +364,11 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- sample with exemption pattern ---
 		{
 			name: "sample exemption: redhat email bypasses sampling",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					Or: []FilterNode{
-						{Field: "OwnerEmail", Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
+						{Field: FieldOwnerEmail, Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
 						{Operator: OperatorSample, Values: []string{"1.0"}},
 					},
 				},
@@ -349,10 +378,11 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		},
 		{
 			name: "sample exemption: non-redhat email passes via notmatches",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					Or: []FilterNode{
-						{Field: "OwnerEmail", Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
+						{Field: FieldOwnerEmail, Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
 						{Operator: OperatorSample, Values: []string{"0"}},
 					},
 				},
@@ -362,10 +392,11 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		},
 		{
 			name: "sample exemption: redhat email with sample 0 fails",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					Or: []FilterNode{
-						{Field: "OwnerEmail", Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
+						{Field: FieldOwnerEmail, Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
 						{Operator: OperatorSample, Values: []string{"0"}},
 					},
 				},
@@ -376,24 +407,27 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		// --- error cases ---
 		{
 			name: "unknown field returns error",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "UnknownField", Operator: OperatorIn, Values: []string{"x"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: "UnknownField", Operator: OperatorIn, Values: []string{"x"}},
 			},
 			ctx:     baseCtx,
 			wantErr: true,
 		},
 		{
 			name: "unsupported operator returns error",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{Field: "CloudProvider", Operator: "equals", Values: []string{"aws"}},
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{Field: FieldCloudProvider, Operator: "equals", Values: []string{"aws"}},
 			},
 			ctx:     baseCtx,
 			wantErr: true,
 		},
 		{
 			name: "error in AND child propagates",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					And: []FilterNode{
 						{Field: "BadField", Operator: OperatorIn, Values: []string{"x"}},
 					},
@@ -404,8 +438,9 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 		},
 		{
 			name: "error in OR child propagates",
-			filter: &InvestigationFilter{
-				Filter: &FilterNode{
+			entry: &ChainEntry{
+				Name: "test",
+				When: &FilterNode{
 					Or: []FilterNode{
 						{Field: "BadField", Operator: OperatorIn, Values: []string{"x"}},
 					},
@@ -418,13 +453,85 @@ func TestFilterEvaluate(t *testing.T) { //nolint:maintidx // table-driven test w
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, reason, err := tt.filter.Evaluate(tt.ctx)
+			got, reason, err := tt.entry.ShouldRun(tt.ctx)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Evaluate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ShouldRun() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr && got != tt.want {
-				t.Errorf("Evaluate() = %v, want %v (reason: %s)", got, tt.want, reason)
+				t.Errorf("ShouldRun() = %v, want %v (reason: %s)", got, tt.want, reason)
+			}
+		})
+	}
+}
+
+func TestInvestigationConfigShouldRun(t *testing.T) {
+	baseCtx := &types.FilterContext{
+		ClusterID:      "abc-123",
+		OrganizationID: "org-456",
+		CloudProvider:  "aws",
+	}
+
+	tests := []struct {
+		name    string
+		ic      *InvestigationConfig
+		ctx     *types.FilterContext
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "nil when passes",
+			ic:   &InvestigationConfig{AlertTitle: "Test", When: nil},
+			ctx:  baseCtx,
+			want: true,
+		},
+		{
+			name: "nil context passes",
+			ic: &InvestigationConfig{
+				AlertTitle: "Test",
+				When:       &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"gcp"}},
+			},
+			ctx:  nil,
+			want: true,
+		},
+		{
+			name: "chain-level filter passes",
+			ic: &InvestigationConfig{
+				AlertTitle: "Test",
+				When:       &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
+			},
+			ctx:  baseCtx,
+			want: true,
+		},
+		{
+			name: "chain-level filter blocks",
+			ic: &InvestigationConfig{
+				AlertTitle: "Test",
+				When:       &FilterNode{Field: FieldOrganizationID, Operator: OperatorNotIn, Values: []string{"org-456"}},
+			},
+			ctx:  baseCtx,
+			want: false,
+		},
+		{
+			name: "chain-level filter error propagates",
+			ic: &InvestigationConfig{
+				AlertTitle: "Test",
+				When:       &FilterNode{Field: "BadField", Operator: OperatorIn, Values: []string{"x"}},
+			},
+			ctx:     baseCtx,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason, err := tt.ic.ShouldRun(tt.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ShouldRun() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ShouldRun() = %v, want %v (reason: %s)", got, tt.want, reason)
 			}
 		})
 	}
@@ -439,22 +546,22 @@ func TestFilterNodeValidate(t *testing.T) {
 		// --- valid leaves ---
 		{
 			name:    "valid in leaf",
-			node:    FilterNode{Field: "AlertName", Operator: OperatorIn, Values: []string{"chgm"}},
+			node:    FilterNode{Field: FieldAlertName, Operator: OperatorIn, Values: []string{"chgm"}},
 			wantErr: false,
 		},
 		{
 			name:    "valid notin leaf",
-			node:    FilterNode{Field: "CloudProvider", Operator: OperatorNotIn, Values: []string{"gcp"}},
+			node:    FilterNode{Field: FieldCloudProvider, Operator: OperatorNotIn, Values: []string{"gcp"}},
 			wantErr: false,
 		},
 		{
 			name:    "valid matches leaf",
-			node:    FilterNode{Field: "OwnerEmail", Operator: OperatorMatches, Values: []string{".*@redhat\\.com$"}},
+			node:    FilterNode{Field: FieldOwnerEmail, Operator: OperatorMatches, Values: []string{".*@redhat\\.com$"}},
 			wantErr: false,
 		},
 		{
 			name:    "valid notmatches leaf",
-			node:    FilterNode{Field: "OwnerEmail", Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
+			node:    FilterNode{Field: FieldOwnerEmail, Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
 			wantErr: false,
 		},
 		{
@@ -477,7 +584,7 @@ func TestFilterNodeValidate(t *testing.T) {
 			name: "valid and branch",
 			node: FilterNode{
 				And: []FilterNode{
-					{Field: "AlertName", Operator: OperatorIn, Values: []string{"chgm"}},
+					{Field: FieldAlertName, Operator: OperatorIn, Values: []string{"chgm"}},
 				},
 			},
 			wantErr: false,
@@ -486,7 +593,7 @@ func TestFilterNodeValidate(t *testing.T) {
 			name: "valid or branch",
 			node: FilterNode{
 				Or: []FilterNode{
-					{Field: "AlertName", Operator: OperatorIn, Values: []string{"chgm"}},
+					{Field: FieldAlertName, Operator: OperatorIn, Values: []string{"chgm"}},
 				},
 			},
 			wantErr: false,
@@ -495,15 +602,15 @@ func TestFilterNodeValidate(t *testing.T) {
 		{
 			name: "both 'and' and 'or'",
 			node: FilterNode{
-				And: []FilterNode{{Field: "AlertName", Operator: OperatorIn, Values: []string{"a"}}},
-				Or:  []FilterNode{{Field: "AlertName", Operator: OperatorIn, Values: []string{"b"}}},
+				And: []FilterNode{{Field: FieldAlertName, Operator: OperatorIn, Values: []string{"a"}}},
+				Or:  []FilterNode{{Field: FieldAlertName, Operator: OperatorIn, Values: []string{"b"}}},
 			},
 			wantErr: true,
 		},
 		{
 			name: "branch with operator",
 			node: FilterNode{
-				And:      []FilterNode{{Field: "AlertName", Operator: OperatorIn, Values: []string{"a"}}},
+				And:      []FilterNode{{Field: FieldAlertName, Operator: OperatorIn, Values: []string{"a"}}},
 				Operator: OperatorIn,
 			},
 			wantErr: true,
@@ -526,27 +633,27 @@ func TestFilterNodeValidate(t *testing.T) {
 		},
 		{
 			name:    "in with empty values",
-			node:    FilterNode{Field: "AlertName", Operator: OperatorIn, Values: []string{}},
+			node:    FilterNode{Field: FieldAlertName, Operator: OperatorIn, Values: []string{}},
 			wantErr: true,
 		},
 		{
 			name:    "in with nil values",
-			node:    FilterNode{Field: "AlertName", Operator: OperatorIn},
+			node:    FilterNode{Field: FieldAlertName, Operator: OperatorIn},
 			wantErr: true,
 		},
 		{
 			name:    "unsupported operator",
-			node:    FilterNode{Field: "AlertName", Operator: "equals", Values: []string{"x"}},
+			node:    FilterNode{Field: FieldAlertName, Operator: "equals", Values: []string{"x"}},
 			wantErr: true,
 		},
 		{
 			name:    "matches with invalid regex",
-			node:    FilterNode{Field: "OwnerEmail", Operator: OperatorMatches, Values: []string{"[invalid"}},
+			node:    FilterNode{Field: FieldOwnerEmail, Operator: OperatorMatches, Values: []string{"[invalid"}},
 			wantErr: true,
 		},
 		{
 			name:    "notmatches with invalid regex",
-			node:    FilterNode{Field: "OwnerEmail", Operator: OperatorNotMatches, Values: []string{"[invalid"}},
+			node:    FilterNode{Field: FieldOwnerEmail, Operator: OperatorNotMatches, Values: []string{"[invalid"}},
 			wantErr: true,
 		},
 		{
@@ -556,7 +663,7 @@ func TestFilterNodeValidate(t *testing.T) {
 		},
 		{
 			name:    "sample with field",
-			node:    FilterNode{Field: "CloudProvider", Operator: OperatorSample, Values: []string{"0.5"}},
+			node:    FilterNode{Field: FieldCloudProvider, Operator: OperatorSample, Values: []string{"0.5"}},
 			wantErr: true,
 		},
 		{
@@ -610,56 +717,56 @@ func TestFilterNodeValidate(t *testing.T) {
 	}
 }
 
-func TestKeys(t *testing.T) {
+func TestChainEntryKeys(t *testing.T) {
 	tests := []struct {
-		name string
-		f    InvestigationFilter
-		want []string
+		name  string
+		entry ChainEntry
+		want  []string
 	}{
 		{
-			name: "nil filter",
-			f:    InvestigationFilter{},
-			want: []string{},
+			name:  "nil when",
+			entry: ChainEntry{Name: "test"},
+			want:  []string{},
 		},
 		{
-			name: "single leaf",
-			f:    InvestigationFilter{Filter: &FilterNode{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"aws"}}},
-			want: []string{"CloudProvider"},
+			name:  "single leaf",
+			entry: ChainEntry{Name: "test", When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}}},
+			want:  []string{FieldCloudProvider},
 		},
 		{
-			name: "sample leaf has no keys",
-			f:    InvestigationFilter{Filter: &FilterNode{Operator: OperatorSample, Values: []string{"0.5"}}},
-			want: []string{},
+			name:  "sample leaf has no keys",
+			entry: ChainEntry{Name: "test", When: &FilterNode{Operator: OperatorSample, Values: []string{"0.5"}}},
+			want:  []string{},
 		},
 		{
 			name: "and branch collects all keys",
-			f: InvestigationFilter{Filter: &FilterNode{
+			entry: ChainEntry{Name: "test", When: &FilterNode{
 				And: []FilterNode{
-					{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"aws"}},
-					{Field: "ClusterState", Operator: OperatorIn, Values: []string{"ready"}},
+					{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
+					{Field: FieldClusterState, Operator: OperatorIn, Values: []string{"ready"}},
 				},
 			}},
-			want: []string{"CloudProvider", "ClusterState"},
+			want: []string{FieldCloudProvider, FieldClusterState},
 		},
 		{
 			name: "nested tree collects all keys",
-			f: InvestigationFilter{Filter: &FilterNode{
+			entry: ChainEntry{Name: "test", When: &FilterNode{
 				And: []FilterNode{
-					{Field: "CloudProvider", Operator: OperatorIn, Values: []string{"aws"}},
+					{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
 					{Or: []FilterNode{
-						{Field: "ClusterID", Operator: OperatorIn, Values: []string{"abc"}},
-						{Field: "OrganizationID", Operator: OperatorIn, Values: []string{"org"}},
+						{Field: FieldClusterID, Operator: OperatorIn, Values: []string{"abc"}},
+						{Field: FieldOrganizationID, Operator: OperatorIn, Values: []string{"org"}},
 						{Operator: OperatorSample, Values: []string{"0.5"}},
 					}},
 				},
 			}},
-			want: []string{"CloudProvider", "ClusterID", "OrganizationID"},
+			want: []string{FieldCloudProvider, FieldClusterID, FieldOrganizationID},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.f.Keys()
+			got := tt.entry.Keys()
 			if len(got) != len(tt.want) {
 				t.Fatalf("Keys() = %v, want %v", got, tt.want)
 			}
@@ -688,17 +795,17 @@ func TestResolveAllFields(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"ClusterID":      "cid",
-		"ClusterName":    "cname",
-		"OrganizationID": "oid",
-		"OwnerID":        "uid",
-		"OwnerEmail":     "e@r.com",
-		"CloudProvider":  "aws",
-		"HCP":            "true",
-		"ClusterState":   "ready",
-		"AlertName":      "alert",
-		"AlertTitle":     "title",
-		"ServiceName":    "svc",
+		FieldClusterID:      "cid",
+		FieldClusterName:    "cname",
+		FieldOrganizationID: "oid",
+		FieldOwnerID:        "uid",
+		FieldOwnerEmail:     "e@r.com",
+		FieldCloudProvider:  "aws",
+		FieldHCP:            "true",
+		FieldClusterState:   "ready",
+		FieldAlertName:      "alert",
+		FieldAlertTitle:     "title",
+		FieldServiceName:    "svc",
 	}
 
 	for field, want := range expected {

--- a/pkg/config/filter_test.go
+++ b/pkg/config/filter_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 )
 
-func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven test with many cases
+func TestInvestigationEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven test with many cases
 	baseCtx := &types.FilterContext{
 		ClusterID:      "abc-123",
 		ClusterName:    "my-cluster",
@@ -23,7 +23,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 
 	tests := []struct {
 		name    string
-		entry   *ChainEntry
+		entry   *InvestigationEntry
 		ctx     *types.FilterContext
 		want    bool
 		wantErr bool
@@ -31,19 +31,19 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- nil / empty ---
 		{
 			name:  "nil when passes",
-			entry: &ChainEntry{Name: "test"},
+			entry: &InvestigationEntry{Name: "test"},
 			ctx:   baseCtx,
 			want:  true,
 		},
 		{
 			name:  "nil when with nil filter node passes",
-			entry: &ChainEntry{Name: "test", When: nil},
+			entry: &InvestigationEntry{Name: "test", When: nil},
 			ctx:   baseCtx,
 			want:  true,
 		},
 		{
 			name: "nil context passes",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldAlertName, Operator: OperatorIn, Values: []string{"chgm"}},
 			},
@@ -53,7 +53,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- single leaf: in ---
 		{
 			name: "in operator matches",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws", "gcp"}},
 			},
@@ -62,7 +62,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "in operator does not match",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"gcp", "azure"}},
 			},
@@ -72,7 +72,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- single leaf: notin ---
 		{
 			name: "notin operator matches",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorNotIn, Values: []string{"gcp"}},
 			},
@@ -81,7 +81,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "notin operator does not match",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorNotIn, Values: []string{"aws"}},
 			},
@@ -91,7 +91,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- single leaf: matches ---
 		{
 			name: "matches operator matches",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorMatches, Values: []string{".*@redhat\\.com$"}},
 			},
@@ -100,7 +100,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "matches operator does not match",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorMatches, Values: []string{".*@ibm\\.com$"}},
 			},
@@ -109,7 +109,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "matches with multiple patterns matches second",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorMatches, Values: []string{".*@ibm\\.com$", ".*@redhat\\.com$"}},
 			},
@@ -119,7 +119,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- single leaf: notmatches ---
 		{
 			name: "notmatches operator matches (no regex match = true)",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorNotMatches, Values: []string{".*@ibm\\.com$"}},
 			},
@@ -128,7 +128,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "notmatches operator does not match (regex matches = false)",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorNotMatches, Values: []string{".*@redhat\\.com$"}},
 			},
@@ -138,7 +138,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- AND branch ---
 		{
 			name: "AND all pass",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					And: []FilterNode{
@@ -153,7 +153,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "AND one fails",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					And: []FilterNode{
@@ -168,7 +168,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- OR branch ---
 		{
 			name: "OR one matches",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					Or: []FilterNode{
@@ -182,7 +182,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "OR none match",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					Or: []FilterNode{
@@ -196,7 +196,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "OR second matches",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					Or: []FilterNode{
@@ -211,7 +211,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- nested AND + OR ---
 		{
 			name: "AND+OR both pass",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					And: []FilterNode{
@@ -227,7 +227,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "AND+OR AND fails",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					And: []FilterNode{
@@ -243,7 +243,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "AND+OR OR fails",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					And: []FilterNode{
@@ -260,7 +260,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- deeply nested (3 levels) ---
 		{
 			name: "3-level nesting",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					And: []FilterNode{
@@ -281,7 +281,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- field types ---
 		{
 			name: "HCP bool field false",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldHCP, Operator: OperatorIn, Values: []string{"false"}},
 			},
@@ -290,7 +290,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "HCP bool field true",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldHCP, Operator: OperatorIn, Values: []string{"true"}},
 			},
@@ -299,7 +299,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "OwnerEmail field",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorIn, Values: []string{"user@redhat.com"}},
 			},
@@ -308,7 +308,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "OrganizationID field",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldOrganizationID, Operator: OperatorIn, Values: []string{"org-456"}},
 			},
@@ -317,7 +317,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "ServiceName field",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldServiceName, Operator: OperatorIn, Values: []string{"prod-osd"}},
 			},
@@ -326,7 +326,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "empty context field does not match in",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorIn, Values: []string{"user@redhat.com"}},
 			},
@@ -335,7 +335,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "empty context field matches notin",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldOwnerEmail, Operator: OperatorNotIn, Values: []string{"user@redhat.com"}},
 			},
@@ -345,7 +345,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- sample operator ---
 		{
 			name: "sample 1.0 always passes",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Operator: OperatorSample, Values: []string{"1.0"}},
 			},
@@ -354,7 +354,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "sample 0 always fails",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Operator: OperatorSample, Values: []string{"0"}},
 			},
@@ -364,7 +364,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- sample with exemption pattern ---
 		{
 			name: "sample exemption: redhat email bypasses sampling",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					Or: []FilterNode{
@@ -378,7 +378,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "sample exemption: non-redhat email passes via notmatches",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					Or: []FilterNode{
@@ -392,7 +392,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "sample exemption: redhat email with sample 0 fails",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					Or: []FilterNode{
@@ -407,7 +407,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		// --- error cases ---
 		{
 			name: "unknown field returns error",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: "UnknownField", Operator: OperatorIn, Values: []string{"x"}},
 			},
@@ -416,7 +416,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "unsupported operator returns error",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{Field: FieldCloudProvider, Operator: "equals", Values: []string{"aws"}},
 			},
@@ -425,7 +425,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "error in AND child propagates",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					And: []FilterNode{
@@ -438,7 +438,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 		},
 		{
 			name: "error in OR child propagates",
-			entry: &ChainEntry{
+			entry: &InvestigationEntry{
 				Name: "test",
 				When: &FilterNode{
 					Or: []FilterNode{
@@ -465,7 +465,7 @@ func TestChainEntryShouldRun(t *testing.T) { //nolint:maintidx // table-driven t
 	}
 }
 
-func TestInvestigationConfigShouldRun(t *testing.T) {
+func TestAlertConfigShouldRun(t *testing.T) {
 	baseCtx := &types.FilterContext{
 		ClusterID:      "abc-123",
 		OrganizationID: "org-456",
@@ -474,20 +474,20 @@ func TestInvestigationConfigShouldRun(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		ic      *InvestigationConfig
+		ac      *AlertConfig
 		ctx     *types.FilterContext
 		want    bool
 		wantErr bool
 	}{
 		{
 			name: "nil when passes",
-			ic:   &InvestigationConfig{AlertTitle: "Test", When: nil},
+			ac:   &AlertConfig{AlertTitle: "Test", When: nil},
 			ctx:  baseCtx,
 			want: true,
 		},
 		{
 			name: "nil context passes",
-			ic: &InvestigationConfig{
+			ac: &AlertConfig{
 				AlertTitle: "Test",
 				When:       &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"gcp"}},
 			},
@@ -495,8 +495,8 @@ func TestInvestigationConfigShouldRun(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "chain-level filter passes",
-			ic: &InvestigationConfig{
+			name: "alert-level filter passes",
+			ac: &AlertConfig{
 				AlertTitle: "Test",
 				When:       &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
 			},
@@ -504,8 +504,8 @@ func TestInvestigationConfigShouldRun(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "chain-level filter blocks",
-			ic: &InvestigationConfig{
+			name: "alert-level filter blocks",
+			ac: &AlertConfig{
 				AlertTitle: "Test",
 				When:       &FilterNode{Field: FieldOrganizationID, Operator: OperatorNotIn, Values: []string{"org-456"}},
 			},
@@ -513,8 +513,8 @@ func TestInvestigationConfigShouldRun(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "chain-level filter error propagates",
-			ic: &InvestigationConfig{
+			name: "alert-level filter error propagates",
+			ac: &AlertConfig{
 				AlertTitle: "Test",
 				When:       &FilterNode{Field: "BadField", Operator: OperatorIn, Values: []string{"x"}},
 			},
@@ -525,7 +525,7 @@ func TestInvestigationConfigShouldRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, reason, err := tt.ic.ShouldRun(tt.ctx)
+			got, reason, err := tt.ac.ShouldRun(tt.ctx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ShouldRun() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -717,30 +717,30 @@ func TestFilterNodeValidate(t *testing.T) {
 	}
 }
 
-func TestChainEntryKeys(t *testing.T) {
+func TestInvestigationEntryKeys(t *testing.T) {
 	tests := []struct {
 		name  string
-		entry ChainEntry
+		entry InvestigationEntry
 		want  []string
 	}{
 		{
 			name:  "nil when",
-			entry: ChainEntry{Name: "test"},
+			entry: InvestigationEntry{Name: "test"},
 			want:  []string{},
 		},
 		{
 			name:  "single leaf",
-			entry: ChainEntry{Name: "test", When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}}},
+			entry: InvestigationEntry{Name: "test", When: &FilterNode{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}}},
 			want:  []string{FieldCloudProvider},
 		},
 		{
 			name:  "sample leaf has no keys",
-			entry: ChainEntry{Name: "test", When: &FilterNode{Operator: OperatorSample, Values: []string{"0.5"}}},
+			entry: InvestigationEntry{Name: "test", When: &FilterNode{Operator: OperatorSample, Values: []string{"0.5"}}},
 			want:  []string{},
 		},
 		{
 			name: "and branch collects all keys",
-			entry: ChainEntry{Name: "test", When: &FilterNode{
+			entry: InvestigationEntry{Name: "test", When: &FilterNode{
 				And: []FilterNode{
 					{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
 					{Field: FieldClusterState, Operator: OperatorIn, Values: []string{"ready"}},
@@ -750,7 +750,7 @@ func TestChainEntryKeys(t *testing.T) {
 		},
 		{
 			name: "nested tree collects all keys",
-			entry: ChainEntry{Name: "test", When: &FilterNode{
+			entry: InvestigationEntry{Name: "test", When: &FilterNode{
 				And: []FilterNode{
 					{Field: FieldCloudProvider, Operator: OperatorIn, Values: []string{"aws"}},
 					{Or: []FilterNode{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -298,7 +298,7 @@ func (c *investigationRunner) runChain(
 	params map[string]string,
 ) (err error) {
 	if len(alertConfig.Investigations) > 0 {
-		metrics.Inc(metrics.Alerts, alertConfig.AlertTitle)
+		metrics.Inc(metrics.Alerts, alertConfig.GetName())
 	}
 
 	var latestBuilder investigation.ResourceBuilder

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -87,7 +87,7 @@ type Dependencies struct {
 	BackplaneProxy      string
 	AWSProxy            string
 	ExperimentalEnabled bool
-	FilterConfig        *config.Config
+	Cfg                 *config.Config
 }
 
 // Retry configuration for transient infrastructure errors
@@ -147,10 +147,10 @@ func initializeDependencies(configPath string) (*Dependencies, error) {
 	experimentalEnabledVar := os.Getenv("CAD_EXPERIMENTAL_ENABLED")
 	experimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
 
-	// Load investigation filter config (optional — nil means no filtering)
-	filterConfig, err := config.LoadConfig(configPath, investigations.GetAvailableInvestigationsNames())
+	// Load investigation config
+	cfg, err := config.LoadConfig(configPath, investigations.GetAvailableInvestigationsNames())
 	if err != nil {
-		return nil, fmt.Errorf("failed to load investigation filter config: %w", err)
+		return nil, fmt.Errorf("failed to load investigation config: %w", err)
 	}
 
 	// Create OCM client
@@ -177,7 +177,7 @@ func initializeDependencies(configPath string) (*Dependencies, error) {
 		BackplaneProxy:      backplaneProxy,
 		AWSProxy:            awsProxy,
 		ExperimentalEnabled: experimentalEnabled,
-		FilterConfig:        filterConfig,
+		Cfg:                 cfg,
 	}, nil
 }
 
@@ -332,8 +332,8 @@ func (c *investigationRunner) runChain(
 		}
 
 		// Create a fresh aiassisted instance with the runtime config to avoid mutating the registry singleton.
-		if _, ok := inv.(*aiassisted.Investigation); ok && c.dependencies.FilterConfig != nil {
-			inv = &aiassisted.Investigation{AIConfig: c.dependencies.FilterConfig.GetAIAgentConfig()}
+		if _, ok := inv.(*aiassisted.Investigation); ok && c.dependencies.Cfg != nil {
+			inv = &aiassisted.Investigation{AIConfig: c.dependencies.Cfg.GetAIAgentConfig()}
 		}
 
 		builder, bErr := investigation.NewResourceBuilder(

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -287,8 +287,11 @@ func (c *investigationRunner) runChain(
 
 	var latestBuilder investigation.ResourceBuilder
 	defer func() {
-		if err != nil && latestBuilder != nil {
-			handleCADFailure(err, latestBuilder, c.notifier)
+		if err != nil {
+			c.recordManualCompletion(alertConfig.AlertTitle, "error")
+			if latestBuilder != nil {
+				handleCADFailure(err, latestBuilder, c.notifier)
+			}
 		}
 	}()
 
@@ -316,10 +319,12 @@ func (c *investigationRunner) runChain(
 			if escErr := c.notifier.EscalateWithNote(fmt.Sprintf("🤖 Investigations for alert %q were filtered: %s. Escalating to SRE. 🤖", alertConfig.AlertTitle, reason)); escErr != nil {
 				logging.Errorf("Failed to escalate filtered alert: %v", escErr)
 			}
+			c.recordManualCompletion(alertConfig.AlertTitle, "filtered")
 			return nil
 		}
 	}
 
+	hasFindings := false
 	for _, entry := range alertConfig.Investigations {
 		inv := investigations.GetInvestigationByName(entry.Name)
 		if inv == nil {
@@ -369,6 +374,7 @@ func (c *investigationRunner) runChain(
 		}
 
 		if len(result.Actions) > 0 {
+			hasFindings = true
 			if execErr := c.executeActions(builder, &result, inv.Name()); execErr != nil {
 				cleanupBuilder(builder)
 				return fmt.Errorf("failed to execute %s actions: %w", inv.Name(), execErr)
@@ -379,8 +385,15 @@ func (c *investigationRunner) runChain(
 
 		if result.StopInvestigations != nil {
 			logging.Infof("Stopping investigations due to %q: %v", inv.Name(), result.StopInvestigations)
+			c.recordManualCompletion(alertConfig.AlertTitle, "stopped")
 			return nil
 		}
+	}
+
+	if hasFindings {
+		c.recordManualCompletion(alertConfig.AlertTitle, "success")
+	} else {
+		c.recordManualCompletion(alertConfig.AlertTitle, "no_findings")
 	}
 
 	// Post-chain: title update (PD mode only)
@@ -476,6 +489,15 @@ func calculateBackoff(attempt int) time.Duration {
 		backoff = maxRetryBackoff
 	}
 	return backoff
+}
+
+// recordManualCompletion records manual investigation completion metric.
+// Only tracks if this is a manual investigation (notifier is inactive).
+func (c *investigationRunner) recordManualCompletion(invName string, status string) {
+	if !c.notifier.IsActive() {
+		dryRun := strconv.FormatBool(c.dryRun)
+		metrics.Inc(metrics.ManualInvestigationCompleted, invName, status, dryRun)
+	}
 }
 
 func handleCADFailure(err error, rb investigation.ResourceBuilder, notifier incidentNotifier) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -28,6 +28,11 @@ import (
 
 const pagerdutyTitlePrefix = "[CAD Investigated]"
 
+// errAlertFiltered is returned by runChain when the alert-level When filter
+// rejects the alert. The caller uses this to fall through to AI/escalation
+// instead of treating it as a hard failure.
+var errAlertFiltered = errors.New("alert filtered by when clause")
+
 type PagerDutyConfig struct {
 	PayloadPath string
 }
@@ -287,7 +292,7 @@ func (c *investigationRunner) runChain(
 
 	var latestBuilder investigation.ResourceBuilder
 	defer func() {
-		if err != nil {
+		if err != nil && !errors.Is(err, errAlertFiltered) {
 			c.recordManualCompletion(alertConfig.AlertTitle, "error")
 			if latestBuilder != nil {
 				handleCADFailure(err, latestBuilder, c.notifier)
@@ -316,11 +321,8 @@ func (c *investigationRunner) runChain(
 		}
 		if !pass {
 			logging.Infof("Alert %q filtered out: %s", alertConfig.AlertTitle, reason)
-			if escErr := c.notifier.EscalateWithNote(fmt.Sprintf("🤖 Investigations for alert %q were filtered: %s. Escalating to SRE. 🤖", alertConfig.AlertTitle, reason)); escErr != nil {
-				logging.Errorf("Failed to escalate filtered alert: %v", escErr)
-			}
 			c.recordManualCompletion(alertConfig.AlertTitle, "filtered")
-			return nil
+			return fmt.Errorf("%w: %s", errAlertFiltered, reason)
 		}
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -15,11 +15,8 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/config"
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations"
-	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/ccam"
-	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/chgm"
-	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/expiredcertificates"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/aiassisted"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
-	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/precheck"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/managedcloud"
 	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
@@ -30,8 +27,6 @@ import (
 )
 
 const pagerdutyTitlePrefix = "[CAD Investigated]"
-
-var certPreCheckSkip = []string{"mustgather"}
 
 type PagerDutyConfig struct {
 	PayloadPath string
@@ -273,10 +268,21 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 	return nil, fmt.Errorf("no valid controller configuration provided")
 }
 
-func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId string, inv investigation.Investigation, pdClient *pagerduty.SdkClient, filterCtx *types.FilterContext, params map[string]string) error {
-	metrics.Inc(metrics.Alerts, inv.Name())
+// runChain executes a config-defined chain of investigations.
+func (c *investigationRunner) runChain(
+	ctx context.Context,
+	clusterId string,
+	chainConfig *config.InvestigationConfig,
+	pdClient *pagerduty.SdkClient,
+	filterCtx *types.FilterContext,
+	params map[string]string,
+) error {
+	// Use the first investigation name for the alert metric if we have a chain
+	if len(chainConfig.Chain) > 0 {
+		metrics.Inc(metrics.Alerts, chainConfig.AlertTitle)
+	}
 
-	builder, err := investigation.NewResourceBuilder(c.ocmClient, c.bpClient, clusterId, inv.Name(), c.dependencies.BackplaneURL, params)
+	builder, err := investigation.NewResourceBuilder(c.ocmClient, c.bpClient, clusterId, chainConfig.AlertTitle, c.dependencies.BackplaneURL, params)
 	if pdClient != nil {
 		builder.WithPdClient(pdClient)
 	}
@@ -309,121 +315,92 @@ func (c *investigationRunner) runInvestigation(ctx context.Context, clusterId st
 			}
 		}
 		if err != nil {
-			// Record error completion for manual investigations before handling failure
-			c.recordManualCompletion(inv.Name(), pdClient, "error")
 			handleCADFailure(err, builder, pdClient)
 		}
 	}()
 
-	preCheck := precheck.ClusterStatePrecheck{}
-	result, err := preCheck.Run(builder)
-	if err != nil {
-		return err
-	}
-	if len(result.Actions) > 0 {
-		if err = c.executeActions(builder, &result, "precheck"); err != nil {
-			return fmt.Errorf("failed to execute precheck actions: %w", err)
+	// Chain-level filter: evaluated before running any entry.
+	if filterCtx != nil && chainConfig.When != nil {
+		var requiredKeys []string
+		chainConfig.When.Keys(&requiredKeys)
+		if populateErr := c.populateFilterContextFromOCM(filterCtx, builder, clusterId, requiredKeys); populateErr != nil {
+			logging.Errorf("Could not populate filter context, skipping chain: %v", populateErr)
+			return nil
 		}
-		// We stop if the precheck returns any action this mean we do not want to run anything else.
-		c.recordManualCompletion(inv.Name(), pdClient, "precheck_stopped")
-		return nil
-	}
-	if result.StopInvestigations != nil {
-		logging.Errorf("Stopping investigations due to: %w", result.StopInvestigations)
-		c.recordManualCompletion(inv.Name(), pdClient, "stop_investigations")
-		return nil
-	}
-
-	// Evaluate the investigation filter if one is configured for this investigation.
-	// Only populate OCM fields (org ID, owner) when a filter actually needs them.
-	if filtered := c.evaluateFilter(inv.Name(), filterCtx, builder, clusterId, pdClient); filtered {
-		metrics.Inc(metrics.AlertsFiltered, inv.Name())
-		c.recordManualCompletion(inv.Name(), pdClient, "filtered")
-		return nil
-	}
-
-	ccamInvestigation := ccam.CloudCredentialsCheck{}
-	result, err = ccamInvestigation.Run(builder)
-	if err != nil {
-		return err
-	}
-	// FIXME: Once all migrations are converted this can be removed.
-	updateMetrics(inv.Name(), &result)
-
-	// Execute ccam actions if any
-	if len(result.Actions) > 0 {
-		if err = c.executeActions(builder, &result, "ccam"); err != nil {
-			return fmt.Errorf("failed to execute ccam actions: %w", err)
+		pass, reason, filterErr := chainConfig.ShouldRun(filterCtx)
+		if filterErr != nil {
+			logging.Errorf("Chain-level filter error for %q: %v", chainConfig.AlertTitle, filterErr)
+			return nil
 		}
-		chgmInv := chgm.Investigation{}
-		// In case of a CHGM there is no need to investigate further now, other investigations that don't need AWS might
-		// be able to proceed. To handle this case we will *only* return when CCAM found something and it's CGHM - handling
-		// non-AWS access is up to following investigations.
-		if inv.AlertTitle() == chgmInv.AlertTitle() {
-			c.recordManualCompletion(inv.Name(), pdClient, "ccam_stopped")
+		if !pass {
+			logging.Infof("Chain %q filtered out: %s", chainConfig.AlertTitle, reason)
+			if pdClient != nil {
+				if escErr := pdClient.EscalateIncidentWithNote(fmt.Sprintf("🤖 Investigation chain %q was filtered: %s. Escalating to SRE. 🤖", chainConfig.AlertTitle, reason)); escErr != nil {
+					logging.Errorf("Failed to escalate filtered chain: %v", escErr)
+				}
+			}
 			return nil
 		}
 	}
 
-	certCheck := &expiredcertificates.Investigation{}
-	if pdClient != nil && inv.Name() != certCheck.Name() && !slices.Contains(certPreCheckSkip, inv.Name()) {
-		c.runCertPreCheck(clusterId, pdClient, certCheck)
+	for _, entry := range chainConfig.Chain {
+		inv := investigations.GetInvestigationByName(entry.Name)
+		if inv == nil {
+			return fmt.Errorf("unknown investigation %q in chain for %q", entry.Name, chainConfig.AlertTitle)
+		}
+
+		// Create a fresh aiassisted instance with the runtime config to avoid mutating the registry singleton.
+		if _, ok := inv.(*aiassisted.Investigation); ok && c.dependencies.FilterConfig != nil {
+			inv = &aiassisted.Investigation{AIConfig: c.dependencies.FilterConfig.GetAIAgentConfig()}
+		}
+
+		// Per-entry filter evaluation
+		if entry.When != nil && filterCtx != nil {
+			requiredKeys := entry.Keys()
+			if populateErr := c.populateFilterContextFromOCM(filterCtx, builder, clusterId, requiredKeys); populateErr != nil {
+				logging.Errorf("Could not populate filter context for %q, skipping entry: %v", entry.Name, populateErr)
+				continue
+			}
+			pass, reason, filterErr := entry.ShouldRun(filterCtx)
+			if filterErr != nil {
+				logging.Errorf("Entry-level filter error for %q: %v", entry.Name, filterErr)
+				continue
+			}
+			if !pass {
+				logging.Infof("Entry %q filtered out: %s", entry.Name, reason)
+				continue
+			}
+		}
+
+		logging.Infof("Running investigation %q", inv.Name())
+		result, attempts, runErr := runInvestigationWithRetry(inv, builder)
+		if runErr != nil {
+			return fmt.Errorf("investigation %q failed after %d attempt(s): %w", inv.Name(), attempts, runErr)
+		}
+
+		// Execute actions immediately
+		if len(result.Actions) > 0 {
+			if execErr := c.executeActions(builder, &result, inv.Name()); execErr != nil {
+				return fmt.Errorf("failed to execute %s actions: %w", inv.Name(), execErr)
+			}
+		}
+
+		// StopInvestigations halts the chain
+		if result.StopInvestigations != nil {
+			logging.Infof("Stopping investigation chain due to %q: %v", inv.Name(), result.StopInvestigations)
+			return nil
+		}
 	}
 
-	logging.Infof("Starting investigation for %s", inv.Name())
-	result, attempts, err := runInvestigationWithRetry(inv, builder)
-	if err != nil {
-		return fmt.Errorf("investigation failed after %d attempt(s): %w", attempts, err)
-	}
-	updateMetrics(inv.Name(), &result)
-
-	// FIXME: This will work, once all notes are taken using executor note write and not the resources notes.
-	hasFindings := len(result.Actions) > 0
-
-	// Execute investigation actions if any
-	if err = c.executeActions(builder, &result, inv.Name()); err != nil {
-		return fmt.Errorf("failed to execute %s actions: %w", inv.Name(), err)
-	}
-
-	a := executor.PagerDutyTitleUpdate{Prefix: pagerdutyTitlePrefix}
-	result = investigation.InvestigationResult{
-		Actions: []types.Action{&a},
-	}
-	if err = c.executeActions(builder, &result, inv.Name()); err != nil {
-		return fmt.Errorf("failed to execute PagerDuty title update: %w", err)
-	}
-
-	// Record completion for manual investigations with outcome
-	if hasFindings {
-		c.recordManualCompletion(inv.Name(), pdClient, "success")
-	} else {
-		c.recordManualCompletion(inv.Name(), pdClient, "no_findings")
+	// Post-chain: title update (PD mode only)
+	if pdClient != nil {
+		a := executor.PagerDutyTitleUpdate{Prefix: pagerdutyTitlePrefix}
+		titleResult := investigation.InvestigationResult{
+			Actions: []types.Action{&a},
+		}
+		return c.executeActions(builder, &titleResult, chainConfig.AlertTitle)
 	}
 	return nil
-}
-
-func (c *investigationRunner) runCertPreCheck(clusterId string, pdClient *pagerduty.SdkClient, certCheck *expiredcertificates.Investigation) {
-	certBuilder, err := investigation.NewResourceBuilder(c.ocmClient, c.bpClient, clusterId, certCheck.Name(), c.dependencies.BackplaneURL, nil)
-	if err != nil {
-		logging.Warnf("Expired certificates pre-check: failed to create resource builder: %v", err)
-		return
-	}
-	certBuilder.WithPdClient(pdClient)
-
-	certResult, certErr := certCheck.Run(certBuilder)
-	if certErr != nil {
-		logging.Warnf("Expired certificates pre-check failed: %v", certErr)
-	}
-	if len(certResult.Actions) > 0 {
-		if certErr = c.executeActions(certBuilder, &certResult, certCheck.Name()); certErr != nil {
-			logging.Warnf("Failed to execute expired certificates actions: %v", certErr)
-		}
-	}
-	if certResources, _ := certBuilder.Build(); certResources != nil && certResources.RestConfig != nil {
-		if cleanErr := certResources.RestConfig.Clean(); cleanErr != nil {
-			logging.Warnf("Failed to clean expired certificates rest config: %v", cleanErr)
-		}
-	}
 }
 
 // runInvestigationWithRetry executes an investigation with retry logic for transient errors.
@@ -511,21 +488,6 @@ func handleCADFailure(err error, rb investigation.ResourceBuilder, pdClient *pag
 	}
 }
 
-func updateMetrics(investigationName string, result *investigation.InvestigationResult) {
-	if result.ServiceLogPrepared.Performed {
-		metrics.Inc(metrics.ServicelogPrepared, append([]string{investigationName}, result.ServiceLogPrepared.Labels...)...)
-	}
-	if result.LimitedSupportSet.Performed {
-		metrics.Inc(metrics.LimitedSupportSet, append([]string{investigationName}, result.LimitedSupportSet.Labels...)...)
-	}
-	if result.MustGatherPerformed.Performed {
-		metrics.Inc(metrics.MustGatherPerformed, append([]string{investigationName}, result.MustGatherPerformed.Labels...)...)
-	}
-	if result.EtcdDatabaseAnalysis.Performed {
-		metrics.Inc(metrics.EtcdDatabaseAnalysis, append([]string{investigationName}, result.EtcdDatabaseAnalysis.Labels...)...)
-	}
-}
-
 // recordManualCompletion records manual investigation completion metric
 // Only tracks if this is a manual investigation (pdClient is nil)
 func (c *investigationRunner) recordManualCompletion(invName string, pdClient *pagerduty.SdkClient, status string) {
@@ -586,49 +548,11 @@ func (c *investigationRunner) executeActions(
 	return nil
 }
 
-// evaluateFilter checks whether the investigation should be filtered out.
-// Returns true if the investigation was filtered (should not run), false otherwise.
-func (c *investigationRunner) evaluateFilter(invName string, filterCtx *types.FilterContext, builder investigation.ResourceBuilder, clusterID string, pdClient *pagerduty.SdkClient) bool {
-	if c.dependencies.FilterConfig == nil || filterCtx == nil {
-		return false
-	}
-
-	invFilter := c.dependencies.FilterConfig.GetFilter(invName)
-	if invFilter == nil {
-		return false
-	}
-	requiredKeys := invFilter.Keys()
-
-	if err := c.populateFilterContextFromOCM(filterCtx, builder, clusterID, requiredKeys); err != nil {
-		logging.Errorf("Could not fill context with required fields %s, skipping investigation: %v", invName, err)
-		return true
-	}
-
-	pass, reason, filterErr := invFilter.Evaluate(filterCtx)
-	switch {
-	case filterErr != nil:
-		logging.Errorf("Filter evaluation error for %s, skipping investigation: %v", invName, filterErr)
-	case pass:
-		logging.Infof("Filter passed for %s: %s", invName, reason)
-		return false
-	default:
-		logging.Infof("Investigation %s filtered out for cluster %s: %s", invName, clusterID, reason)
-	}
-
-	if pdClient != nil {
-		if escErr := pdClient.EscalateIncidentWithNote(fmt.Sprintf("🤖 Investigation %s was filtered out by configuration. Escalating to SRE. 🤖", invName)); escErr != nil {
-			logging.Errorf("Failed to escalate filtered investigation: %v", escErr)
-		}
-	}
-
-	return true
-}
-
 // populateFilterContextFromOCM enriches the filter context with OCM cluster fields.
-// This is called after precheck so the cluster object is available from the builder cache.
+// This is called before filter evaluation so the cluster object is available from the builder cache.
 // Failures to populate individual fields are logged as warnings but do not fail the investigation.
 func (c *investigationRunner) populateFilterContextFromOCM(filterCtx *types.FilterContext, builder investigation.ResourceBuilder, clusterID string, requiredKeys []string) error {
-	resources, err := builder.Build()
+	resources, err := builder.WithCluster().Build()
 	if err != nil {
 		logging.Warnf("Could not populate filter context: builder error: %v", err)
 		return err

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -268,19 +268,19 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 	return nil, fmt.Errorf("no valid controller configuration provided")
 }
 
-// runChain executes a config-defined chain of investigations.
+// runChain executes a config-defined list of investigations for an alert.
 // Each investigation gets its own ResourceBuilder so the backplane remediation
 // name matches the investigation's metadata.yaml RBAC definition.
 func (c *investigationRunner) runChain(
 	ctx context.Context,
 	clusterId string,
-	chainConfig *config.InvestigationConfig,
+	alertConfig *config.AlertConfig,
 	pdClient *pagerduty.SdkClient,
 	filterCtx *types.FilterContext,
 	params map[string]string,
 ) (err error) {
-	if len(chainConfig.Chain) > 0 {
-		metrics.Inc(metrics.Alerts, chainConfig.AlertTitle)
+	if len(alertConfig.Investigations) > 0 {
+		metrics.Inc(metrics.Alerts, alertConfig.AlertTitle)
 	}
 
 	var latestBuilder investigation.ResourceBuilder
@@ -290,40 +290,40 @@ func (c *investigationRunner) runChain(
 		}
 	}()
 
-	// Chain-level filter: evaluated once before running any entry.
-	if filterCtx != nil && chainConfig.When != nil {
+	// Alert-level filter: evaluated once before running any investigation.
+	if filterCtx != nil && alertConfig.When != nil {
 		filterBuilder, fErr := investigation.NewResourceBuilder(
-			c.ocmClient, c.bpClient, clusterId, chainConfig.GetName(),
+			c.ocmClient, c.bpClient, clusterId, alertConfig.GetName(),
 			c.dependencies.BackplaneURL, params)
 		if fErr != nil {
 			return fmt.Errorf("failed to create filter builder: %w", fErr)
 		}
 		var requiredKeys []string
-		chainConfig.When.Keys(&requiredKeys)
+		alertConfig.When.Keys(&requiredKeys)
 		if populateErr := c.populateFilterContextFromOCM(filterCtx, filterBuilder, clusterId, requiredKeys); populateErr != nil {
-			logging.Errorf("Could not populate filter context, skipping chain: %v", populateErr)
+			logging.Errorf("Could not populate filter context, skipping alert: %v", populateErr)
 			return nil
 		}
-		pass, reason, filterErr := chainConfig.ShouldRun(filterCtx)
+		pass, reason, filterErr := alertConfig.ShouldRun(filterCtx)
 		if filterErr != nil {
-			logging.Errorf("Chain-level filter error for %q: %v", chainConfig.AlertTitle, filterErr)
+			logging.Errorf("Alert-level filter error for %q: %v", alertConfig.AlertTitle, filterErr)
 			return nil
 		}
 		if !pass {
-			logging.Infof("Chain %q filtered out: %s", chainConfig.AlertTitle, reason)
+			logging.Infof("Alert %q filtered out: %s", alertConfig.AlertTitle, reason)
 			if pdClient != nil {
-				if escErr := pdClient.EscalateIncidentWithNote(fmt.Sprintf("🤖 Investigation chain %q was filtered: %s. Escalating to SRE. 🤖", chainConfig.AlertTitle, reason)); escErr != nil {
-					logging.Errorf("Failed to escalate filtered chain: %v", escErr)
+				if escErr := pdClient.EscalateIncidentWithNote(fmt.Sprintf("🤖 Investigations for alert %q were filtered: %s. Escalating to SRE. 🤖", alertConfig.AlertTitle, reason)); escErr != nil {
+					logging.Errorf("Failed to escalate filtered alert: %v", escErr)
 				}
 			}
 			return nil
 		}
 	}
 
-	for _, entry := range chainConfig.Chain {
+	for _, entry := range alertConfig.Investigations {
 		inv := investigations.GetInvestigationByName(entry.Name)
 		if inv == nil {
-			return fmt.Errorf("unknown investigation %q in chain for %q", entry.Name, chainConfig.AlertTitle)
+			return fmt.Errorf("unknown investigation %q for alert %q", entry.Name, alertConfig.AlertTitle)
 		}
 
 		// Create a fresh aiassisted instance with the runtime config to avoid mutating the registry singleton.
@@ -380,7 +380,7 @@ func (c *investigationRunner) runChain(
 		cleanupBuilder(builder)
 
 		if result.StopInvestigations != nil {
-			logging.Infof("Stopping investigation chain due to %q: %v", inv.Name(), result.StopInvestigations)
+			logging.Infof("Stopping investigations due to %q: %v", inv.Name(), result.StopInvestigations)
 			return nil
 		}
 	}
@@ -391,7 +391,7 @@ func (c *investigationRunner) runChain(
 		titleResult := investigation.InvestigationResult{
 			Actions: []types.Action{&a},
 		}
-		return c.executeActions(latestBuilder, &titleResult, chainConfig.AlertTitle)
+		return c.executeActions(latestBuilder, &titleResult, alertConfig.AlertTitle)
 	}
 	return nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -402,7 +402,7 @@ func (c *investigationRunner) runChain(
 	}
 
 	// Post-chain: title update (PD mode only)
-	if c.notifier.IsActive() && latestBuilder != nil {
+	if c.notifier.HasPagerDuty() && latestBuilder != nil {
 		a := executor.PagerDutyTitleUpdate{Prefix: pagerdutyTitlePrefix}
 		titleResult := investigation.InvestigationResult{
 			Actions: []types.Action{&a},
@@ -499,7 +499,7 @@ func calculateBackoff(attempt int) time.Duration {
 // recordManualCompletion records manual investigation completion metric.
 // Only tracks if this is a manual investigation (notifier is inactive).
 func (c *investigationRunner) recordManualCompletion(invName string, status string) {
-	if !c.notifier.IsActive() {
+	if !c.notifier.HasPagerDuty() {
 		dryRun := strconv.FormatBool(c.dryRun)
 		metrics.Inc(metrics.ManualInvestigationCompleted, invName, status, dryRun)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -62,7 +62,7 @@ func (p *ManualConfig) Validate() error {
 type CommonConfig struct {
 	LogLevel   string
 	Identifier string
-	ConfigPath string // Optional path to investigation filter config file (overrides CAD_INVESTIGATION_CONFIG_PATH)
+	ConfigPath string // Path to investigation config file; falls back to CAD_INVESTIGATION_CONFIG_PATH env var
 }
 
 type Controller interface {
@@ -109,9 +109,12 @@ func (d *Dependencies) Cleanup() {
 }
 
 // initializeDependencies loads environment variables and creates shared clients.
-// configPath is an optional path to the investigation filter config file;
-// if empty, the CAD_INVESTIGATION_CONFIG_PATH env var is used instead.
+// configPath is the path to the investigation config file;
+// if empty, the CAD_INVESTIGATION_CONFIG_PATH env var is used as a fallback.
 func initializeDependencies(configPath string) (*Dependencies, error) {
+	if configPath == "" {
+		configPath = os.Getenv("CAD_INVESTIGATION_CONFIG_PATH")
+	}
 	// Load k8s environment variables
 	backplaneURL := os.Getenv("BACKPLANE_URL")
 	if backplaneURL == "" {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -269,6 +269,8 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 }
 
 // runChain executes a config-defined chain of investigations.
+// Each investigation gets its own ResourceBuilder so the backplane remediation
+// name matches the investigation's metadata.yaml RBAC definition.
 func (c *investigationRunner) runChain(
 	ctx context.Context,
 	clusterId string,
@@ -277,54 +279,28 @@ func (c *investigationRunner) runChain(
 	filterCtx *types.FilterContext,
 	params map[string]string,
 ) (err error) {
-	// Use the first investigation name for the alert metric if we have a chain
 	if len(chainConfig.Chain) > 0 {
 		metrics.Inc(metrics.Alerts, chainConfig.AlertTitle)
 	}
 
-	var builder investigation.ResourceBuilder
-	builder, err = investigation.NewResourceBuilder(c.ocmClient, c.bpClient, clusterId, chainConfig.AlertTitle, c.dependencies.BackplaneURL, params)
-	if pdClient != nil {
-		builder.WithPdClient(pdClient)
-	}
-	if err != nil {
-		return fmt.Errorf("failed to create resource builder: %w", err)
-	}
-
+	var latestBuilder investigation.ResourceBuilder
 	defer func() {
-		// The builder caches resources, so we can access them here even if a later step failed.
-		// We ignore the error here because we just want to get any resources that were created.
-		resources, _ := builder.Build()
-
-		// Cleanup rest config if it exists
-		if resources != nil && resources.RestConfig != nil {
-			// Failing the rest config cleanup call is not critical
-			// There is garbage collection for the RBAC within MCC https://issues.redhat.com/browse/OSD-27692
-			// We only log the error for now but could add it to the investigation notes or handle differently
-			logging.Info("Cleaning cluster api access")
-			deferErr := resources.RestConfig.Clean()
-			if deferErr != nil {
-				logging.Error(deferErr)
-			}
-		}
-
-		if resources != nil && resources.OCClient != nil {
-			logging.Info("Cleaning oc kubeconfig file access")
-			deferErr := resources.OCClient.Clean()
-			if deferErr != nil {
-				logging.Error(deferErr)
-			}
-		}
-		if err != nil {
-			handleCADFailure(err, builder, pdClient)
+		if err != nil && latestBuilder != nil {
+			handleCADFailure(err, latestBuilder, pdClient)
 		}
 	}()
 
-	// Chain-level filter: evaluated before running any entry.
+	// Chain-level filter: evaluated once before running any entry.
 	if filterCtx != nil && chainConfig.When != nil {
+		filterBuilder, fErr := investigation.NewResourceBuilder(
+			c.ocmClient, c.bpClient, clusterId, chainConfig.GetName(),
+			c.dependencies.BackplaneURL, params)
+		if fErr != nil {
+			return fmt.Errorf("failed to create filter builder: %w", fErr)
+		}
 		var requiredKeys []string
 		chainConfig.When.Keys(&requiredKeys)
-		if populateErr := c.populateFilterContextFromOCM(filterCtx, builder, clusterId, requiredKeys); populateErr != nil {
+		if populateErr := c.populateFilterContextFromOCM(filterCtx, filterBuilder, clusterId, requiredKeys); populateErr != nil {
 			logging.Errorf("Could not populate filter context, skipping chain: %v", populateErr)
 			return nil
 		}
@@ -355,20 +331,34 @@ func (c *investigationRunner) runChain(
 			inv = &aiassisted.Investigation{AIConfig: c.dependencies.FilterConfig.GetAIAgentConfig()}
 		}
 
+		builder, bErr := investigation.NewResourceBuilder(
+			c.ocmClient, c.bpClient, clusterId, inv.Name(),
+			c.dependencies.BackplaneURL, params)
+		if bErr != nil {
+			return fmt.Errorf("failed to create builder for %q: %w", inv.Name(), bErr)
+		}
+		if pdClient != nil {
+			builder.WithPdClient(pdClient)
+		}
+		latestBuilder = builder
+
 		// Per-entry filter evaluation
 		if entry.When != nil && filterCtx != nil {
 			requiredKeys := entry.Keys()
 			if populateErr := c.populateFilterContextFromOCM(filterCtx, builder, clusterId, requiredKeys); populateErr != nil {
 				logging.Errorf("Could not populate filter context for %q, skipping entry: %v", entry.Name, populateErr)
+				cleanupBuilder(builder)
 				continue
 			}
 			pass, reason, filterErr := entry.ShouldRun(filterCtx)
 			if filterErr != nil {
 				logging.Errorf("Entry-level filter error for %q: %v", entry.Name, filterErr)
+				cleanupBuilder(builder)
 				continue
 			}
 			if !pass {
 				logging.Infof("Entry %q filtered out: %s", entry.Name, reason)
+				cleanupBuilder(builder)
 				continue
 			}
 		}
@@ -376,17 +366,19 @@ func (c *investigationRunner) runChain(
 		logging.Infof("Running investigation %q", inv.Name())
 		result, attempts, runErr := runInvestigationWithRetry(inv, builder)
 		if runErr != nil {
+			cleanupBuilder(builder)
 			return fmt.Errorf("investigation %q failed after %d attempt(s): %w", inv.Name(), attempts, runErr)
 		}
 
-		// Execute actions immediately
 		if len(result.Actions) > 0 {
 			if execErr := c.executeActions(builder, &result, inv.Name()); execErr != nil {
+				cleanupBuilder(builder)
 				return fmt.Errorf("failed to execute %s actions: %w", inv.Name(), execErr)
 			}
 		}
 
-		// StopInvestigations halts the chain
+		cleanupBuilder(builder)
+
 		if result.StopInvestigations != nil {
 			logging.Infof("Stopping investigation chain due to %q: %v", inv.Name(), result.StopInvestigations)
 			return nil
@@ -394,14 +386,46 @@ func (c *investigationRunner) runChain(
 	}
 
 	// Post-chain: title update (PD mode only)
-	if pdClient != nil {
+	if pdClient != nil && latestBuilder != nil {
 		a := executor.PagerDutyTitleUpdate{Prefix: pagerdutyTitlePrefix}
 		titleResult := investigation.InvestigationResult{
 			Actions: []types.Action{&a},
 		}
-		return c.executeActions(builder, &titleResult, chainConfig.AlertTitle)
+		return c.executeActions(latestBuilder, &titleResult, chainConfig.AlertTitle)
 	}
 	return nil
+}
+
+// cleanupBuilder cleans up all resources on the builder that have Clean() methods.
+func cleanupBuilder(builder investigation.ResourceBuilder) {
+	resources, _ := builder.Build()
+	if resources == nil {
+		return
+	}
+	if resources.RestConfig != nil {
+		logging.Info("Cleaning cluster api access")
+		if err := resources.RestConfig.Clean(); err != nil {
+			logging.Error(err)
+		}
+	}
+	if resources.OCClient != nil {
+		logging.Info("Cleaning oc kubeconfig file access")
+		if err := resources.OCClient.Clean(); err != nil {
+			logging.Error(err)
+		}
+	}
+	if resources.ManagementRestConfig != nil {
+		logging.Info("Cleaning management cluster api access")
+		if err := resources.ManagementRestConfig.Clean(); err != nil {
+			logging.Error(err)
+		}
+	}
+	if resources.ManagementOCClient != nil {
+		logging.Info("Cleaning management oc kubeconfig file access")
+		if err := resources.ManagementOCClient.Clean(); err != nil {
+			logging.Error(err)
+		}
+	}
 }
 
 // runInvestigationWithRetry executes an investigation with retry logic for transient errors.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -276,13 +276,14 @@ func (c *investigationRunner) runChain(
 	pdClient *pagerduty.SdkClient,
 	filterCtx *types.FilterContext,
 	params map[string]string,
-) error {
+) (err error) {
 	// Use the first investigation name for the alert metric if we have a chain
 	if len(chainConfig.Chain) > 0 {
 		metrics.Inc(metrics.Alerts, chainConfig.AlertTitle)
 	}
 
-	builder, err := investigation.NewResourceBuilder(c.ocmClient, c.bpClient, clusterId, chainConfig.AlertTitle, c.dependencies.BackplaneURL, params)
+	var builder investigation.ResourceBuilder
+	builder, err = investigation.NewResourceBuilder(c.ocmClient, c.bpClient, clusterId, chainConfig.AlertTitle, c.dependencies.BackplaneURL, params)
 	if pdClient != nil {
 		builder.WithPdClient(pdClient)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -155,10 +155,14 @@ func initializeDependencies(configPath string) (*Dependencies, error) {
 	experimentalEnabledVar := os.Getenv("CAD_EXPERIMENTAL_ENABLED")
 	experimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
 
-	// Load investigation config
-	cfg, err := config.LoadConfig(configPath, investigations.GetAvailableInvestigationsNames())
-	if err != nil {
-		return nil, fmt.Errorf("failed to load investigation config: %w", err)
+	// Load investigation config (optional for manual runs)
+	var cfg *config.Config
+	var err error
+	if configPath != "" {
+		cfg, err = config.LoadConfig(configPath, investigations.GetAvailableInvestigationsNames())
+		if err != nil {
+			return nil, fmt.Errorf("failed to load investigation config: %w", err)
+		}
 	}
 
 	// Create OCM client
@@ -197,6 +201,10 @@ func Run(opts ControllerOptions) error {
 		return err
 	}
 	defer deps.Cleanup()
+
+	if opts.Pd != nil && deps.Cfg == nil {
+		return fmt.Errorf("investigation config is required for PagerDuty mode; set --config or CAD_INVESTIGATION_CONFIG_PATH")
+	}
 
 	ctrl, err := NewController(opts, deps)
 	if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -322,13 +322,11 @@ func (c *investigationRunner) runChain(
 		var requiredKeys []string
 		alertConfig.When.Keys(&requiredKeys)
 		if populateErr := c.populateFilterContextFromOCM(filterCtx, filterBuilder, clusterId, requiredKeys); populateErr != nil {
-			logging.Errorf("Could not populate filter context, skipping alert: %v", populateErr)
-			return nil
+			return fmt.Errorf("could not populate filter context for alert %q: %w", alertConfig.AlertTitle, populateErr)
 		}
 		pass, reason, filterErr := alertConfig.ShouldRun(filterCtx)
 		if filterErr != nil {
-			logging.Errorf("Alert-level filter error for %q: %v", alertConfig.AlertTitle, filterErr)
-			return nil
+			return fmt.Errorf("alert-level filter error for %q: %w", alertConfig.AlertTitle, filterErr)
 		}
 		if !pass {
 			logging.Infof("Alert %q filtered out: %s", alertConfig.AlertTitle, reason)
@@ -362,15 +360,13 @@ func (c *investigationRunner) runChain(
 		if entry.When != nil && filterCtx != nil {
 			requiredKeys := entry.Keys()
 			if populateErr := c.populateFilterContextFromOCM(filterCtx, builder, clusterId, requiredKeys); populateErr != nil {
-				logging.Errorf("Could not populate filter context for %q, skipping entry: %v", entry.Name, populateErr)
 				cleanupBuilder(builder)
-				continue
+				return fmt.Errorf("could not populate filter context for %q: %w", entry.Name, populateErr)
 			}
 			pass, reason, filterErr := entry.ShouldRun(filterCtx)
 			if filterErr != nil {
-				logging.Errorf("Entry-level filter error for %q: %v", entry.Name, filterErr)
 				cleanupBuilder(builder)
-				continue
+				return fmt.Errorf("entry-level filter error for %q: %w", entry.Name, filterErr)
 			}
 			if !pass {
 				logging.Infof("Entry %q filtered out: %s", entry.Name, reason)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -71,6 +71,7 @@ type investigationRunner struct {
 	logger       *zap.SugaredLogger
 	dependencies *Dependencies
 	dryRun       bool
+	notifier     incidentNotifier
 }
 
 type ControllerOptions struct {
@@ -239,6 +240,7 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 				executor:     executor.NewWebhookExecutor(deps.OCMClient, pdClient, deps.BackplaneClient, logger),
 				logger:       logger,
 				dependencies: deps,
+				notifier:     newPDIncidentNotifier(pdClient),
 			},
 		}, nil
 	}
@@ -261,6 +263,7 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 				logger:       logger,
 				dependencies: deps,
 				dryRun:       opts.Manual.DryRun,
+				notifier:     newNoopIncidentNotifier(),
 			},
 		}, nil
 	}
@@ -275,7 +278,6 @@ func (c *investigationRunner) runChain(
 	ctx context.Context,
 	clusterId string,
 	alertConfig *config.AlertConfig,
-	pdClient *pagerduty.SdkClient,
 	filterCtx *types.FilterContext,
 	params map[string]string,
 ) (err error) {
@@ -286,7 +288,7 @@ func (c *investigationRunner) runChain(
 	var latestBuilder investigation.ResourceBuilder
 	defer func() {
 		if err != nil && latestBuilder != nil {
-			handleCADFailure(err, latestBuilder, pdClient)
+			handleCADFailure(err, latestBuilder, c.notifier)
 		}
 	}()
 
@@ -311,10 +313,8 @@ func (c *investigationRunner) runChain(
 		}
 		if !pass {
 			logging.Infof("Alert %q filtered out: %s", alertConfig.AlertTitle, reason)
-			if pdClient != nil {
-				if escErr := pdClient.EscalateIncidentWithNote(fmt.Sprintf("🤖 Investigations for alert %q were filtered: %s. Escalating to SRE. 🤖", alertConfig.AlertTitle, reason)); escErr != nil {
-					logging.Errorf("Failed to escalate filtered alert: %v", escErr)
-				}
+			if escErr := c.notifier.EscalateWithNote(fmt.Sprintf("🤖 Investigations for alert %q were filtered: %s. Escalating to SRE. 🤖", alertConfig.AlertTitle, reason)); escErr != nil {
+				logging.Errorf("Failed to escalate filtered alert: %v", escErr)
 			}
 			return nil
 		}
@@ -337,9 +337,7 @@ func (c *investigationRunner) runChain(
 		if bErr != nil {
 			return fmt.Errorf("failed to create builder for %q: %w", inv.Name(), bErr)
 		}
-		if pdClient != nil {
-			builder.WithPdClient(pdClient)
-		}
+		c.notifier.AttachToBuilder(builder)
 		latestBuilder = builder
 
 		// Per-entry filter evaluation
@@ -386,7 +384,7 @@ func (c *investigationRunner) runChain(
 	}
 
 	// Post-chain: title update (PD mode only)
-	if pdClient != nil && latestBuilder != nil {
+	if c.notifier.IsActive() && latestBuilder != nil {
 		a := executor.PagerDutyTitleUpdate{Prefix: pagerdutyTitlePrefix}
 		titleResult := investigation.InvestigationResult{
 			Actions: []types.Action{&a},
@@ -480,7 +478,7 @@ func calculateBackoff(attempt int) time.Duration {
 	return backoff
 }
 
-func handleCADFailure(err error, rb investigation.ResourceBuilder, pdClient *pagerduty.SdkClient) {
+func handleCADFailure(err error, rb investigation.ResourceBuilder, notifier incidentNotifier) {
 	logging.Errorf("CAD investigation failed: %v", err)
 	resources, err := rb.Build()
 	if err != nil {
@@ -489,7 +487,7 @@ func handleCADFailure(err error, rb investigation.ResourceBuilder, pdClient *pag
 
 	var docErr *ocm.DocumentationMismatchError
 	if errors.As(err, &docErr) {
-		escalateDocumentationMismatch(docErr, resources, pdClient)
+		escalateDocumentationMismatch(docErr, resources, notifier)
 		return
 	}
 
@@ -501,25 +499,10 @@ func handleCADFailure(err error, rb investigation.ResourceBuilder, pdClient *pag
 		notes = "🚨 CAD investigation failed prior to resource initialization, CAD team has been notified. Please investigate manually. 🚨"
 	}
 
-	if pdClient != nil {
-		pdErr := pdClient.EscalateIncidentWithNote(notes)
-		if pdErr != nil {
-			logging.Errorf("Failed to escalate notes to PagerDuty: %v", pdErr)
-		} else {
-			logging.Info("CAD failure & incident notes added to PagerDuty")
-		}
+	if escErr := notifier.EscalateWithNote(notes); escErr != nil {
+		logging.Errorf("Failed to escalate notes to PagerDuty: %v", escErr)
 	} else {
-		logging.Errorf("Failed to obtain PagerDuty client, unable to escalate CAD failure to PagerDuty notes.")
-	}
-}
-
-// recordManualCompletion records manual investigation completion metric
-// Only tracks if this is a manual investigation (pdClient is nil)
-func (c *investigationRunner) recordManualCompletion(invName string, pdClient *pagerduty.SdkClient, status string) {
-	if pdClient == nil {
-		// This is a manual investigation
-		dryRun := strconv.FormatBool(c.dryRun)
-		metrics.Inc(metrics.ManualInvestigationCompleted, invName, status, dryRun)
+		logging.Info("CAD failure & incident notes added to PagerDuty")
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -330,6 +330,7 @@ func (c *investigationRunner) runChain(
 		}
 		if !pass {
 			logging.Infof("Alert %q filtered out: %s", alertConfig.AlertTitle, reason)
+			metrics.Inc(metrics.AlertsFiltered, alertConfig.GetName())
 			c.recordManualCompletion(alertConfig.AlertTitle, "filtered")
 			return fmt.Errorf("%w: %s", errAlertFiltered, reason)
 		}
@@ -370,6 +371,7 @@ func (c *investigationRunner) runChain(
 			}
 			if !pass {
 				logging.Infof("Entry %q filtered out: %s", entry.Name, reason)
+				metrics.Inc(metrics.AlertsFiltered, entry.Name)
 				cleanupBuilder(builder)
 				continue
 			}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -504,9 +504,9 @@ func (c *investigationRunner) recordManualCompletion(invName string, status stri
 
 func handleCADFailure(err error, rb investigation.ResourceBuilder, notifier incidentNotifier) {
 	logging.Errorf("CAD investigation failed: %v", err)
-	resources, err := rb.Build()
-	if err != nil {
-		logging.Errorf("resource builder failed with error: %v", err)
+	resources, buildErr := rb.Build()
+	if buildErr != nil {
+		logging.Errorf("resource builder failed with error: %v", buildErr)
 	}
 
 	var docErr *ocm.DocumentationMismatchError

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -3,13 +3,12 @@ package controller
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
+	"github.com/openshift/configuration-anomaly-detection/pkg/config"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/aiassisted"
-	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 )
@@ -39,13 +38,12 @@ type ManualController struct {
 	investigationRunner
 }
 
-// getInvestigation looks up an investigation by short name first, then falls back to the registry lookup.
-func getInvestigation(name string, experimental bool) investigation.Investigation {
-	// Check if the name is a short name and map it to the full name
+// resolveInvestigationName maps a short name to the full investigation name.
+func resolveInvestigationName(name string) string {
 	if fullName, ok := shortNameToInvestigation[name]; ok {
-		name = fullName
+		return fullName
 	}
-	return investigations.GetInvestigationByName(name, experimental)
+	return name
 }
 
 func (c *ManualController) Investigate(ctx context.Context) error {
@@ -53,10 +51,9 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 		c.logger.Info("🔍 DRY RUN MODE: Investigation will run without performing any external operations")
 	}
 
-	experimentalEnabledVar := os.Getenv("CAD_EXPERIMENTAL_ENABLED")
-	experimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
-	alertInvestigation := getInvestigation(c.manual.InvestigationName, experimentalEnabled)
-	if alertInvestigation == nil {
+	name := resolveInvestigationName(c.manual.InvestigationName)
+	inv := investigations.GetInvestigationByName(name)
+	if inv == nil {
 		availableInvestigations := make([]string, 0, len(shortNameToInvestigation))
 		for shortName, longName := range shortNameToInvestigation {
 			format := fmt.Sprintf("- %s (%s)", shortName, longName)
@@ -68,13 +65,27 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 
 	// Track manual investigation start
 	dryRun := strconv.FormatBool(c.dryRun)
-	metrics.Inc(metrics.ManualInvestigationStarted, alertInvestigation.Name(), dryRun)
+	metrics.Inc(metrics.ManualInvestigationStarted, inv.Name(), dryRun)
 
 	// For AI investigations, create a new instance with the runtime config from the global config.
-	if _, ok := alertInvestigation.(*aiassisted.Investigation); ok {
-		alertInvestigation = &aiassisted.Investigation{
+	if _, ok := inv.(*aiassisted.Investigation); ok {
+		inv = &aiassisted.Investigation{
 			AIConfig: c.dependencies.FilterConfig.GetAIAgentConfig(),
 		}
+	}
+
+	chain := []config.ChainEntry{}
+	if inv.Name() != "precheck" {
+		chain = append(chain, config.ChainEntry{Name: "precheck"})
+	}
+	if inv.Name() != "ccam" && inv.Name() != "precheck" {
+		chain = append(chain, config.ChainEntry{Name: "ccam"})
+	}
+	chain = append(chain, config.ChainEntry{Name: inv.Name()})
+
+	chainConfig := &config.InvestigationConfig{
+		AlertTitle: inv.Name(),
+		Chain:      chain,
 	}
 
 	// When --with-filtering is set, create a filter context so filters are evaluated.
@@ -82,10 +93,10 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 	var filterCtx *types.FilterContext
 	if c.manual.WithFiltering {
 		filterCtx = &types.FilterContext{
-			AlertName: alertInvestigation.Name(),
+			AlertName: inv.Name(),
 		}
 	}
 
 	// No PD client for manual runs.
-	return c.runInvestigation(ctx, c.manual.ClusterId, alertInvestigation, nil, filterCtx, c.manual.Params)
+	return c.runChain(ctx, c.manual.ClusterId, chainConfig, nil, filterCtx, c.manual.Params)
 }

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -70,7 +70,7 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 	// For AI investigations, create a new instance with the runtime config from the global config.
 	if _, ok := inv.(*aiassisted.Investigation); ok {
 		inv = &aiassisted.Investigation{
-			AIConfig: c.dependencies.FilterConfig.GetAIAgentConfig(),
+			AIConfig: c.dependencies.Cfg.GetAIAgentConfig(),
 		}
 	}
 

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -85,6 +85,7 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 
 	chainConfig := &config.InvestigationConfig{
 		AlertTitle: inv.Name(),
+		Name:       inv.Name(),
 		Chain:      chain,
 	}
 

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/config"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations"
-	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/aiassisted"
 	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 )
@@ -66,13 +65,6 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 	// Track manual investigation start
 	dryRun := strconv.FormatBool(c.dryRun)
 	metrics.Inc(metrics.ManualInvestigationStarted, inv.Name(), dryRun)
-
-	// For AI investigations, create a new instance with the runtime config from the global config.
-	if _, ok := inv.(*aiassisted.Investigation); ok {
-		inv = &aiassisted.Investigation{
-			AIConfig: c.dependencies.Cfg.GetAIAgentConfig(),
-		}
-	}
 
 	invEntries := []config.InvestigationEntry{}
 	if inv.Name() != "precheck" {

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -18,9 +18,9 @@ import (
 var shortNameToInvestigation = map[string]string{
 	"ai":                       "aiassisted",
 	"can-not-retrieve-updates": "cannotretrieveupdatessre",
-	"chgm":                     "Cluster Has Gone Missing (CHGM)",
+	"chgm":                     "chgm",
 	"cmbb":                     "clustermonitoringerrorbudgetburn",
-	"cpd":                      "ClusterProvisioningDelay",
+	"cpd":                      "cpd",
 	"etcd-quota-low":           "etcddatabasequotalowspace",
 	"insightsoperatordown":     "insightsoperatordown",
 	"machine-health-check":     "machinehealthcheckunterminatedshortcircuitsre",

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -98,6 +98,5 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 		}
 	}
 
-	// No PD client for manual runs.
-	return c.runChain(ctx, c.manual.ClusterId, alertConfig, nil, filterCtx, c.manual.Params)
+	return c.runChain(ctx, c.manual.ClusterId, alertConfig, filterCtx, c.manual.Params)
 }

--- a/pkg/controller/manual.go
+++ b/pkg/controller/manual.go
@@ -74,19 +74,19 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 		}
 	}
 
-	chain := []config.ChainEntry{}
+	invEntries := []config.InvestigationEntry{}
 	if inv.Name() != "precheck" {
-		chain = append(chain, config.ChainEntry{Name: "precheck"})
+		invEntries = append(invEntries, config.InvestigationEntry{Name: "precheck"})
 	}
 	if inv.Name() != "ccam" && inv.Name() != "precheck" {
-		chain = append(chain, config.ChainEntry{Name: "ccam"})
+		invEntries = append(invEntries, config.InvestigationEntry{Name: "ccam"})
 	}
-	chain = append(chain, config.ChainEntry{Name: inv.Name()})
+	invEntries = append(invEntries, config.InvestigationEntry{Name: inv.Name()})
 
-	chainConfig := &config.InvestigationConfig{
-		AlertTitle: inv.Name(),
-		Name:       inv.Name(),
-		Chain:      chain,
+	alertConfig := &config.AlertConfig{
+		AlertTitle:     inv.Name(),
+		Name:           inv.Name(),
+		Investigations: invEntries,
 	}
 
 	// When --with-filtering is set, create a filter context so filters are evaluated.
@@ -99,5 +99,5 @@ func (c *ManualController) Investigate(ctx context.Context) error {
 	}
 
 	// No PD client for manual runs.
-	return c.runChain(ctx, c.manual.ClusterId, chainConfig, nil, filterCtx, c.manual.Params)
+	return c.runChain(ctx, c.manual.ClusterId, alertConfig, nil, filterCtx, c.manual.Params)
 }

--- a/pkg/controller/notifier.go
+++ b/pkg/controller/notifier.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
+)
+
+// incidentNotifier abstracts PagerDuty incident operations so that
+// manual (non-PD) runs use a no-op implementation instead of
+// nil-checking a *pagerduty.SdkClient.
+type incidentNotifier interface {
+	EscalateWithNote(note string) error
+	AttachToBuilder(builder investigation.ResourceBuilder)
+	IsActive() bool
+}
+
+// pdIncidentNotifier wraps a real PagerDuty client.
+type pdIncidentNotifier struct {
+	client *pagerduty.SdkClient
+}
+
+func newPDIncidentNotifier(client *pagerduty.SdkClient) incidentNotifier {
+	return &pdIncidentNotifier{client: client}
+}
+
+func (n *pdIncidentNotifier) EscalateWithNote(note string) error {
+	return n.client.EscalateIncidentWithNote(note)
+}
+
+func (n *pdIncidentNotifier) AttachToBuilder(builder investigation.ResourceBuilder) {
+	builder.WithPdClient(n.client)
+}
+
+func (n *pdIncidentNotifier) IsActive() bool {
+	return true
+}
+
+// noopIncidentNotifier is used by ManualController where no PagerDuty client exists.
+type noopIncidentNotifier struct{}
+
+func newNoopIncidentNotifier() incidentNotifier {
+	return &noopIncidentNotifier{}
+}
+
+func (n *noopIncidentNotifier) EscalateWithNote(note string) error {
+	logging.Infof("Skipping PD escalation (manual mode)")
+	return nil
+}
+
+func (n *noopIncidentNotifier) AttachToBuilder(_ investigation.ResourceBuilder) {}
+
+func (n *noopIncidentNotifier) IsActive() bool {
+	return false
+}

--- a/pkg/controller/notifier.go
+++ b/pkg/controller/notifier.go
@@ -12,7 +12,7 @@ import (
 type incidentNotifier interface {
 	EscalateWithNote(note string) error
 	AttachToBuilder(builder investigation.ResourceBuilder)
-	IsActive() bool
+	HasPagerDuty() bool
 }
 
 // pdIncidentNotifier wraps a real PagerDuty client.
@@ -32,7 +32,7 @@ func (n *pdIncidentNotifier) AttachToBuilder(builder investigation.ResourceBuild
 	builder.WithPdClient(n.client)
 }
 
-func (n *pdIncidentNotifier) IsActive() bool {
+func (n *pdIncidentNotifier) HasPagerDuty() bool {
 	return true
 }
 
@@ -50,6 +50,6 @@ func (n *noopIncidentNotifier) EscalateWithNote(note string) error {
 
 func (n *noopIncidentNotifier) AttachToBuilder(_ investigation.ResourceBuilder) {}
 
-func (n *noopIncidentNotifier) IsActive() bool {
+func (n *noopIncidentNotifier) HasPagerDuty() bool {
 	return false
 }

--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -6,8 +6,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/openshift/configuration-anomaly-detection/pkg/investigations"
-	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/aiassisted"
+	"github.com/openshift/configuration-anomaly-detection/pkg/config"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
@@ -23,10 +22,6 @@ type PagerDutyController struct {
 }
 
 func (c *PagerDutyController) Investigate(ctx context.Context) error {
-	experimentalEnabledVar := os.Getenv("CAD_EXPERIMENTAL_ENABLED")
-	experimentalEnabled, _ := strconv.ParseBool(experimentalEnabledVar)
-	alertInvestigation := investigations.GetInvestigation(c.pdClient.GetTitle(), experimentalEnabled)
-
 	clusterID, err := c.pdClient.RetrieveClusterID()
 	if err != nil {
 		return err
@@ -36,31 +31,43 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 	c.logger = logging.InitLogger(c.config.LogLevel, c.config.Identifier, clusterID)
 	c.logger.Infof("Investigating incident '%s' for service '%s (%s)'", c.pdClient.GetIncidentRef(), c.pdClient.GetServiceID(), c.pdClient.GetServiceName())
 
-	// If no formal investigation matches, fall back to AI investigation when enabled.
-	// AI is considered enabled when experimental mode is on and the filter config
-	// has an entry for "aiassisted". The actual cluster/org-level filtering happens
-	// later in runInvestigation via the filter evaluation.
-	if alertInvestigation == nil {
-		alertInvestigation = handleUnsupportedAlertWithAI(c.dependencies)
-		if alertInvestigation == nil {
-			err := c.pdClient.EscalateIncident()
-			if err != nil {
-				return fmt.Errorf("could not escalate unsupported alert: %w", err)
+	experimentalEnabled, _ := strconv.ParseBool(os.Getenv("CAD_EXPERIMENTAL_ENABLED"))
+
+	cfg := c.dependencies.FilterConfig
+	alertTitle := c.pdClient.GetTitle()
+
+	var chainConfig *config.InvestigationConfig
+
+	// Look up chain from config
+	if cfg != nil {
+		chainConfig = cfg.GetChain(alertTitle, experimentalEnabled)
+	}
+
+	// AI fallback: if no chain matches and ai_agent is configured, build an ad-hoc chain
+	if chainConfig == nil {
+		if experimentalEnabled && cfg != nil && cfg.AIAgent != nil {
+			chainConfig = &config.InvestigationConfig{
+				AlertTitle: "aiassisted-fallback",
+				Chain: []config.ChainEntry{
+					{Name: "precheck"},
+					{Name: "aiassisted"},
+				},
+			}
+		} else {
+			if escErr := c.pdClient.EscalateIncident(); escErr != nil {
+				return fmt.Errorf("could not escalate unsupported alert: %w", escErr)
 			}
 			return nil
 		}
 	}
 
-	// Build the filter context with PagerDuty fields available at this point.
-	// OCM fields will be populated inside runInvestigation after precheck.
 	filterCtx := &types.FilterContext{
-		AlertName:   alertInvestigation.AlertTitle(),
-		AlertTitle:  c.pdClient.GetTitle(),
+		AlertName:   chainConfig.AlertTitle,
+		AlertTitle:  alertTitle,
 		ServiceName: c.pdClient.GetServiceName(),
 	}
 
-	// Continue with investigation...
-	return c.runInvestigation(ctx, clusterID, alertInvestigation, c.pdClient, filterCtx, nil)
+	return c.runChain(ctx, clusterID, chainConfig, c.pdClient, filterCtx, nil)
 }
 
 func escalateDocumentationMismatch(docErr *ocm.DocumentationMismatchError, resources *investigation.Resources, pdClient *pagerduty.SdkClient) {
@@ -84,22 +91,3 @@ func escalateDocumentationMismatch(docErr *ocm.DocumentationMismatchError, resou
 	logging.Info("Escalated documentation mismatch to PagerDuty")
 }
 
-// handleUnsupportedAlertWithAI checks if AI investigation is enabled via the filter config.
-// AI is considered enabled when the filter config has an entry for "aiassisted".
-// Returns an AI investigation populated with the runtime config, or nil if disabled.
-func handleUnsupportedAlertWithAI(deps *Dependencies) investigation.Investigation {
-	if deps.FilterConfig == nil {
-		return nil
-	}
-
-	// AI is enabled when the filter config has an entry for "aiassisted".
-	// The actual cluster/org-level gating is handled by filter evaluation
-	// in runInvestigation after OCM context is populated.
-	if deps.FilterConfig.GetFilter("aiassisted") == nil {
-		return nil
-	}
-
-	return &aiassisted.Investigation{
-		AIConfig: deps.FilterConfig.GetAIAgentConfig(),
-	}
-}

--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -43,31 +44,42 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 		alertConfig = cfg.GetAlert(alertTitle, experimentalEnabled)
 	}
 
-	// AI fallback: if no alert matches and ai_agent is configured, build an ad-hoc config
-	if alertConfig == nil {
-		if cfg != nil && cfg.AIAgent != nil {
-			alertConfig = &config.AlertConfig{
-				AlertTitle: "aiassisted-fallback",
-				Investigations: []config.InvestigationEntry{
-					{Name: "precheck"},
-					{Name: "aiassisted"},
-				},
-			}
-		} else {
-			if escErr := c.pdClient.EscalateIncident(); escErr != nil {
-				return fmt.Errorf("could not escalate unsupported alert: %w", escErr)
-			}
-			return nil
+	// If we matched a config, try running its chain. If the alert-level When
+	// filter rejects, fall through to AI/escalation instead of stopping.
+	if alertConfig != nil {
+		filterCtx := &types.FilterContext{
+			AlertName:   alertConfig.AlertTitle,
+			AlertTitle:  alertTitle,
+			ServiceName: c.pdClient.GetServiceName(),
 		}
+		err := c.runChain(ctx, clusterID, alertConfig, filterCtx, nil)
+		if !errors.Is(err, errAlertFiltered) {
+			return err
+		}
+		logging.Infof("Alert %q filtered out, falling through to AI/escalation", alertConfig.AlertTitle)
 	}
 
-	filterCtx := &types.FilterContext{
-		AlertName:   alertConfig.AlertTitle,
-		AlertTitle:  alertTitle,
-		ServiceName: c.pdClient.GetServiceName(),
+	// AI fallback: no title match, or title matched but when-clause filtered
+	if cfg != nil && cfg.AIAgent != nil {
+		alertConfig = &config.AlertConfig{
+			AlertTitle: "aiassisted-fallback",
+			Investigations: []config.InvestigationEntry{
+				{Name: "precheck"},
+				{Name: "aiassisted"},
+			},
+		}
+		filterCtx := &types.FilterContext{
+			AlertName:   alertConfig.AlertTitle,
+			AlertTitle:  alertTitle,
+			ServiceName: c.pdClient.GetServiceName(),
+		}
+		return c.runChain(ctx, clusterID, alertConfig, filterCtx, nil)
 	}
 
-	return c.runChain(ctx, clusterID, alertConfig, filterCtx, nil)
+	if escErr := c.pdClient.EscalateIncident(); escErr != nil {
+		return fmt.Errorf("could not escalate unsupported alert: %w", escErr)
+	}
+	return nil
 }
 
 func escalateDocumentationMismatch(docErr *ocm.DocumentationMismatchError, resources *investigation.Resources, notifier incidentNotifier) {

--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -65,7 +65,9 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 			AlertTitle: "aiassisted-fallback",
 			Investigations: []config.InvestigationEntry{
 				{Name: "precheck"},
-				{Name: "aiassisted"},
+				{Name: "aiassisted", When: &config.FilterNode{
+					Field: config.FieldHCP, Operator: config.OperatorIn, Values: []string{"false"},
+				}},
 			},
 		}
 		filterCtx := &types.FilterContext{

--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -33,7 +33,7 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 
 	experimentalEnabled, _ := strconv.ParseBool(os.Getenv("CAD_EXPERIMENTAL_ENABLED"))
 
-	cfg := c.dependencies.FilterConfig
+	cfg := c.dependencies.Cfg
 	alertTitle := c.pdClient.GetTitle()
 
 	var alertConfig *config.AlertConfig

--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -45,7 +45,7 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 
 	// AI fallback: if no alert matches and ai_agent is configured, build an ad-hoc config
 	if alertConfig == nil {
-		if experimentalEnabled && cfg != nil && cfg.AIAgent != nil {
+		if cfg != nil && cfg.AIAgent != nil {
 			alertConfig = &config.AlertConfig{
 				AlertTitle: "aiassisted-fallback",
 				Investigations: []config.InvestigationEntry{

--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -67,10 +67,10 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 		ServiceName: c.pdClient.GetServiceName(),
 	}
 
-	return c.runChain(ctx, clusterID, alertConfig, c.pdClient, filterCtx, nil)
+	return c.runChain(ctx, clusterID, alertConfig, filterCtx, nil)
 }
 
-func escalateDocumentationMismatch(docErr *ocm.DocumentationMismatchError, resources *investigation.Resources, pdClient *pagerduty.SdkClient) {
+func escalateDocumentationMismatch(docErr *ocm.DocumentationMismatchError, resources *investigation.Resources, notifier incidentNotifier) {
 	message := docErr.EscalationMessage()
 
 	if resources != nil && resources.Notes != nil {
@@ -78,12 +78,7 @@ func escalateDocumentationMismatch(docErr *ocm.DocumentationMismatchError, resou
 		message = resources.Notes.String()
 	}
 
-	if pdClient == nil {
-		logging.Errorf("Failed to obtain PagerDuty client, unable to escalate documentation mismatch to PagerDuty notes.")
-		return
-	}
-
-	if err := pdClient.EscalateIncidentWithNote(message); err != nil {
+	if err := notifier.EscalateWithNote(message); err != nil {
 		logging.Errorf("Failed to escalate documentation mismatch notes to PagerDuty: %v", err)
 		return
 	}

--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -36,19 +36,19 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 	cfg := c.dependencies.FilterConfig
 	alertTitle := c.pdClient.GetTitle()
 
-	var chainConfig *config.InvestigationConfig
+	var alertConfig *config.AlertConfig
 
-	// Look up chain from config
+	// Look up alert config
 	if cfg != nil {
-		chainConfig = cfg.GetChain(alertTitle, experimentalEnabled)
+		alertConfig = cfg.GetAlert(alertTitle, experimentalEnabled)
 	}
 
-	// AI fallback: if no chain matches and ai_agent is configured, build an ad-hoc chain
-	if chainConfig == nil {
+	// AI fallback: if no alert matches and ai_agent is configured, build an ad-hoc config
+	if alertConfig == nil {
 		if experimentalEnabled && cfg != nil && cfg.AIAgent != nil {
-			chainConfig = &config.InvestigationConfig{
+			alertConfig = &config.AlertConfig{
 				AlertTitle: "aiassisted-fallback",
-				Chain: []config.ChainEntry{
+				Investigations: []config.InvestigationEntry{
 					{Name: "precheck"},
 					{Name: "aiassisted"},
 				},
@@ -62,12 +62,12 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 	}
 
 	filterCtx := &types.FilterContext{
-		AlertName:   chainConfig.AlertTitle,
+		AlertName:   alertConfig.AlertTitle,
 		AlertTitle:  alertTitle,
 		ServiceName: c.pdClient.GetServiceName(),
 	}
 
-	return c.runChain(ctx, clusterID, chainConfig, c.pdClient, filterCtx, nil)
+	return c.runChain(ctx, clusterID, alertConfig, c.pdClient, filterCtx, nil)
 }
 
 func escalateDocumentationMismatch(docErr *ocm.DocumentationMismatchError, resources *investigation.Resources, pdClient *pagerduty.SdkClient) {
@@ -90,4 +90,3 @@ func escalateDocumentationMismatch(docErr *ocm.DocumentationMismatchError, resou
 
 	logging.Info("Escalated documentation mismatch to PagerDuty")
 }
-

--- a/pkg/investigations/aiassisted/README.md
+++ b/pkg/investigations/aiassisted/README.md
@@ -7,7 +7,7 @@ AI-powered investigation using AWS Bedrock AgentCore for alerts without formal i
 The aiassisted investigation serves as a **fallback handler** for alerts that don't have explicit investigation implementations in CAD. When CAD receives an alert without a matching investigation handler, it can invoke an AWS Bedrock AgentCore agent to investigate the issue and provide remediation guidance.
 
 **Trigger**: Any alert without an explicit CAD investigation handler (fallback)
-**Clusters**: Allowlist-controlled via investigation filter config (configured clusters and organizations only)
+**Clusters**: Allowlist-controlled via investigation config (configured clusters and organizations only)
 **Status**: Promoted (`IsExperimental() = false`)
 
 ## How It Works
@@ -59,7 +59,7 @@ The AI investigation requires two types of configuration:
 
 #### 1. Global Config (`CAD_INVESTIGATION_CONFIG_PATH`)
 
-The AI runtime config and filter rules are in the YAML config file. See `docs/investigation-filter-config.example.yaml` for the full example.
+The AI runtime config and filter rules are in the YAML config file. See `docs/investigation-config.example.yaml` for the full example.
 
 ```yaml
 ai_agent:

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -250,16 +250,3 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 func (c *Investigation) Name() string {
 	return "aiassisted"
 }
-
-func (c *Investigation) AlertTitle() string {
-	// Return empty string - this investigation is used as a fallback, not for matching specific alert titles
-	return ""
-}
-
-func (c *Investigation) Description() string {
-	return "AI-powered investigation using AgentCore for unknown alerts"
-}
-
-func (c *Investigation) IsExperimental() bool {
-	return false
-}

--- a/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
+++ b/pkg/investigations/cannotretrieveupdatessre/cannotretrieveupdatessre.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	"github.com/openshift/configuration-anomaly-detection/pkg/networkverifier"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
 
@@ -31,7 +32,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	} else {
 		switch verifierResult {
 		case networkverifier.Failure:
-			result.ServiceLogPrepared = investigation.InvestigationStep{Performed: true, Labels: nil}
+			metrics.Inc(metrics.ServicelogPrepared, c.Name())
 			notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post --cluster-id %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=%s", r.Cluster.ID(), failureReason)
 		case networkverifier.Success:
 			notes.AppendSuccess("Network verifier passed")
@@ -96,16 +97,4 @@ func checkCondition(condition configv1.ClusterOperatorStatusCondition) (string, 
 
 func (i *Investigation) Name() string {
 	return "cannotretrieveupdatessre"
-}
-
-func (i *Investigation) AlertTitle() string {
-	return "CannotRetrieveUpdatesSRE"
-}
-
-func (i *Investigation) Description() string {
-	return fmt.Sprintf("Investigates '%s' alerts by running network verifier and checking ClusterVersion", i.Name())
-}
-
-func (i *Investigation) IsExperimental() bool {
-	return true
 }

--- a/pkg/investigations/ccam/ccam.go
+++ b/pkg/investigations/ccam/ccam.go
@@ -74,6 +74,10 @@ func (c *CloudCredentialsCheck) Run(r investigation.ResourceBuilder) (investigat
 	return result, err
 }
 
+func (c *CloudCredentialsCheck) Name() string {
+	return "ccam"
+}
+
 // userCausedErrors contains the list of backplane returned error strings that we map to
 // customer modifications/role deletions.
 var userCausedErrors = []string{

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -156,18 +156,6 @@ func (i *Investigation) Name() string {
 	return "Cluster Has Gone Missing (CHGM)"
 }
 
-func (i *Investigation) AlertTitle() string {
-	return "has gone missing"
-}
-
-func (i *Investigation) Description() string {
-	return "Detects reason for clusters that have gone missing"
-}
-
-func (i *Investigation) IsExperimental() bool {
-	return false
-}
-
 // hasRecentlyResumed checks if the cluster was woken up from
 // hibernation within the last 2h. In that case, the internal
 // certificates of the kubelets could have expired and CSRs need to be approved

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -36,7 +36,7 @@ type Investigation struct{}
 // Run runs the investigation for a triggered chgm pagerduty event
 func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
-	r, err := rb.WithClusterDeployment().Build()
+	r, err := rb.WithClusterDeployment().WithAwsClient().Build()
 	if err != nil {
 		return result, err
 	}

--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -153,7 +153,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 }
 
 func (i *Investigation) Name() string {
-	return "Cluster Has Gone Missing (CHGM)"
+	return "chgm"
 }
 
 // hasRecentlyResumed checks if the cluster was woken up from

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -164,18 +164,6 @@ func (c *Investigation) Name() string {
 	return "clustermonitoringerrorbudgetburn"
 }
 
-func (c *Investigation) AlertTitle() string {
-	return "ClusterMonitoringErrorBudgetBurnSRE"
-}
-
-func (c *Investigation) Description() string {
-	return "Investigation to analyze a ClusterMonitoringErrorBudgetBurnSRE alert"
-}
-
-func (c *Investigation) IsExperimental() bool {
-	return false
-}
-
 // Check if the `Available` status condition reports a broken UWM config
 func isUWMConfigInvalid(monitoringCo *configv1.ClusterOperator) bool {
 	symptomStatusString := `the User Workload Configuration from "config.yaml" key in the "openshift-user-workload-monitoring/user-workload-monitoring-config" ConfigMap could not be parsed`

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	investigation "github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	"github.com/openshift/configuration-anomaly-detection/pkg/networkverifier"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
@@ -124,8 +125,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	switch verifierResult {
 	case networkverifier.Failure:
 		logging.Infof("Network verifier reported failure: %s", failureReason)
-		// XXX: metrics.Inc(metrics.ServicelogPrepared, investigationName)
-		result.ServiceLogPrepared = investigation.InvestigationStep{Performed: true, Labels: nil}
+		metrics.Inc(metrics.ServicelogPrepared, c.Name())
 		notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post --cluster-id %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=\"%s\"", r.Cluster.ID(), failureReason)
 	case networkverifier.Success:
 		notes.AppendSuccess("Network verifier passed")
@@ -142,18 +142,6 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 func (c *Investigation) Name() string {
 	return "ClusterProvisioningDelay"
-}
-
-func (c *Investigation) AlertTitle() string {
-	return "ClusterProvisioningDelay -"
-}
-
-func (c *Investigation) Description() string {
-	return "Investigates the ClusterProvisioningDelay alert"
-}
-
-func (c *Investigation) IsExperimental() bool {
-	return false
 }
 
 func isSubnetRouteValid(awsClient aws.Client, subnetID string) (bool, error) {

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -141,7 +141,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 }
 
 func (c *Investigation) Name() string {
-	return "ClusterProvisioningDelay"
+	return "cpd"
 }
 
 func isSubnetRouteValid(awsClient aws.Client, subnetID string) (bool, error) {

--- a/pkg/investigations/describenodes/describenodes.go
+++ b/pkg/investigations/describenodes/describenodes.go
@@ -223,15 +223,3 @@ func newNodeDescriber(k8sClient k8sclient.Client) (nodeDescriber, error) {
 func (i *Investigation) Name() string {
 	return "describenodes"
 }
-
-func (i *Investigation) AlertTitle() string {
-	return ""
-}
-
-func (i *Investigation) Description() string {
-	return "Describe all nodes in the cluster with full details including pod information"
-}
-
-func (i *Investigation) IsExperimental() bool {
-	return true
-}

--- a/pkg/investigations/describenodes/describenodes_test.go
+++ b/pkg/investigations/describenodes/describenodes_test.go
@@ -98,20 +98,6 @@ func TestName(t *testing.T) {
 	}
 }
 
-func TestAlertTitle(t *testing.T) {
-	inv := &Investigation{}
-	if inv.AlertTitle() != "" {
-		t.Errorf("expected empty alert title, got %q", inv.AlertTitle())
-	}
-}
-
-func TestIsExperimental(t *testing.T) {
-	inv := &Investigation{}
-	if !inv.IsExperimental() {
-		t.Error("expected IsExperimental to return true")
-	}
-}
-
 // --- Run tests ---
 
 func TestRun_DefaultDescribesAllNodes(t *testing.T) {

--- a/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace.go
+++ b/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace.go
@@ -61,10 +61,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	if err != nil {
 		r.Notes.AppendWarning("Failed to determine if cluster is HCP: %v", err)
 		logging.Warnf("failed to check if cluster is HCP: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "hcp_check_failed"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "hcp_check_failed")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Failed to determine cluster type - manual investigation required"),
@@ -98,10 +95,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		}
 		r.Notes.AppendWarning("Failed to take etcd snapshot: %v", err)
 		logging.Errorf("failed to take etcd snapshot: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "snapshot_failed"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "snapshot_failed")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Failed to take etcd snapshot - manual investigation required"),
@@ -130,10 +124,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		}
 		r.Notes.AppendWarning("Failed to create analysis job: %v", err)
 		logging.Errorf("failed to create analysis job: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "analysis_job_failed"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "analysis_job_failed")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Failed to create analysis job - manual investigation required"),
@@ -150,10 +141,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		}
 		r.Notes.AppendWarning("Analysis job failed or timed out: %v", err)
 		logging.Errorf("analysis job failed: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "analysis_job_failed"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "analysis_job_failed")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Analysis job failed or timed out - manual investigation required"),
@@ -170,10 +158,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		}
 		r.Notes.AppendWarning("Failed to retrieve analysis results: %v", err)
 		logging.Errorf("failed to get job logs: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "parse_failed"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "parse_failed")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Failed to retrieve analysis results - manual investigation required"),
@@ -185,10 +170,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	if err != nil {
 		r.Notes.AppendWarning("Failed to parse analysis results: %v", err)
 		logging.Errorf("failed to parse analysis output: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "parse_failed"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "parse_failed")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Failed to parse analysis results - manual investigation required"),
@@ -207,10 +189,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		Data:      formattedResults,
 	}
 
-	result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-		Performed: true,
-		Labels:    []string{"success", "completed"},
-	}
+	metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "success", "completed")
 
 	result.Actions = append(
 		executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
@@ -250,10 +229,7 @@ func (i *Investigation) runHCPEtcdAnalysis(ctx context.Context, rb investigation
 		}
 		r.Notes.AppendWarning("Failed to get etcd pod: %v", err)
 		logging.Errorf("failed to get etcd pod: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "etcd_not_found"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "etcd_not_found")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Failed to get etcd pod - manual investigation required"),
@@ -265,10 +241,7 @@ func (i *Investigation) runHCPEtcdAnalysis(ctx context.Context, rb investigation
 	if err != nil {
 		r.Notes.AppendWarning("Etcdctl container image not found")
 		logging.Errorf("Etcdctl container image not found")
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "etcdctl_container_image_not_found"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "etcdctl_container_image_not_found")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Failed to find etcdctl container image - manual investigation required"),
@@ -287,10 +260,7 @@ func (i *Investigation) runHCPEtcdAnalysis(ctx context.Context, rb investigation
 	if err != nil {
 		r.Notes.AppendWarning("Failed to build analysis job: %v", err)
 		logging.Errorf("Failed to build analysis job: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "analysis_job_failed"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "analysis_job_failed")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Failed to build analysis job - manual investigation required"),
@@ -305,10 +275,7 @@ func (i *Investigation) runHCPEtcdAnalysis(ctx context.Context, rb investigation
 		}
 		r.Notes.AppendWarning("Failed to create analysis job: %v", err)
 		logging.Errorf("failed to create analysis job: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "analysis_job_failed"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "analysis_job_failed")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Failed to create analysis job - manual investigation required"),
@@ -337,10 +304,7 @@ func (i *Investigation) runHCPEtcdAnalysis(ctx context.Context, rb investigation
 		}
 		r.Notes.AppendWarning("Analysis job failed or timed out: %v", err)
 		logging.Errorf("analysis job failed: %v", err)
-		result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-			Performed: true,
-			Labels:    []string{"failure", "analysis_job_failed"},
-		}
+		metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "failure", "analysis_job_failed")
 		result.Actions = append(
 			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 			executor.Escalate("Analysis job failed or timed out - manual investigation required"),
@@ -348,10 +312,7 @@ func (i *Investigation) runHCPEtcdAnalysis(ctx context.Context, rb investigation
 		return result, nil
 	}
 
-	result.EtcdDatabaseAnalysis = investigation.InvestigationStep{
-		Performed: true,
-		Labels:    []string{"success", "completed"},
-	}
+	metrics.Inc(metrics.EtcdDatabaseAnalysis, i.Name(), "success", "completed")
 
 	result.Actions = executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name())
 	if isWarningAlert(r.PdClient) {
@@ -364,18 +325,6 @@ func (i *Investigation) runHCPEtcdAnalysis(ctx context.Context, rb investigation
 
 func (i *Investigation) Name() string {
 	return "etcddatabasequotalowspace"
-}
-
-func (i *Investigation) AlertTitle() string {
-	return "etcdDatabaseQuotaLowSpace"
-}
-
-func (i *Investigation) Description() string {
-	return "Takes etcd snapshots and performs database analysis for etcd quota issues"
-}
-
-func (i *Investigation) IsExperimental() bool {
-	return false
 }
 
 // isWarningAlert checks if the PagerDuty incident title indicates a warning-severity alert.

--- a/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace_test.go
+++ b/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace_test.go
@@ -83,18 +83,6 @@ func TestInvestigationMethods(t *testing.T) {
 		got := inv.Name()
 		assert.Equal(t, expected, got)
 	})
-
-	t.Run("AlertTitle", func(t *testing.T) {
-		expected := "etcdDatabaseQuotaLowSpace"
-		got := inv.AlertTitle()
-		assert.Equal(t, expected, got)
-	})
-
-	t.Run("Description", func(t *testing.T) {
-		expected := "Takes etcd snapshots and performs database analysis for etcd quota issues"
-		got := inv.Description()
-		assert.Equal(t, expected, got)
-	})
 }
 
 func TestIsWarningAlert(t *testing.T) {
@@ -386,12 +374,9 @@ func TestRunHCPEtcdAnalysis_NoEtcdPod(t *testing.T) {
 	}
 
 	inv := &Investigation{}
-	result, err := inv.runHCPEtcdAnalysis(context.TODO(), rb)
+	_, err := inv.runHCPEtcdAnalysis(context.TODO(), rb)
 
 	assert.NoError(t, err)
-	assert.True(t, result.EtcdDatabaseAnalysis.Performed)
-	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "failure")
-	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "etcd_not_found")
 }
 
 func TestRunHCPEtcdAnalysis_NoRunningEtcdPod(t *testing.T) {
@@ -427,12 +412,9 @@ func TestRunHCPEtcdAnalysis_NoRunningEtcdPod(t *testing.T) {
 	}
 
 	inv := &Investigation{}
-	result, err := inv.runHCPEtcdAnalysis(context.TODO(), rb)
+	_, err := inv.runHCPEtcdAnalysis(context.TODO(), rb)
 
 	assert.NoError(t, err)
-	assert.True(t, result.EtcdDatabaseAnalysis.Performed)
-	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "failure")
-	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "etcd_not_found")
 }
 
 func TestRunHCPEtcdAnalysis_MissingResetMemberContainer(t *testing.T) {
@@ -476,10 +458,7 @@ func TestRunHCPEtcdAnalysis_MissingResetMemberContainer(t *testing.T) {
 	}
 
 	inv := &Investigation{}
-	result, err := inv.runHCPEtcdAnalysis(context.TODO(), rb)
+	_, err := inv.runHCPEtcdAnalysis(context.TODO(), rb)
 
 	assert.NoError(t, err)
-	assert.True(t, result.EtcdDatabaseAnalysis.Performed)
-	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "failure")
-	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "etcdctl_container_image_not_found")
 }

--- a/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace_test.go
+++ b/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace_test.go
@@ -309,8 +309,6 @@ func TestRunHCPEtcdAnalysis_WarningAlertSilenced(t *testing.T) {
 	result, err := inv.runHCPEtcdAnalysis(ctx, rb)
 
 	assert.NoError(t, err)
-	assert.True(t, result.EtcdDatabaseAnalysis.Performed)
-	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "success")
 	assert.Len(t, result.Actions, 3) // NoteAndReportFrom (2 actions) + Silence (1 action)
 	assert.Equal(t, "silence_incident", result.Actions[2].Type())
 
@@ -348,8 +346,6 @@ func TestRunHCPEtcdAnalysis_CriticalAlertEscalated(t *testing.T) {
 	result, err := inv.runHCPEtcdAnalysis(ctx, rb)
 
 	assert.NoError(t, err)
-	assert.True(t, result.EtcdDatabaseAnalysis.Performed)
-	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "success")
 	assert.Len(t, result.Actions, 3) // NoteAndReportFrom (2 actions) + Escalate (1 action)
 	assert.Equal(t, "escalate_incident", result.Actions[2].Type())
 }

--- a/pkg/investigations/insightsoperatordown/insightsoperatordown.go
+++ b/pkg/investigations/insightsoperatordown/insightsoperatordown.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	"github.com/openshift/configuration-anomaly-detection/pkg/networkverifier"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
 	"k8s.io/apimachinery/pkg/fields"
@@ -98,7 +99,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	switch verifierResult {
 	case networkverifier.Failure:
 		logging.Infof("Network verifier reported failure: %s", failureReason)
-		result.ServiceLogPrepared = investigation.InvestigationStep{Performed: true, Labels: nil}
+		metrics.Inc(metrics.ServicelogPrepared, c.Name())
 		notes.AppendWarning("NetworkVerifier found unreachable targets. \n \n Verify and send service log if necessary: \n osdctl servicelog post --cluster-id %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json -p URLS=%s", r.Cluster.ID(), failureReason)
 	case networkverifier.Success:
 		notes.AppendSuccess("Network verifier passed")
@@ -124,16 +125,4 @@ func isOCPBUG22226(co *configv1.ClusterOperator) bool {
 
 func (c *Investigation) Name() string {
 	return "insightsoperatordown"
-}
-
-func (c *Investigation) AlertTitle() string {
-	return "InsightsOperatorDown"
-}
-
-func (c *Investigation) Description() string {
-	return "Investigate insights operator down alert"
-}
-
-func (c *Investigation) IsExperimental() bool {
-	return false
 }

--- a/pkg/investigations/investigation/investigation.go
+++ b/pkg/investigations/investigation/investigation.go
@@ -21,20 +21,8 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 )
 
-type InvestigationStep struct {
-	Performed bool
-	Labels    []string
-}
-
 type InvestigationResult struct {
-	// NEW: Actions to execute via reporter (modern approach)
 	Actions []types.Action
-
-	// EXISTING: Legacy fields (deprecated, maintained for backwards compatibility)
-	LimitedSupportSet    InvestigationStep
-	ServiceLogPrepared   InvestigationStep
-	MustGatherPerformed  InvestigationStep
-	EtcdDatabaseAnalysis InvestigationStep
 
 	// If multiple investigations might be run this can indicate a fatal error that makes running additional investigations useless.
 	// If nil, investigations should continue. If not nil, should contain a meaningful error message explaining why investigations must stop.
@@ -72,9 +60,6 @@ type Investigation interface {
 	// Please note that when adding an investigation the name and the directory currently need to be the same,
 	// so that backplane-api can fetch the metadata.yaml
 	Name() string
-	AlertTitle() string
-	Description() string
-	IsExperimental() bool
 }
 
 // Resources holds all resources/tools required for alert investigations

--- a/pkg/investigations/investigation/investigation.go
+++ b/pkg/investigations/investigation/investigation.go
@@ -210,23 +210,34 @@ func (r *ResourceBuilderT) Build() (*Resources, error) {
 			return r.builtResources, r.buildErr
 		}
 
-		// Check if this is an infra cluster (hive, management or service)
-		internalID := r.builtResources.Cluster.ID()
-		isManaging, err := r.ocmClient.IsManagingCluster(internalID)
-		if err != nil {
-			logging.Warnf("Failed to check if cluster %s is a managing cluster: %v. Assuming it IS a managing cluster (fail-closed).", internalID, err)
-			r.builtResources.IsInfrastructureCluster = true
-			r.builtResources.IsInfrastructureClusterUncertain = true
-		} else {
-			r.builtResources.IsInfrastructureCluster = isManaging
-			if isManaging {
-				logging.Infof("Cluster %s is an infrastructure cluster (hive, management, or service cluster)", internalID)
-			}
-		}
-
 		// Detect HCP early so investigations can use IsHCP without requiring management cluster resources
+		// Must check HCP status BEFORE calling IsManagingCluster() because the OCM API returns an error
+		// when trying to list external configuration labels on HCP clusters.
 		if hypershift := r.builtResources.Cluster.Hypershift(); hypershift != nil && hypershift.Enabled() {
 			r.builtResources.IsHCP = true
+		}
+
+		// Check if this is an infra cluster (hive, management or service)
+		// HCP clusters are customer clusters by definition - they can never be management clusters.
+		// Management clusters are the infrastructure that HOSTS HCP control planes.
+		internalID := r.builtResources.Cluster.ID()
+		if r.builtResources.IsHCP {
+			// HCP clusters are customer clusters, not infrastructure
+			r.builtResources.IsInfrastructureCluster = false
+			logging.Debugf("Cluster %s is HCP - treating as customer cluster, not infrastructure", internalID)
+		} else {
+			// For non-HCP clusters, check if it's a management/service/hive cluster
+			isManaging, err := r.ocmClient.IsManagingCluster(internalID)
+			if err != nil {
+				logging.Warnf("Failed to check if cluster %s is a managing cluster: %v. Assuming it IS a managing cluster (fail-closed).", internalID, err)
+				r.builtResources.IsInfrastructureCluster = true
+				r.builtResources.IsInfrastructureClusterUncertain = true
+			} else {
+				r.builtResources.IsInfrastructureCluster = isManaging
+				if isManaging {
+					logging.Infof("Cluster %s is an infrastructure cluster (hive, management, or service cluster)", internalID)
+				}
+			}
 		}
 	}
 

--- a/pkg/investigations/investigation/investigation.go
+++ b/pkg/investigations/investigation/investigation.go
@@ -210,35 +210,7 @@ func (r *ResourceBuilderT) Build() (*Resources, error) {
 			return r.builtResources, r.buildErr
 		}
 
-		// Detect HCP early so investigations can use IsHCP without requiring management cluster resources
-		// Must check HCP status BEFORE calling IsManagingCluster() because the OCM API returns an error
-		// when trying to list external configuration labels on HCP clusters.
-		if hypershift := r.builtResources.Cluster.Hypershift(); hypershift != nil && hypershift.Enabled() {
-			r.builtResources.IsHCP = true
-		}
-
-		// Check if this is an infra cluster (hive, management or service)
-		// HCP clusters are customer clusters by definition - they can never be management clusters.
-		// Management clusters are the infrastructure that HOSTS HCP control planes.
-		internalID := r.builtResources.Cluster.ID()
-		if r.builtResources.IsHCP {
-			// HCP clusters are customer clusters, not infrastructure
-			r.builtResources.IsInfrastructureCluster = false
-			logging.Debugf("Cluster %s is HCP - treating as customer cluster, not infrastructure", internalID)
-		} else {
-			// For non-HCP clusters, check if it's a management/service/hive cluster
-			isManaging, err := r.ocmClient.IsManagingCluster(internalID)
-			if err != nil {
-				logging.Warnf("Failed to check if cluster %s is a managing cluster: %v. Assuming it IS a managing cluster (fail-closed).", internalID, err)
-				r.builtResources.IsInfrastructureCluster = true
-				r.builtResources.IsInfrastructureClusterUncertain = true
-			} else {
-				r.builtResources.IsInfrastructureCluster = isManaging
-				if isManaging {
-					logging.Infof("Cluster %s is an infrastructure cluster (hive, management, or service cluster)", internalID)
-				}
-			}
-		}
+		r.detectClusterType()
 	}
 
 	if r.buildNotes && r.builtResources.Notes == nil {
@@ -453,4 +425,35 @@ func (r *ResourceBuilderMock) Build() (*Resources, error) {
 		return r.Resources, r.BuildError
 	}
 	return r.Resources, nil
+}
+
+// detectClusterType sets IsHCP and IsInfrastructureCluster on the built resources.
+// Must check HCP status BEFORE calling IsManagingCluster() because the OCM API returns an error
+// when trying to list external configuration labels on HCP clusters.
+func (r *ResourceBuilderT) detectClusterType() {
+	hypershift := r.builtResources.Cluster.Hypershift()
+	r.builtResources.IsHCP = hypershift != nil && hypershift.Enabled()
+
+	// HCP clusters are customer clusters by definition - they can never be management clusters.
+	// Management clusters are the infrastructure that HOSTS HCP control planes.
+	internalID := r.builtResources.Cluster.ID()
+	if r.builtResources.IsHCP {
+		r.builtResources.IsInfrastructureCluster = false
+		logging.Debugf("Cluster %s is HCP - treating as customer cluster, not infrastructure", internalID)
+		return
+	}
+
+	// For non-HCP clusters, check if it's a management/service/hive cluster
+	isManaging, err := r.ocmClient.IsManagingCluster(internalID)
+	if err != nil {
+		logging.Warnf("Failed to check if cluster %s is a managing cluster: %v. Assuming it IS a managing cluster (fail-closed).", internalID, err)
+		r.builtResources.IsInfrastructureCluster = true
+		r.builtResources.IsInfrastructureClusterUncertain = true
+		return
+	}
+
+	r.builtResources.IsInfrastructureCluster = isManaging
+	if isManaging {
+		logging.Infof("Cluster %s is an infrastructure cluster (hive, management, or service cluster)", internalID)
+	}
 }

--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre.go
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre.go
@@ -318,15 +318,3 @@ func (i *Investigation) InvestigateNode(node corev1.Node) {
 func (i *Investigation) Name() string {
 	return strings.ToLower(alertname)
 }
-
-func (i *Investigation) AlertTitle() string {
-	return alertname
-}
-
-func (i *Investigation) Description() string {
-	return fmt.Sprintf("Investigates '%s' alerts", alertname)
-}
-
-func (i *Investigation) IsExperimental() bool {
-	return false
-}

--- a/pkg/investigations/mustgather/mustgather.go
+++ b/pkg/investigations/mustgather/mustgather.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/utils/tarball"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 	"github.com/openshift/configuration-anomaly-detection/pkg/utils"
 )
@@ -182,24 +183,13 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 
 	r.Notes.AppendAutomation("CAD collected a must-gather and uploaded it to the Red Hat SFTP server under /anonymous/users/%s/%s", username, path.Base(tarfile.Name()))
-	result.MustGatherPerformed = investigation.InvestigationStep{Performed: true, Labels: []string{productName}}
+	metrics.Inc(metrics.MustGatherPerformed, c.Name(), productName)
 	result.Actions = executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), c.Name())
 	return result, nil
 }
 
 func (c *Investigation) Name() string {
 	return "mustgather"
-}
-
-func (c *Investigation) AlertTitle() string { return "CreateMustGather" }
-
-func (c *Investigation) Description() string {
-	return "creates a must gather for a cluster"
-}
-
-func (c *Investigation) IsExperimental() bool {
-	// TODO: Update to false when graduating to production.
-	return false
 }
 
 // waitForMustGatherNamespaceDeletion waits for any existing openshift-must-gather-* namespace to be deleted

--- a/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
+++ b/pkg/investigations/ocmagentresponsefailure/ocmagentresponsefailure.go
@@ -90,19 +90,6 @@ func (i *Investigation) Name() string {
 	return "ocmagentresponsefailure"
 }
 
-func (i *Investigation) Description() string {
-	return "Investigates the OCMAgentResponseFailureServiceLogsSRE alert"
-}
-
-func (i *Investigation) IsExperimental() bool {
-	// TODO: Update to false when graduating to production.
-	return true
-}
-
-func (i *Investigation) AlertTitle() string {
-	return "OCMAgentResponseFailureServiceLogsSRE"
-}
-
 // checkUserBanStatus checks if the cluster owner is banned.
 // It returns a set of actions, and a boolean indicating whether the investigation should halt
 func checkUserBanStatus(r *investigation.Resources) (checkResult, error) {

--- a/pkg/investigations/precheck/precheck.go
+++ b/pkg/investigations/precheck/precheck.go
@@ -23,6 +23,7 @@ func (c *ClusterStatePrecheck) Run(rb investigation.ResourceBuilder) (investigat
 		clusterNotFound := &investigation.ClusterNotFoundError{}
 		if errors.As(err, clusterNotFound) {
 			logging.Warnf("Cluster not found. Escalating and exiting: %w", clusterNotFound)
+			result.StopInvestigations = errors.New("cluster not found")
 			result.Actions = []types.Action{
 				executor.Escalate("CAD: Cluster not found."),
 			}
@@ -73,4 +74,8 @@ func (c *ClusterStatePrecheck) Run(rb investigation.ResourceBuilder) (investigat
 		return result, nil
 	}
 	return result, nil
+}
+
+func (c *ClusterStatePrecheck) Name() string {
+	return "precheck"
 }

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -1,10 +1,9 @@
 package investigations
 
 import (
-	"strings"
-
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/aiassisted"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/cannotretrieveupdatessre"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/ccam"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/chgm"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clusterhealthcheck"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clustermonitoringerrorbudgetburn"
@@ -19,12 +18,15 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/mustgather"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/ocmagentresponsefailure"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/pdbblockingnodedrain"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/precheck"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/restartcontrolplane"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/upgradeconfigsyncfailureover4hr"
 )
 
 // availableInvestigations holds all Investigation implementations.
 var availableInvestigations = []investigation.Investigation{
+	&precheck.ClusterStatePrecheck{},
+	&ccam.CloudCredentialsCheck{},
 	&aiassisted.Investigation{},
 	&chgm.Investigation{},
 	&clustermonitoringerrorbudgetburn.Investigation{},
@@ -44,43 +46,17 @@ var availableInvestigations = []investigation.Investigation{
 	&pdbblockingnodedrain.Investigation{},
 }
 
-// GetInvestigation returns the first Investigation that applies to the given alert title.
-// Returns nil if no formal investigation matches.
-func GetInvestigation(title string, experimental bool) investigation.Investigation {
+// GetInvestigationByName returns the Investigation with the given name, or nil if not found.
+func GetInvestigationByName(name string) investigation.Investigation {
 	for _, inv := range availableInvestigations {
-		if inv.AlertTitle() == "" {
-			continue
-		}
-		if strings.Contains(title, inv.AlertTitle()) && (experimental || !inv.IsExperimental()) {
+		if inv.Name() == name {
 			return inv
 		}
 	}
 	return nil
 }
 
-func GetInvestigationByName(name string, experimental bool) investigation.Investigation {
-	for _, inv := range availableInvestigations {
-		if strings.Contains(inv.Name(), name) && (experimental || !inv.IsExperimental()) {
-			return inv
-		}
-	}
-	return nil
-}
-
-// GetAvailableInvestigationsTitles returns a string array with the alert titles of all available investigations.
-func GetAvailableInvestigationsTitles() []string {
-	alertTitles := make([]string, 0, len(availableInvestigations))
-
-	for _, inv := range availableInvestigations {
-		if inv.AlertTitle() == "" {
-			continue
-		}
-		alertTitles = append(alertTitles, inv.AlertTitle())
-	}
-	return alertTitles
-}
-
-// GetAvailableInvestigationsNames returns a string array with the alert names of all available investigations.
+// GetAvailableInvestigationsNames returns a string array with the names of all available investigations.
 func GetAvailableInvestigationsNames() []string {
 	alertNames := make([]string, 0, len(availableInvestigations))
 

--- a/pkg/investigations/restartcontrolplane/restartcontrolplane.go
+++ b/pkg/investigations/restartcontrolplane/restartcontrolplane.go
@@ -80,13 +80,3 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 func (c *Investigation) Name() string {
 	return "restartcontrolplane"
 }
-
-func (c *Investigation) AlertTitle() string { return "RestartControlPlane" }
-
-func (c *Investigation) Description() string {
-	return "restarts the control plane of an HCP cluster"
-}
-
-func (c *Investigation) IsExperimental() bool {
-	return false
-}

--- a/pkg/investigations/restartcontrolplane/restartcontrolplane_test.go
+++ b/pkg/investigations/restartcontrolplane/restartcontrolplane_test.go
@@ -47,21 +47,6 @@ func TestInvestigation_Name(t *testing.T) {
 	assert.Equal(t, "restartcontrolplane", inv.Name())
 }
 
-func TestInvestigation_AlertTitle(t *testing.T) {
-	inv := &Investigation{}
-	assert.Equal(t, "RestartControlPlane", inv.AlertTitle())
-}
-
-func TestInvestigation_Description(t *testing.T) {
-	inv := &Investigation{}
-	assert.Equal(t, "restarts the control plane of an HCP cluster", inv.Description())
-}
-
-func TestInvestigation_IsExperimental(t *testing.T) {
-	inv := &Investigation{}
-	assert.False(t, inv.IsExperimental())
-}
-
 func TestInvestigation_Run_BuildError(t *testing.T) {
 	buildErr := errors.New("build failed")
 	rb := &investigation.ResourceBuilderMock{

--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
@@ -146,15 +146,3 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 func (c *Investigation) Name() string {
 	return "upgradeconfigsyncfailureover4hr"
 }
-
-func (c *Investigation) AlertTitle() string {
-	return "UpgradeConfigSyncFailureOver4HrSRE"
-}
-
-func (c *Investigation) Description() string {
-	return "Investigates the UpgradeConfigSyncFailureOver4hr alert"
-}
-
-func (c *Investigation) IsExperimental() bool {
-	return false
-}

--- a/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
+++ b/pkg/investigations/upgradeconfigsyncfailureover4hr/upgradeconfigsyncfailureover4hr.go
@@ -17,7 +17,7 @@ type Investigation struct{}
 
 func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
 	result := investigation.InvestigationResult{}
-	r, err := rb.Build()
+	r, err := rb.WithCluster().Build()
 	if err != nil {
 		return result, err
 	}

--- a/test/e2e/configuration_anomaly_detection_tests.go
+++ b/test/e2e/configuration_anomaly_detection_tests.go
@@ -5,6 +5,7 @@ package osde2etests
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"os"
 	"time"
@@ -14,11 +15,15 @@ import (
 	. "github.com/onsi/gomega"
 	ocmConfig "github.com/openshift-online/ocm-common/pkg/ocm/config"
 	ocmConnBuilder "github.com/openshift-online/ocm-common/pkg/ocm/connection-builder"
+	"github.com/openshift/configuration-anomaly-detection/pkg/config"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations"
 	"github.com/openshift/configuration-anomaly-detection/test/e2e/utils"
 	ocme2e "github.com/openshift/osde2e-common/pkg/clients/ocm"
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+//go:embed e2e-investigation-config.yaml
+var e2eInvestigationConfig []byte
 
 var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 	var (
@@ -27,6 +32,7 @@ var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 		// region       string
 		clusterID    string
 		testPdClient utils.TestPagerDutyClient
+		cadCfg       *config.Config
 	)
 
 	BeforeAll(func(ctx context.Context) {
@@ -84,6 +90,9 @@ var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 		pdRoutingKey := os.Getenv("CAD_PAGERDUTY_ROUTING_KEY")
 		Expect(pdRoutingKey).NotTo(BeEmpty(), "PAGERDUTY_ROUTING_KEY must be set")
 		testPdClient = utils.NewClient(pdRoutingKey)
+
+		cadCfg, err = config.ParseConfig(e2eInvestigationConfig, investigations.GetAvailableInvestigationsNames())
+		Expect(err).NotTo(HaveOccurred(), "Failed to parse embedded investigation config")
 	})
 
 	AfterAll(func() {
@@ -99,8 +108,13 @@ var _ = Describe("Configuration Anomaly Detection", Ordered, func() {
 		lsReasonsBefore := lsResponseBefore.Items().Len()
 		ginkgo.GinkgoWriter.Printf("Limited support reasons before blocking egress: %d\n", lsReasonsBefore)
 
-		// Trigger all investigations we have against the healthy cluster
-		alertTitles := investigations.GetAvailableInvestigationsTitles()
+		// Trigger all configured alerts against the healthy cluster
+		var alertTitles []string
+		for _, a := range cadCfg.Alerts {
+			if !a.Experimental {
+				alertTitles = append(alertTitles, a.AlertTitle)
+			}
+		}
 		ginkgo.GinkgoWriter.Printf("Triggering %d investigations: %v\n", len(alertTitles), alertTitles)
 
 		for _, alertTitle := range alertTitles {

--- a/test/e2e/e2e-investigation-config.yaml
+++ b/test/e2e/e2e-investigation-config.yaml
@@ -1,0 +1,127 @@
+ alerts:
+   # Classic only - requires ClusterDeployment
+   - alert_title: "has gone missing"
+     name: "chgm"
+     when:
+       field: HCP
+       operator: in
+       values: ["false"]
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - "chgm"
+
+   # CPD requires ClusterDeployment and AWS client
+   - alert_title: "ClusterProvisioningDelay"
+     name: "cpd"
+     when:
+       and:
+         - field: CloudProvider
+           operator: in
+           values: ["aws"]
+         - field: HCP
+           operator: in
+           values: ["false"]
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - cpd
+
+   - alert_title: "CreateMustGather"
+     name: "mustgather"
+     investigations:
+       - precheck
+       - name: mustgather
+         when:
+           operator: sample
+           values: ["0.5"]
+
+   # Requires ClusterDeployment for network verification
+   - alert_title: "InsightsOperatorDown"
+     name: "insightsoperatordown"
+     when:
+       field: HCP
+       operator: in
+       values: ["false"]
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - insightsoperatordown
+
+   # Has explicit HCP branching logic inside the investigation
+   - alert_title: "etcdDatabaseQuotaLowSpace"
+     name: "etcddatabasequotalowspace"
+     investigations:
+       - precheck
+       - etcddatabasequotalowspace
+
+   - alert_title: "CannotRetrieveUpdatesSRE"
+     name: "cannotretrieveupdatessre"
+     when:
+       field: HCP
+       operator: in
+       values: ["false"]
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - cannotretrieveupdatessre
+
+   - alert_title: "ClusterMonitoringErrorBudgetBurnSRE"
+     name: "clustermonitoringerrorbudgetburn"
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - clustermonitoringerrorbudgetburn
+
+   - alert_title: "MachineHealthCheckUnterminatedShortCircuitSRE"
+     name: "machinehealthcheckunterminatedshortcircuitsre"
+     when:
+       field: HCP
+       operator: in
+       values: ["false"]
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - machinehealthcheckunterminatedshortcircuitsre
+
+   - alert_title: "UpgradeConfigSyncFailureOver4HrSRE"
+     name: "upgradeconfigsyncfailureover4hr"
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - upgradeconfigsyncfailureover4hr
+
+   - alert_title: "console-errorbudgetburn"
+     name: "consoleerrorbudgetburn"
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - consoleerrorbudgetburn
+
+   - alert_title: "OCMAgentResponseFailureServiceLogsSRE"
+     name: "ocmagentresponsefailure"
+     when:
+       field: HCP
+       operator: in
+       values: ["false"]
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - ocmagentresponsefailure
+
+   - alert_title: "HCPNodepoolUpgradeDelay"
+     name: "pdbblockingnodedrain"
+     investigations:
+       - precheck
+       - ccam
+       - expiredcertificates
+       - pdbblockingnodedrain


### PR DESCRIPTION
Adds support for executing multiple investigations for a given alert; The chain of investigations is defined via a configuration file.

### What type of PR is this?

feature

### What this PR does / Why we need it?

This PR adds multi-investigation support to CAD through the mapping of pipelines of investigations to a given alert.

### Special notes for your reviewer

Do not merge yet

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added alert-title–driven, ordered investigation chains with `when` support at both the alert level and each investigation entry.
  * Added configurable AI-assisted behavior when no alert chain matches.
* **Bug Fixes**
  * Improved consistent alert-chain routing and escalation behavior across PagerDuty and manual flows.
  * Updated must-gather and service log/analysis reporting to use metrics for more reliable instrumentation.
* **Documentation**
  * Updated configuration docs/examples and e2e fixtures to the new `alerts`/`investigations` schema.
* **Tests**
  * Migrated and expanded unit and e2e coverage for chain parsing and selection.
* **Chores**
  * Interceptor now validates configuration at startup and fails fast; removed the extra payload encoding from interceptor “continue” responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->