### PR TITLE
Add mustgathercritical investigation for higher-rate critical alert sampling

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -29,7 +29,7 @@ import (
 
 const pagerdutyTitlePrefix = "[CAD Investigated]"
 
-var certPreCheckSkip = []string{"mustgather"}
+var certPreCheckSkip = []string{"mustgather", "mustgathercritical"}
 
 type PagerDutyConfig struct {
 	PayloadPath string

--- a/pkg/investigations/mustgathercritical/metadata.yaml
+++ b/pkg/investigations/mustgathercritical/metadata.yaml
@@ -1,0 +1,166 @@
+name: mustgathercritical
+rbac:
+  clusterRoleRules:
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "pods/log"
+    - verbs:
+        - "create"
+      apiGroups:
+        - ""
+      resources:
+        - "pods/exec"
+    - verbs:
+        - "create"
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "pods"
+    - verbs:
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "services"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "hypershift.openshift.io"
+      resources:
+        - "awsendpointservices"
+        - "hostedclusters"
+        - "nodepools"
+        - "hostedcontrolplanes"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "nodes"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "infrastructure.cluster.x-k8s.io"
+      resources:
+        - "awsclusters"
+        - "awsmachines"
+        - "awsmachinetemplates"
+        - "kubevirtclusters"
+        - "kubevirtmachinetemplates"
+        - "kubevirtmachines"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "capi-provider.agent-install.openshift.io"
+      resources:
+        - "agentclusters"
+        - "agentmachinetemplates"
+        - "agentmachines"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "cluster.x-k8s.io"
+      resources:
+        - "clusters"
+        - "machinedeployments"
+        - "machines"
+        - "machinesets"
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "config.openshift.io"
+      resources:
+        - "clusteroperators"
+        - "clusterversions"
+    - verbs:
+        - "create"
+        - "delete"
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "namespaces"
+    - verbs:
+        - "create"
+        - "delete"
+        - "list"
+        - "get"
+      apiGroups:
+        - "rbac.authorization.k8s.io"
+      resources:
+        - "clusterrolebindings"
+    - verbs:
+        - "bind"
+      apiGroups:
+        - "rbac.authorization.k8s.io"
+      resources:
+        - "clusterroles"
+      resourceNames:
+        - "cluster-admin"
+    - verbs:
+        - "create"
+        - "delete"
+        - "get"
+        - "list"
+      apiGroups:
+        - ""
+      resources:
+        - "serviceaccounts"
+customerDataAccess: true
+managementClusterRbac:
+  rbac:
+    clusterRoleRules:
+      - verbs:
+          - "get"
+          - "list"
+        apiGroups:
+          - "hypershift.openshift.io"
+        resources:
+          - "awsendpointservices"
+          - "hostedclusters"
+          - "nodepools"
+          - "hostedcontrolplanes"
+      - verbs:
+          - "get"
+          - "list"
+        apiGroups:
+          - "infrastructure.cluster.x-k8s.io"
+        resources:
+          - "awsclusters"
+          - "awsmachines"
+          - "awsmachinetemplates"
+          - "kubevirtclusters"
+          - "kubevirtmachinetemplates"
+          - "kubevirtmachines"
+      - verbs:
+          - "get"
+          - "list"
+        apiGroups:
+          - "capi-provider.agent-install.openshift.io"
+        resources:
+          - "agentclusters"
+          - "agentmachinetemplates"
+          - "agentmachines"
+      - verbs:
+          - "get"
+          - "list"
+        apiGroups:
+          - "cluster.x-k8s.io"
+        resources:
+          - "clusters"
+          - "machinedeployments"
+          - "machines"
+          - "machinesets"

--- a/pkg/investigations/mustgathercritical/mustgathercritical.go
+++ b/pkg/investigations/mustgathercritical/mustgathercritical.go
@@ -1,0 +1,32 @@
+// Package mustgathercritical wraps the mustgather investigation to run on
+// critical-severity alerts with a higher sampling rate configured via CAD filters.
+package mustgathercritical
+
+import (
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/mustgather"
+)
+
+type Investigation struct {
+	delegate mustgather.Investigation
+}
+
+func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
+	return c.delegate.Run(rb)
+}
+
+func (c *Investigation) Name() string {
+	return "mustgathercritical"
+}
+
+func (c *Investigation) AlertTitle() string {
+	return "CreateMustGatherCritical"
+}
+
+func (c *Investigation) Description() string {
+	return "creates a must gather for a cluster with a critical alert"
+}
+
+func (c *Investigation) IsExperimental() bool {
+	return false
+}

--- a/pkg/investigations/mustgathercritical/mustgathercritical_test.go
+++ b/pkg/investigations/mustgathercritical/mustgathercritical_test.go
@@ -1,0 +1,37 @@
+package mustgathercritical
+
+import (
+	"testing"
+)
+
+func TestInvestigation_Name(t *testing.T) {
+	inv := &Investigation{}
+	if got := inv.Name(); got != "mustgathercritical" {
+		t.Errorf("Name() = %q, want %q", got, "mustgathercritical")
+	}
+}
+
+func TestInvestigation_AlertTitle(t *testing.T) {
+	inv := &Investigation{}
+	if got := inv.AlertTitle(); got != "CreateMustGatherCritical" {
+		t.Errorf("AlertTitle() = %q, want %q", got, "CreateMustGatherCritical")
+	}
+}
+
+func TestInvestigation_Description(t *testing.T) {
+	inv := &Investigation{}
+	if got := inv.Description(); got == "" {
+		t.Error("Description() should not be empty")
+	}
+}
+
+func TestInvestigation_IsExperimental(t *testing.T) {
+	inv := &Investigation{}
+	if inv.IsExperimental() {
+		t.Error("IsExperimental() should return false")
+	}
+}
+
+func TestInvestigation_Run(t *testing.T) {
+	t.Skip("Not tested - delegates to mustgather.Investigation.Run which is tested in the mustgather package")
+}

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/mustgather"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/mustgathercritical"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/ocmagentresponsefailure"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/pdbblockingnodedrain"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/restartcontrolplane"
@@ -36,6 +37,7 @@ var availableInvestigations = []investigation.Investigation{
 	&ocmagentresponsefailure.Investigation{},
 	&restartcontrolplane.Investigation{},
 	&cannotretrieveupdatessre.Investigation{},
+	&mustgathercritical.Investigation{},
 	&mustgather.Investigation{},
 	&describenodes.Investigation{},
 	&clusterhealthcheck.Investigation{},


### PR DESCRIPTION
Add mustgathercritical investigation for higher-rate critical alert sampling

https://redhat.atlassian.net/browse/ROSAENG-61354

### What type of PR is this?

feature

### What this PR does / Why we need it?
Adds a new `mustgathercritical` investigation that matches `CreateMustGatherCritical` PagerDuty incident titles. This is a thin wrapper around the existing `mustgather` investigation — it delegates `Run()` to the same must-gather collection and SFTP upload logic.


### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [X] Added tests
- [ ] Created jira card to add unit test
- [] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
