### PR TITLE
ROSA-745: route MintMaker dependency PRs through Prow/Tide

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,7 +56,7 @@
       "enabled": false
     },
     {
-      "description": "Go module non-major updates - automerge",
+      "description": "Go module non-major updates — pre-label lgtm/approved; Tide merges after Prow + Konflux",
       "matchManagers": [
         "gomod"
       ],
@@ -70,12 +70,31 @@
         "pin",
         "digest"
       ],
-      "automerge": true,
+      "automerge": false,
+      "platformAutomerge": false,
       "addLabels": [
         "lgtm",
         "approved",
         "area/dependency",
         "ok-to-test"
+      ]
+    },
+    {
+      "description": "Tekton patch/minor — pre-label lgtm/approved; Tide merges after Prow + Konflux",
+      "matchManagers": [
+        "tekton"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": false,
+      "platformAutomerge": false,
+      "addLabels": [
+        "lgtm",
+        "approved"
       ]
     },
     {


### PR DESCRIPTION
## Summary

[ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) — **configuration-anomaly-detection** has repo-local `renovate.json` overrides on top of `extends` openshift/boilerplate.

This repo cannot rely on boilerplate alone because local `packageRules` set `automerge: true` for grouped gomod updates. This PR aligns MintMaker with the Prow/Tide path:

- **gomod** patch/minor/pin/digest (grouped `golang-dependencies`) → `automerge: false`, `platformAutomerge: false`, keep `lgtm`/`approved`
- **tekton** patch/minor/pin/digest → same Tide routing labels and no platform automerge
- **dockerfile** rules, indirect-major disable, and major gomod manual labels unchanged

## Test plan

- [ ] Merge this config PR (prow + Konflux green)
- [ ] Next MintMaker patch/minor gomod or tekton PR: has `lgtm` + `approved`, no Renovate/platform automerge
- [ ] PR merges via Tide after required checks green
- [ ] Major MintMaker PR still manual

## References

- [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)
- openshift/boilerplate#786 (shared extends path for plain-extends operators)
- MintMaker docs: https://konflux.pages.redhat.com/docs/users/mintmaker/user.html


Made with [Cursor](https://cursor.com)

[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation settings for Go module updates.
  * Non-major updates now use the approval and labeling workflow before merging, instead of automatic merges.
  * Added labels to better support dependency review and testing.
  * Introduced a similar workflow for Tekton patch/minor updates, with automatic merging disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->