### PR TITLE
Remove filtered investigation note when escalating to SRE

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -609,7 +609,7 @@ func (c *investigationRunner) evaluateFilter(invName string, filterCtx *types.Fi
 	}
 
 	if pdClient != nil {
-		if escErr := pdClient.EscalateIncidentWithNote(fmt.Sprintf("🤖 Investigation %s was filtered out by configuration. Escalating to SRE. 🤖", invName)); escErr != nil {
+		if escErr := pdClient.EscalateIncident(); escErr != nil {
 			logging.Errorf("Failed to escalate filtered investigation: %v", escErr)
 		}
 	}


### PR DESCRIPTION
### What type of PR is this?

(feature/bug/documentation/other)

### What this PR does / Why we need it?
🤖 Investigation %s was filtered out by configuration. Escalating to SRE. 🤖 is noisy in PagerDuty. The only investigations that escalate in this way are filtered investigations (aiassisted and mustgather) and this information is not valuable to SRE on call.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated incident escalation handling for filtered investigations so alerts are sent without an extra note.
  * Kept the existing filtering behavior and error logging intact if escalation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->