### PR TITLE
ROSAENG-60290: fix NetworkVerifier error messages containing Go format string artifacts

### DIFF
--- a/pkg/investigations/chgm/chgm.go
+++ b/pkg/investigations/chgm/chgm.go
@@ -89,7 +89,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	// 2. Check if the cluster was hibernated and has recently resumed.
 	hibernationPeriods, err := getHibernationStatusForCluster(r.OcmClient, r.Cluster)
 	if err != nil {
-		logging.Warnf("could not check hibernation status of cluster: %w", err)
+		logging.Warnf("could not check hibernation status of cluster: %v", err)
 	}
 
 	if hasRecentlyResumed(hibernationPeriods, time.Now()) {
@@ -102,7 +102,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	// 3. Check if the customer blocked egresses
 	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 	if err != nil {
-		logging.Error("Network verifier ran into an error: %s", err.Error())
+		logging.Errorf("Network verifier ran into an error: %s", err.Error())
 		r.Notes.AppendWarning("NetworkVerifier failed to run:\n %s", err.Error())
 	}
 

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -116,7 +116,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 	if err != nil {
-		logging.Error("Network verifier ran into an error: %s", err.Error())
+		logging.Errorf("Network verifier ran into an error: %s", err.Error())
 		notes.AppendWarning("NetworkVerifier failed to run:\n\t %s", err.Error())
 		// We do not return as we want the alert to be escalated either no matter what.
 	}

--- a/pkg/investigations/insightsoperatordown/insightsoperatordown.go
+++ b/pkg/investigations/insightsoperatordown/insightsoperatordown.go
@@ -91,7 +91,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	verifierResult, failureReason, err := networkverifier.Run(r.Cluster, r.ClusterDeployment, r.AwsClient, r.OcmClient)
 	if err != nil {
-		logging.Error("Network verifier ran into an error: %s", err.Error())
+		logging.Errorf("Network verifier ran into an error: %s", err.Error())
 		notes.AppendWarning("NetworkVerifier failed to run:\n\t %s", err.Error())
 	}
 

--- a/pkg/networkverifier/networkverifier.go
+++ b/pkg/networkverifier/networkverifier.go
@@ -139,7 +139,14 @@ func Run(cluster *v1.Cluster, clusterDeployment *hivev1.ClusterDeployment, awsCl
 		if len(verifierErrors) > 0 {
 			errorsSummary = verifierErrors[0].Error()
 		}
-		return Undefined, "", fmt.Errorf(exceptionsSummary, errorsSummary)
+		msg := exceptionsSummary
+		if errorsSummary != "" {
+			if msg != "" {
+				msg += ": "
+			}
+			msg += errorsSummary
+		}
+		return Undefined, "", fmt.Errorf("%s", msg)
 	}
 
 	if !out.IsSuccessful() {


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Fixes malformed error messages produced by the NetworkVerifier when it encounters exceptions or errors during egress validation.

Example of the broken output seen in production (Pod f72a1128, 2026-06-16):
```
⚠️ NetworkVerifier failed to run:
     %!(EXTRA string=network verifier error: encountered issue accessing KMS key when launching instance.)
```
The fix replaces the misused fmt.Errorf call with explicit string composition: the exception and error summaries are joined with :  only when both are present, and the result is formatted with a proper %s verb.
Also fixes two related logging misuses found in the same code paths:
```
logging.Error("...%s", err) in chgm, cpd, and insightsoperatordown — logging.Error is non-formatting (variadic interface{}); changed to logging.Errorf
logging.Warnf("...%w", err) in chgm — %w is only valid inside fmt.Errorf; changed to %v
```

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
