### PR TITLE
Populate investigation_payload with Prometheus labels for Cora

### DIFF
--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -137,6 +137,8 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		return result, nil
 	}
 
+	logging.Infof("Payload: %s", string(payloadJSON))
+
 	// Get AI client (handles role assumption and client creation)
 	// Use incident ID as session identifier for audit trail
 	agentClient, err := aws.GetAIClient(ctx, aiConfig.InvokerRoleArn, aiConfig.Region, incidentID)
@@ -153,7 +155,6 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 
 	// Log AI invocation
 	logging.Infof("🤖 Invoking AI agent for incident %s", incidentID)
-	logging.Infof("Payload: %s", string(payloadJSON))
 
 	// Request streaming response format
 	acceptHeader := "text/event-stream"

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -112,14 +112,12 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	incidentID := pdClient.GetIncidentID()
 	alertName := pdClient.GetTitle()
 
-	// Extract alert details from PagerDuty
-	alertDetails, err := extractAlertDetails(pdClient)
+	alertDetails, firingResult, err := r.PdClient.GetAlertContext(incidentID)
 	if err != nil {
-		logging.Warnf("Failed to extract alert details: %v", err)
+		logging.Warnf("Failed to extract alert context: %v", err)
 	}
 
-	// Build investigation payload with alert context
-	payloadData := buildInvestigationPayload(alertDetails, pdClient.GetIncidentRef())
+	payloadData := buildInvestigationPayload(firingResult, &alertDetails, pdClient.GetIncidentRef())
 
 	investigationData := &InvestigationPayload{
 		InvestigationID:      incidentID,

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -118,6 +118,9 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 
 	payloadData := buildInvestigationPayload(firingResult, &alertDetails, pdClient.GetIncidentRef())
+	if err != nil {
+		payloadData["alert_context_error"] = err.Error()
+	}
 
 	investigationData := &InvestigationPayload{
 		InvestigationID:      incidentID,

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -26,10 +26,10 @@ type Investigation struct {
 
 // InvestigationPayload represents the payload sent to the AgentCore agent
 type InvestigationPayload struct {
-	InvestigationID      string `json:"investigation_id"`
-	InvestigationPayload string `json:"investigation_payload"` // TODO: Implement - should contain alert details/context
-	AlertName            string `json:"alert_name"`
-	ClusterID            string `json:"cluster_id"`
+	InvestigationID      string                 `json:"investigation_id"`
+	InvestigationPayload map[string]interface{} `json:"investigation_payload"` // Alert details and context
+	AlertName            string                 `json:"alert_name"`
+	ClusterID            string                 `json:"cluster_id"`
 }
 
 // generateSessionID generates a unique session ID for this investigation
@@ -112,10 +112,18 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	incidentID := pdClient.GetIncidentID()
 	alertName := pdClient.GetTitle()
 
-	// Build investigation payload using typed structure
+	// Extract alert details from PagerDuty
+	alertDetails, err := extractAlertDetails(pdClient)
+	if err != nil {
+		logging.Warnf("Failed to extract alert details: %v", err)
+	}
+
+	// Build investigation payload with alert context
+	payloadData := buildInvestigationPayload(alertDetails, pdClient.GetIncidentRef())
+
 	investigationData := &InvestigationPayload{
 		InvestigationID:      incidentID,
-		InvestigationPayload: "{}", // TODO: Populate with alert details when implemented
+		InvestigationPayload: payloadData,
 		AlertName:            alertName,
 		ClusterID:            clusterID,
 	}

--- a/pkg/investigations/aiassisted/alert_parser.go
+++ b/pkg/investigations/aiassisted/alert_parser.go
@@ -1,103 +1,51 @@
 package aiassisted
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
-	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 )
 
-var (
-	errNoAlertBody    = errors.New("alert body is nil")
-	errNoAlertDetails = errors.New("alert body has no details field")
-)
-
-// FiringAlert represents a single firing alert from the firing_json PagerDuty detail field.
-type FiringAlert struct {
-	Labels      map[string]string `json:"labels"`
-	Annotations map[string]string `json:"annotations"`
-	StartsAt    string            `json:"startsAt"`
-	EndsAt      string            `json:"endsAt"`
-}
-
-// parseFiringJSON parses the firing_json detail field into structured alerts.
-func parseFiringJSON(firingJSON string) ([]FiringAlert, error) {
-	if firingJSON == "" {
-		return []FiringAlert{}, nil
-	}
-
-	var alerts []FiringAlert
-	if err := json.Unmarshal([]byte(firingJSON), &alerts); err != nil {
-		return nil, fmt.Errorf("failed to parse firing_json: %w", err)
-	}
-
-	return alerts, nil
-}
-
-// extractAlertDetails gets the custom details map from the first PD alert's Body["details"].
-func extractAlertDetails(pdClient *pagerduty.SdkClient) (map[string]interface{}, error) {
-	incidentID := pdClient.GetIncidentID()
-	alerts, err := pdClient.GetAlertsForIncident(incidentID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get alerts for incident: %w", err)
-	}
-
-	if alerts == nil || len(*alerts) == 0 {
-		return nil, fmt.Errorf("no alerts found for incident %s", incidentID)
-	}
-
-	alert := (*alerts)[0]
-	if alert.Body == nil {
-		return nil, errNoAlertBody
-	}
-
-	details, ok := alert.Body["details"].(map[string]interface{})
-	if !ok {
-		return nil, errNoAlertDetails
-	}
-
-	return details, nil
-}
-
-// buildInvestigationPayload constructs the investigation payload from alert details.
-func buildInvestigationPayload(details map[string]interface{}, incidentURL string) map[string]interface{} {
+func buildInvestigationPayload(firingResult *pagerduty.FiringAlertsResult, details *pagerduty.AlertCustomDetails, incidentURL string) map[string]interface{} {
 	payloadData := make(map[string]interface{})
 
 	payloadData["incident_url"] = incidentURL
+
+	if firingResult != nil {
+		if len(firingResult.Alerts) > 0 {
+			payloadData["firing_alerts"] = firingResult.Alerts
+		}
+		if len(firingResult.RawFallbacks) > 0 {
+			payloadData["firing_json_raw"] = firingResult.RawFallbacks
+		}
+		if firingResult.Partial {
+			payloadData["firing_alerts_partial"] = true
+		}
+	}
 
 	if details == nil {
 		return payloadData
 	}
 
-	if firingJSON, ok := details["firing_json"].(string); ok && firingJSON != "" {
-		firingAlerts, err := parseFiringJSON(firingJSON)
-		if err != nil {
-			logging.Warnf("firing_json could not be parsed — sending raw string as fallback: %v", err)
-			payloadData["firing_json_raw"] = firingJSON
-		} else if len(firingAlerts) > 0 {
-			payloadData["firing_alerts"] = firingAlerts
-			logging.Infof("Extracted %d firing alert(s) from firing_json for AI investigation", len(firingAlerts))
-		}
+	alertDetails := make(map[string]interface{})
+	if details.Link != "" {
+		alertDetails["link"] = details.Link
 	}
-
-	filteredDetails := make(map[string]interface{})
-	allowedFields := []string{
-		"link",
-		"num_firing",
-		"num_resolved",
-		"ocm_link",
-		"region",
-		"dashboard",
+	if details.NumFiring != "" {
+		alertDetails["num_firing"] = details.NumFiring
 	}
-	for _, field := range allowedFields {
-		if value, ok := details[field]; ok {
-			filteredDetails[field] = value
-		}
+	if details.NumResolved != "" {
+		alertDetails["num_resolved"] = details.NumResolved
 	}
-	if len(filteredDetails) > 0 {
-		payloadData["alert_details"] = filteredDetails
+	if details.OCMLink != "" {
+		alertDetails["ocm_link"] = details.OCMLink
+	}
+	if details.Region != "" {
+		alertDetails["region"] = details.Region
+	}
+	if details.Dashboard != "" {
+		alertDetails["dashboard"] = details.Dashboard
+	}
+	if len(alertDetails) > 0 {
+		payloadData["alert_details"] = alertDetails
 	}
 
 	return payloadData

--- a/pkg/investigations/aiassisted/alert_parser.go
+++ b/pkg/investigations/aiassisted/alert_parser.go
@@ -1,0 +1,104 @@
+package aiassisted
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
+)
+
+var (
+	errNoAlertBody    = errors.New("alert body is nil")
+	errNoAlertDetails = errors.New("alert body has no details field")
+)
+
+// FiringAlert represents a single firing alert from the firing_json PagerDuty detail field.
+type FiringAlert struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	StartsAt    string            `json:"startsAt"`
+	EndsAt      string            `json:"endsAt"`
+}
+
+// parseFiringJSON parses the firing_json detail field into structured alerts.
+func parseFiringJSON(firingJSON string) ([]FiringAlert, error) {
+	if firingJSON == "" {
+		return []FiringAlert{}, nil
+	}
+
+	var alerts []FiringAlert
+	if err := json.Unmarshal([]byte(firingJSON), &alerts); err != nil {
+		return nil, fmt.Errorf("failed to parse firing_json: %w", err)
+	}
+
+	return alerts, nil
+}
+
+// extractAlertDetails gets the custom details map from the first PD alert's Body["details"].
+func extractAlertDetails(pdClient *pagerduty.SdkClient) (map[string]interface{}, error) {
+	incidentID := pdClient.GetIncidentID()
+	alerts, err := pdClient.GetAlertsForIncident(incidentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get alerts for incident: %w", err)
+	}
+
+	if alerts == nil || len(*alerts) == 0 {
+		return nil, fmt.Errorf("no alerts found for incident %s", incidentID)
+	}
+
+	alert := (*alerts)[0]
+	if alert.Body == nil {
+		return nil, errNoAlertBody
+	}
+
+	details, ok := alert.Body["details"].(map[string]interface{})
+	if !ok {
+		return nil, errNoAlertDetails
+	}
+
+	return details, nil
+}
+
+// buildInvestigationPayload constructs the investigation payload from alert details.
+func buildInvestigationPayload(details map[string]interface{}, incidentURL string) map[string]interface{} {
+	payloadData := make(map[string]interface{})
+
+	payloadData["incident_url"] = incidentURL
+
+	if details == nil {
+		return payloadData
+	}
+
+	if firingJSON, ok := details["firing_json"].(string); ok && firingJSON != "" {
+		firingAlerts, err := parseFiringJSON(firingJSON)
+		if err != nil {
+			logging.Warnf("firing_json could not be parsed — sending raw string as fallback: %v", err)
+			payloadData["firing_json_raw"] = firingJSON
+		} else if len(firingAlerts) > 0 {
+			payloadData["firing_alerts"] = firingAlerts
+			logging.Infof("Extracted %d firing alert(s) from firing_json for AI investigation", len(firingAlerts))
+		}
+	}
+
+	filteredDetails := make(map[string]interface{})
+	allowedFields := []string{
+		"link",
+		"num_firing",
+		"num_resolved",
+		"ocm_link",
+		"region",
+		"dashboard",
+	}
+	for _, field := range allowedFields {
+		if value, ok := details[field]; ok {
+			filteredDetails[field] = value
+		}
+	}
+	if len(filteredDetails) > 0 {
+		payloadData["alert_details"] = filteredDetails
+	}
+
+	return payloadData
+}

--- a/pkg/investigations/aiassisted/alert_parser_test.go
+++ b/pkg/investigations/aiassisted/alert_parser_test.go
@@ -1,0 +1,229 @@
+package aiassisted
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseFiringJSON(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedCount int
+		expectErr     bool
+	}{
+		{
+			name: "single alert",
+			input: mustMarshal([]FiringAlert{{
+				Labels: map[string]string{
+					"alertname": "KubePersistentVolumeFillingUp",
+					"namespace": "openshift-monitoring",
+					"severity":  "critical",
+				},
+			}}),
+			expectedCount: 1,
+		},
+		{
+			name:          "empty string",
+			input:         "",
+			expectedCount: 0,
+		},
+		{
+			name:      "invalid JSON",
+			input:     "not json",
+			expectErr: true,
+		},
+		{
+			name:          "empty array",
+			input:         "[]",
+			expectedCount: 0,
+		},
+		{
+			name: "multiple firing alerts",
+			input: mustMarshal([]FiringAlert{
+				{Labels: map[string]string{"alertname": "Alert1", "namespace": "ns1"}},
+				{Labels: map[string]string{"alertname": "Alert2", "namespace": "ns2"}},
+			}),
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseFiringJSON(tt.input)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if len(result) != tt.expectedCount {
+				t.Errorf("Expected %d alerts, got %d", tt.expectedCount, len(result))
+			}
+		})
+	}
+}
+
+func TestPayloadStructure(t *testing.T) {
+	firingJSON := mustMarshal([]FiringAlert{
+		{
+			Labels: map[string]string{
+				"alertname":             "KubePersistentVolumeFillingUp",
+				"namespace":             "openshift-monitoring",
+				"persistentvolumeclaim": "prometheus-data-prometheus-k8s-0",
+				"severity":              "critical",
+			},
+			StartsAt: "2026-07-07T12:00:00Z",
+		},
+		{
+			Labels: map[string]string{
+				"alertname":             "KubePersistentVolumeFillingUp",
+				"namespace":             "openshift-monitoring",
+				"persistentvolumeclaim": "prometheus-data-prometheus-k8s-1",
+				"severity":              "critical",
+			},
+			StartsAt: "2026-07-07T12:01:00Z",
+		},
+	})
+
+	details := map[string]interface{}{
+		"firing_json":          firingJSON,
+		"link":                 "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md",
+		"num_firing":           "2",
+		"region":               "us-west-2",
+		"suggested_next_steps": "This should be filtered out",
+	}
+
+	payloadData := buildInvestigationPayload(details, "https://redhat.pagerduty.com/incidents/Q3OFA2AM9FYDAB")
+
+	if payloadData["incident_url"] != "https://redhat.pagerduty.com/incidents/Q3OFA2AM9FYDAB" {
+		t.Errorf("Expected incident_url, got %v", payloadData["incident_url"])
+	}
+
+	firingAlerts, ok := payloadData["firing_alerts"].([]FiringAlert)
+	if !ok {
+		t.Fatal("Expected firing_alerts in payload")
+	}
+	if len(firingAlerts) != 2 {
+		t.Errorf("Expected 2 firing alerts, got %d", len(firingAlerts))
+	}
+	if firingAlerts[1].Labels["persistentvolumeclaim"] != "prometheus-data-prometheus-k8s-1" {
+		t.Errorf("Expected second alert's PVC, got %s", firingAlerts[1].Labels["persistentvolumeclaim"])
+	}
+
+	alertDetails := payloadData["alert_details"].(map[string]interface{})
+	if _, ok := alertDetails["link"]; !ok {
+		t.Error("Expected link in alert_details")
+	}
+	if _, ok := alertDetails["num_firing"]; !ok {
+		t.Error("Expected num_firing in alert_details")
+	}
+	if _, ok := alertDetails["region"]; !ok {
+		t.Error("Expected region in alert_details")
+	}
+	if _, ok := alertDetails["suggested_next_steps"]; ok {
+		t.Error("suggested_next_steps should not be in alert_details (not in allow-list)")
+	}
+}
+
+func TestPayloadFallbackRawJSON(t *testing.T) {
+	invalidJSON := "not valid json {{"
+
+	details := map[string]interface{}{
+		"firing_json": invalidJSON,
+		"link":        "https://example.com/runbook",
+		"num_firing":  "1",
+	}
+
+	payloadData := buildInvestigationPayload(details, "https://redhat.pagerduty.com/incidents/TEST123")
+
+	if _, hasFiring := payloadData["firing_alerts"]; hasFiring {
+		t.Error("firing_alerts should not be present when parsing fails")
+	}
+
+	raw, hasRaw := payloadData["firing_json_raw"].(string)
+	if !hasRaw {
+		t.Fatal("Expected firing_json_raw fallback when parsing fails")
+	}
+	if raw != invalidJSON {
+		t.Errorf("Expected raw string %q, got %q", invalidJSON, raw)
+	}
+}
+
+func TestPayloadWithRealisticPDJSON(t *testing.T) {
+	details := map[string]interface{}{
+		"cluster_id":   "1a2b3c4d-5e6f-7890-abcd-ef1234567890",
+		"firing_json":  `[{"labels":{"alertname":"ClusterProvisioningDelay","managed_notification_template":"ClusterProvisioningDelay","namespace":"openshift-monitoring","severity":"warning"},"annotations":{"summary":"Cluster provisioning is delayed","description":"Cluster 1a2b3c4d has been provisioning for more than 1 hour"},"startsAt":"2026-07-14T10:30:00.000Z","endsAt":"0001-01-01T00:00:00Z"}]`,
+		"link":         "https://github.com/openshift/runbooks/blob/master/alerts/ClusterProvisioningDelay.md",
+		"num_firing":   "1",
+		"num_resolved": "0",
+		"ocm_link":     "https://cloud.redhat.com/openshift/details/1a2b3c4d",
+		"region":       "us-east-1",
+		"dashboard":    "https://grafana.example.com/d/abc123",
+		"notes":        "cluster_id: 1a2b3c4d-5e6f-7890-abcd-ef1234567890",
+	}
+
+	payloadData := buildInvestigationPayload(details, "https://redhat.pagerduty.com/incidents/PABCDEF")
+
+	firingAlerts, ok := payloadData["firing_alerts"].([]FiringAlert)
+	if !ok {
+		t.Fatal("Expected firing_alerts from realistic PD JSON")
+	}
+	if len(firingAlerts) != 1 {
+		t.Fatalf("Expected 1 firing alert, got %d", len(firingAlerts))
+	}
+	if firingAlerts[0].Labels["alertname"] != "ClusterProvisioningDelay" {
+		t.Errorf("Expected alertname ClusterProvisioningDelay, got %s", firingAlerts[0].Labels["alertname"])
+	}
+	if firingAlerts[0].Labels["severity"] != "warning" {
+		t.Errorf("Expected severity warning, got %s", firingAlerts[0].Labels["severity"])
+	}
+	if firingAlerts[0].Annotations["summary"] != "Cluster provisioning is delayed" {
+		t.Errorf("Expected summary annotation, got %s", firingAlerts[0].Annotations["summary"])
+	}
+	if firingAlerts[0].StartsAt != "2026-07-14T10:30:00.000Z" {
+		t.Errorf("Expected startsAt, got %s", firingAlerts[0].StartsAt)
+	}
+
+	alertDetails := payloadData["alert_details"].(map[string]interface{})
+	expectedFields := []string{"link", "num_firing", "num_resolved", "ocm_link", "region", "dashboard"}
+	for _, field := range expectedFields {
+		if _, ok := alertDetails[field]; !ok {
+			t.Errorf("Expected %s in alert_details", field)
+		}
+	}
+	if _, ok := alertDetails["notes"]; ok {
+		t.Error("notes should not be in alert_details (not in allow-list)")
+	}
+	if _, ok := alertDetails["cluster_id"]; ok {
+		t.Error("cluster_id should not be in alert_details (not in allow-list)")
+	}
+}
+
+func TestPayloadNilDetails(t *testing.T) {
+	payloadData := buildInvestigationPayload(nil, "https://redhat.pagerduty.com/incidents/PNIL123")
+
+	if payloadData["incident_url"] != "https://redhat.pagerduty.com/incidents/PNIL123" {
+		t.Errorf("Expected incident_url even with nil details, got %v", payloadData["incident_url"])
+	}
+
+	if _, ok := payloadData["firing_alerts"]; ok {
+		t.Error("firing_alerts should not be present with nil details")
+	}
+	if _, ok := payloadData["alert_details"]; ok {
+		t.Error("alert_details should not be present with nil details")
+	}
+}
+
+func mustMarshal(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}

--- a/pkg/investigations/aiassisted/alert_parser_test.go
+++ b/pkg/investigations/aiassisted/alert_parser_test.go
@@ -1,111 +1,48 @@
 package aiassisted
 
 import (
-	"encoding/json"
 	"testing"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 )
 
-func TestParseFiringJSON(t *testing.T) {
-	tests := []struct {
-		name          string
-		input         string
-		expectedCount int
-		expectErr     bool
-	}{
-		{
-			name: "single alert",
-			input: mustMarshal([]FiringAlert{{
-				Labels: map[string]string{
-					"alertname": "KubePersistentVolumeFillingUp",
-					"namespace": "openshift-monitoring",
-					"severity":  "critical",
-				},
-			}}),
-			expectedCount: 1,
-		},
-		{
-			name:          "empty string",
-			input:         "",
-			expectedCount: 0,
-		},
-		{
-			name:      "invalid JSON",
-			input:     "not json",
-			expectErr: true,
-		},
-		{
-			name:          "empty array",
-			input:         "[]",
-			expectedCount: 0,
-		},
-		{
-			name: "multiple firing alerts",
-			input: mustMarshal([]FiringAlert{
-				{Labels: map[string]string{"alertname": "Alert1", "namespace": "ns1"}},
-				{Labels: map[string]string{"alertname": "Alert2", "namespace": "ns2"}},
-			}),
-			expectedCount: 2,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := parseFiringJSON(tt.input)
-
-			if tt.expectErr {
-				if err == nil {
-					t.Error("Expected error, got nil")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-			}
-			if len(result) != tt.expectedCount {
-				t.Errorf("Expected %d alerts, got %d", tt.expectedCount, len(result))
-			}
-		})
-	}
-}
-
 func TestPayloadStructure(t *testing.T) {
-	firingJSON := mustMarshal([]FiringAlert{
-		{
-			Labels: map[string]string{
-				"alertname":             "KubePersistentVolumeFillingUp",
-				"namespace":             "openshift-monitoring",
-				"persistentvolumeclaim": "prometheus-data-prometheus-k8s-0",
-				"severity":              "critical",
+	firingResult := &pagerduty.FiringAlertsResult{
+		Alerts: []pagerduty.FiringAlert{
+			{
+				Labels: map[string]string{
+					"alertname":             "KubePersistentVolumeFillingUp",
+					"namespace":             "openshift-monitoring",
+					"persistentvolumeclaim": "prometheus-data-prometheus-k8s-0",
+					"severity":              "critical",
+				},
+				StartsAt: "2026-07-07T12:00:00Z",
 			},
-			StartsAt: "2026-07-07T12:00:00Z",
-		},
-		{
-			Labels: map[string]string{
-				"alertname":             "KubePersistentVolumeFillingUp",
-				"namespace":             "openshift-monitoring",
-				"persistentvolumeclaim": "prometheus-data-prometheus-k8s-1",
-				"severity":              "critical",
+			{
+				Labels: map[string]string{
+					"alertname":             "KubePersistentVolumeFillingUp",
+					"namespace":             "openshift-monitoring",
+					"persistentvolumeclaim": "prometheus-data-prometheus-k8s-1",
+					"severity":              "critical",
+				},
+				StartsAt: "2026-07-07T12:01:00Z",
 			},
-			StartsAt: "2026-07-07T12:01:00Z",
 		},
-	})
-
-	details := map[string]interface{}{
-		"firing_json":          firingJSON,
-		"link":                 "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md",
-		"num_firing":           "2",
-		"region":               "us-west-2",
-		"suggested_next_steps": "This should be filtered out",
 	}
 
-	payloadData := buildInvestigationPayload(details, "https://redhat.pagerduty.com/incidents/Q3OFA2AM9FYDAB")
+	details := &pagerduty.AlertCustomDetails{
+		Link:      "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md",
+		NumFiring: "2",
+		Region:    "us-west-2",
+	}
+
+	payloadData := buildInvestigationPayload(firingResult, details, "https://redhat.pagerduty.com/incidents/Q3OFA2AM9FYDAB")
 
 	if payloadData["incident_url"] != "https://redhat.pagerduty.com/incidents/Q3OFA2AM9FYDAB" {
 		t.Errorf("Expected incident_url, got %v", payloadData["incident_url"])
 	}
 
-	firingAlerts, ok := payloadData["firing_alerts"].([]FiringAlert)
+	firingAlerts, ok := payloadData["firing_alerts"].([]pagerduty.FiringAlert)
 	if !ok {
 		t.Fatal("Expected firing_alerts in payload")
 	}
@@ -116,61 +53,162 @@ func TestPayloadStructure(t *testing.T) {
 		t.Errorf("Expected second alert's PVC, got %s", firingAlerts[1].Labels["persistentvolumeclaim"])
 	}
 
+	alertDetails, ok := payloadData["alert_details"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected alert_details in payload")
+	}
+	if alertDetails["link"] != details.Link {
+		t.Errorf("Expected link %q, got %v", details.Link, alertDetails["link"])
+	}
+	if alertDetails["num_firing"] != details.NumFiring {
+		t.Errorf("Expected num_firing %q, got %v", details.NumFiring, alertDetails["num_firing"])
+	}
+	if alertDetails["region"] != details.Region {
+		t.Errorf("Expected region %q, got %v", details.Region, alertDetails["region"])
+	}
+
+	if _, ok := payloadData["firing_alerts_partial"]; ok {
+		t.Error("firing_alerts_partial should not be present when all alerts parse")
+	}
+}
+
+func TestPayloadMultiplePDAlerts(t *testing.T) {
+	firingResult := &pagerduty.FiringAlertsResult{
+		Alerts: []pagerduty.FiringAlert{
+			{Labels: map[string]string{"alertname": "Alert1", "severity": "critical"}, StartsAt: "2026-07-14T10:00:00Z"},
+			{Labels: map[string]string{"alertname": "Alert2", "severity": "warning"}, StartsAt: "2026-07-14T10:05:00Z"},
+			{Labels: map[string]string{"alertname": "Alert3", "severity": "critical"}, StartsAt: "2026-07-14T10:10:00Z"},
+		},
+	}
+
+	details := &pagerduty.AlertCustomDetails{
+		Link:      "https://example.com/runbook1",
+		NumFiring: "3",
+		Region:    "us-east-1",
+	}
+
+	payloadData := buildInvestigationPayload(firingResult, details, "https://redhat.pagerduty.com/incidents/PMULTI")
+
+	firingAlerts, ok := payloadData["firing_alerts"].([]pagerduty.FiringAlert)
+	if !ok {
+		t.Fatal("Expected firing_alerts in payload")
+	}
+	if len(firingAlerts) != 3 {
+		t.Fatalf("Expected 3 merged firing alerts, got %d", len(firingAlerts))
+	}
+	if firingAlerts[0].Labels["alertname"] != "Alert1" {
+		t.Errorf("Expected Alert1, got %s", firingAlerts[0].Labels["alertname"])
+	}
+	if firingAlerts[2].Labels["alertname"] != "Alert3" {
+		t.Errorf("Expected Alert3, got %s", firingAlerts[2].Labels["alertname"])
+	}
+
+	if _, ok := payloadData["firing_alerts_partial"]; ok {
+		t.Error("firing_alerts_partial should not be present when all alerts parse")
+	}
+
 	alertDetails := payloadData["alert_details"].(map[string]interface{})
-	if _, ok := alertDetails["link"]; !ok {
-		t.Error("Expected link in alert_details")
+	if alertDetails["link"] != "https://example.com/runbook1" {
+		t.Errorf("Expected alert_details link, got %v", alertDetails["link"])
 	}
-	if _, ok := alertDetails["num_firing"]; !ok {
-		t.Error("Expected num_firing in alert_details")
+}
+
+func TestPayloadPartialFailure(t *testing.T) {
+	firingResult := &pagerduty.FiringAlertsResult{
+		Alerts: []pagerduty.FiringAlert{
+			{Labels: map[string]string{"alertname": "Alert1", "severity": "critical"}, StartsAt: "2026-07-14T10:00:00Z"},
+		},
+		RawFallbacks: []string{"not valid json {{"},
+		Partial:      true,
 	}
-	if _, ok := alertDetails["region"]; !ok {
-		t.Error("Expected region in alert_details")
+
+	details := &pagerduty.AlertCustomDetails{
+		Link:      "https://example.com/runbook",
+		NumFiring: "2",
 	}
-	if _, ok := alertDetails["suggested_next_steps"]; ok {
-		t.Error("suggested_next_steps should not be in alert_details (not in allow-list)")
+
+	payloadData := buildInvestigationPayload(firingResult, details, "https://redhat.pagerduty.com/incidents/PPARTIAL")
+
+	firingAlerts, ok := payloadData["firing_alerts"].([]pagerduty.FiringAlert)
+	if !ok {
+		t.Fatal("Expected firing_alerts for the alert that parsed")
+	}
+	if len(firingAlerts) != 1 {
+		t.Errorf("Expected 1 firing alert from successful parse, got %d", len(firingAlerts))
+	}
+
+	rawFallbacks, ok := payloadData["firing_json_raw"].([]string)
+	if !ok {
+		t.Fatal("Expected firing_json_raw as []string for failed parse")
+	}
+	if len(rawFallbacks) != 1 {
+		t.Errorf("Expected 1 raw fallback, got %d", len(rawFallbacks))
+	}
+
+	partial, ok := payloadData["firing_alerts_partial"].(bool)
+	if !ok || !partial {
+		t.Error("Expected firing_alerts_partial=true when some alerts fail to parse")
 	}
 }
 
 func TestPayloadFallbackRawJSON(t *testing.T) {
 	invalidJSON := "not valid json {{"
 
-	details := map[string]interface{}{
-		"firing_json": invalidJSON,
-		"link":        "https://example.com/runbook",
-		"num_firing":  "1",
+	firingResult := &pagerduty.FiringAlertsResult{
+		RawFallbacks: []string{invalidJSON},
 	}
 
-	payloadData := buildInvestigationPayload(details, "https://redhat.pagerduty.com/incidents/TEST123")
+	payloadData := buildInvestigationPayload(firingResult, nil, "https://redhat.pagerduty.com/incidents/TEST123")
 
 	if _, hasFiring := payloadData["firing_alerts"]; hasFiring {
-		t.Error("firing_alerts should not be present when parsing fails")
+		t.Error("firing_alerts should not be present when all parsing fails")
 	}
 
-	raw, hasRaw := payloadData["firing_json_raw"].(string)
-	if !hasRaw {
-		t.Fatal("Expected firing_json_raw fallback when parsing fails")
+	rawFallbacks, ok := payloadData["firing_json_raw"].([]string)
+	if !ok {
+		t.Fatal("Expected firing_json_raw as []string when parsing fails")
 	}
-	if raw != invalidJSON {
-		t.Errorf("Expected raw string %q, got %q", invalidJSON, raw)
+	if len(rawFallbacks) != 1 || rawFallbacks[0] != invalidJSON {
+		t.Errorf("Expected raw fallback %q, got %v", invalidJSON, rawFallbacks)
+	}
+
+	if _, ok := payloadData["firing_alerts_partial"]; ok {
+		t.Error("firing_alerts_partial should not be present when no alerts parsed")
 	}
 }
 
 func TestPayloadWithRealisticPDJSON(t *testing.T) {
-	details := map[string]interface{}{
-		"cluster_id":   "1a2b3c4d-5e6f-7890-abcd-ef1234567890",
-		"firing_json":  `[{"labels":{"alertname":"ClusterProvisioningDelay","managed_notification_template":"ClusterProvisioningDelay","namespace":"openshift-monitoring","severity":"warning"},"annotations":{"summary":"Cluster provisioning is delayed","description":"Cluster 1a2b3c4d has been provisioning for more than 1 hour"},"startsAt":"2026-07-14T10:30:00.000Z","endsAt":"0001-01-01T00:00:00Z"}]`,
-		"link":         "https://github.com/openshift/runbooks/blob/master/alerts/ClusterProvisioningDelay.md",
-		"num_firing":   "1",
-		"num_resolved": "0",
-		"ocm_link":     "https://cloud.redhat.com/openshift/details/1a2b3c4d",
-		"region":       "us-east-1",
-		"dashboard":    "https://grafana.example.com/d/abc123",
-		"notes":        "cluster_id: 1a2b3c4d-5e6f-7890-abcd-ef1234567890",
+	firingResult := &pagerduty.FiringAlertsResult{
+		Alerts: []pagerduty.FiringAlert{
+			{
+				Labels: map[string]string{
+					"alertname":                     "ClusterProvisioningDelay",
+					"managed_notification_template": "ClusterProvisioningDelay",
+					"namespace":                     "openshift-monitoring",
+					"severity":                      "warning",
+				},
+				Annotations: map[string]string{
+					"summary":     "Cluster provisioning is delayed",
+					"description": "Cluster 1a2b3c4d has been provisioning for more than 1 hour",
+				},
+				StartsAt: "2026-07-14T10:30:00.000Z",
+				EndsAt:   "0001-01-01T00:00:00Z",
+			},
+		},
 	}
 
-	payloadData := buildInvestigationPayload(details, "https://redhat.pagerduty.com/incidents/PABCDEF")
+	details := &pagerduty.AlertCustomDetails{
+		Link:        "https://github.com/openshift/runbooks/blob/master/alerts/ClusterProvisioningDelay.md",
+		NumFiring:   "1",
+		NumResolved: "0",
+		OCMLink:     "https://cloud.redhat.com/openshift/details/1a2b3c4d",
+		Region:      "us-east-1",
+		Dashboard:   "https://grafana.example.com/d/abc123",
+	}
 
-	firingAlerts, ok := payloadData["firing_alerts"].([]FiringAlert)
+	payloadData := buildInvestigationPayload(firingResult, details, "https://redhat.pagerduty.com/incidents/PABCDEF")
+
+	firingAlerts, ok := payloadData["firing_alerts"].([]pagerduty.FiringAlert)
 	if !ok {
 		t.Fatal("Expected firing_alerts from realistic PD JSON")
 	}
@@ -197,33 +235,19 @@ func TestPayloadWithRealisticPDJSON(t *testing.T) {
 			t.Errorf("Expected %s in alert_details", field)
 		}
 	}
-	if _, ok := alertDetails["notes"]; ok {
-		t.Error("notes should not be in alert_details (not in allow-list)")
-	}
-	if _, ok := alertDetails["cluster_id"]; ok {
-		t.Error("cluster_id should not be in alert_details (not in allow-list)")
-	}
 }
 
-func TestPayloadNilDetails(t *testing.T) {
-	payloadData := buildInvestigationPayload(nil, "https://redhat.pagerduty.com/incidents/PNIL123")
+func TestPayloadNilInputs(t *testing.T) {
+	payloadData := buildInvestigationPayload(nil, nil, "https://redhat.pagerduty.com/incidents/PNIL123")
 
 	if payloadData["incident_url"] != "https://redhat.pagerduty.com/incidents/PNIL123" {
-		t.Errorf("Expected incident_url even with nil details, got %v", payloadData["incident_url"])
+		t.Errorf("Expected incident_url even with nil inputs, got %v", payloadData["incident_url"])
 	}
 
 	if _, ok := payloadData["firing_alerts"]; ok {
-		t.Error("firing_alerts should not be present with nil details")
+		t.Error("firing_alerts should not be present with nil inputs")
 	}
 	if _, ok := payloadData["alert_details"]; ok {
-		t.Error("alert_details should not be present with nil details")
+		t.Error("alert_details should not be present with nil inputs")
 	}
-}
-
-func mustMarshal(v interface{}) string {
-	b, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	return string(b)
 }

--- a/pkg/pagerduty/mock/pagerdutymock.go
+++ b/pkg/pagerduty/mock/pagerdutymock.go
@@ -12,6 +12,7 @@ package pdmock
 import (
 	reflect "reflect"
 
+	pagerduty "github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -19,6 +20,7 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
+	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.
@@ -78,6 +80,22 @@ func (m *MockClient) EscalateIncidentWithNote(notes string) error {
 func (mr *MockClientMockRecorder) EscalateIncidentWithNote(notes any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EscalateIncidentWithNote", reflect.TypeOf((*MockClient)(nil).EscalateIncidentWithNote), notes)
+}
+
+// GetAlertContext mocks base method.
+func (m *MockClient) GetAlertContext(incidentID string) (pagerduty.AlertCustomDetails, *pagerduty.FiringAlertsResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAlertContext", incidentID)
+	ret0, _ := ret[0].(pagerduty.AlertCustomDetails)
+	ret1, _ := ret[1].(*pagerduty.FiringAlertsResult)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetAlertContext indicates an expected call of GetAlertContext.
+func (mr *MockClientMockRecorder) GetAlertContext(incidentID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAlertContext", reflect.TypeOf((*MockClient)(nil).GetAlertContext), incidentID)
 }
 
 // GetServiceID mocks base method.

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -34,6 +34,7 @@ type Client interface {
 	AddNote(notes string) error
 	EscalateIncident() error
 	EscalateIncidentWithNote(notes string) error
+	GetAlertContext(incidentID string) (AlertCustomDetails, *FiringAlertsResult, error)
 	GetServiceID() string
 	GetTitle() string
 	MoveToEscalationPolicy(escalationPolicyID string) error
@@ -463,6 +464,97 @@ func extractAlertDetails(sdkAlert sdk.IncidentAlert) (AlertDetails, error) {
 		ClusterID: clusterID,
 	}
 	return alertDetails, nil
+}
+
+// getRawAlertDetails returns the raw Body["details"] maps from all alerts of an incident.
+func (c *SdkClient) getRawAlertDetails(incidentID string) ([]map[string]interface{}, error) {
+	alerts, err := c.GetAlertsForIncident(incidentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get alerts for incident: %w", err)
+	}
+
+	if alerts == nil || len(*alerts) == 0 {
+		return nil, fmt.Errorf("no alerts found for incident %s", incidentID)
+	}
+
+	allDetails := make([]map[string]interface{}, 0, len(*alerts))
+	for i, alert := range *alerts {
+		if alert.Body == nil {
+			logging.Warnf("Alert %d/%d has nil body, skipping", i+1, len(*alerts))
+			continue
+		}
+		details, ok := alert.Body["details"].(map[string]interface{})
+		if !ok {
+			logging.Warnf("Alert %d/%d body has no details field, skipping", i+1, len(*alerts))
+			continue
+		}
+		allDetails = append(allDetails, details)
+	}
+
+	if len(allDetails) == 0 {
+		return nil, fmt.Errorf("no alerts with valid details found for incident %s", incidentID)
+	}
+
+	return allDetails, nil
+}
+
+func stringFromDetails(details map[string]interface{}, key string) string {
+	val, _ := details[key].(string)
+	return val
+}
+
+// GetAlertContext fetches all PD alerts for an incident once and returns both
+// the typed custom details (from the first alert) and parsed firing alerts (from all alerts).
+func (c *SdkClient) GetAlertContext(incidentID string) (AlertCustomDetails, *FiringAlertsResult, error) {
+	rawDetails, err := c.getRawAlertDetails(incidentID)
+	if err != nil {
+		return AlertCustomDetails{}, nil, err
+	}
+
+	first := rawDetails[0]
+	customDetails := AlertCustomDetails{
+		Link:        stringFromDetails(first, "link"),
+		NumFiring:   stringFromDetails(first, "num_firing"),
+		NumResolved: stringFromDetails(first, "num_resolved"),
+		OCMLink:     stringFromDetails(first, "ocm_link"),
+		Region:      stringFromDetails(first, "region"),
+		Dashboard:   stringFromDetails(first, "dashboard"),
+	}
+
+	firingResult := &FiringAlertsResult{}
+	for _, details := range rawDetails {
+		firingJSON, ok := details["firing_json"].(string)
+		if !ok || firingJSON == "" {
+			continue
+		}
+		parsed, err := ParseFiringJSON(firingJSON)
+		if err != nil {
+			logging.Warnf("firing_json could not be parsed — saving raw string as fallback: %v", err)
+			firingResult.RawFallbacks = append(firingResult.RawFallbacks, firingJSON)
+			continue
+		}
+		firingResult.Alerts = append(firingResult.Alerts, parsed...)
+	}
+
+	if len(firingResult.RawFallbacks) > 0 && len(firingResult.Alerts) > 0 {
+		firingResult.Partial = true
+	}
+
+	return customDetails, firingResult, nil
+}
+
+// ParseFiringJSON parses the firing_json custom detail field into structured FiringAlert objects.
+func ParseFiringJSON(firingJSON string) ([]FiringAlert, error) {
+	if firingJSON == "" {
+		return []FiringAlert{}, nil
+	}
+
+	var alerts []FiringAlert
+	if err := json.Unmarshal([]byte(firingJSON), &alerts); err != nil {
+		return nil, fmt.Errorf("failed to parse firing_json: %w", err)
+	}
+
+	return alerts, nil
 }
 
 // commonErrorHandling will take a sdk.APIError and check it on common known errors.

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -499,8 +499,14 @@ func (c *SdkClient) getRawAlertDetails(incidentID string) ([]map[string]interfac
 }
 
 func stringFromDetails(details map[string]interface{}, key string) string {
-	val, _ := details[key].(string)
-	return val
+	raw := details[key]
+	if raw == nil {
+		return ""
+	}
+	if s, ok := raw.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", raw)
 }
 
 // GetAlertContext fetches all PD alerts for an incident once and returns both
@@ -523,14 +529,34 @@ func (c *SdkClient) GetAlertContext(incidentID string) (AlertCustomDetails, *Fir
 
 	firingResult := &FiringAlertsResult{}
 	for _, details := range rawDetails {
-		firingJSON, ok := details["firing_json"].(string)
-		if !ok || firingJSON == "" {
+		raw := details["firing_json"]
+		if raw == nil {
 			continue
 		}
-		parsed, err := ParseFiringJSON(firingJSON)
+
+		var jsonBytes []byte
+		switch v := raw.(type) {
+		case string:
+			if v == "" {
+				continue
+			}
+			jsonBytes = []byte(v)
+		default:
+			// PD deserializes JSON bodies, so firing_json arrives as []interface{} not a string.
+			// Re-marshal to JSON so ParseFiringJSON can unmarshal into typed structs.
+			var marshalErr error
+			jsonBytes, marshalErr = json.Marshal(v)
+			if marshalErr != nil {
+				logging.Warnf("firing_json could not be re-marshaled: %v", marshalErr)
+				firingResult.RawFallbacks = append(firingResult.RawFallbacks, fmt.Sprintf("%v", v))
+				continue
+			}
+		}
+
+		parsed, err := ParseFiringJSON(string(jsonBytes))
 		if err != nil {
 			logging.Warnf("firing_json could not be parsed — saving raw string as fallback: %v", err)
-			firingResult.RawFallbacks = append(firingResult.RawFallbacks, firingJSON)
+			firingResult.RawFallbacks = append(firingResult.RawFallbacks, string(jsonBytes))
 			continue
 		}
 		firingResult.Alerts = append(firingResult.Alerts, parsed...)

--- a/pkg/pagerduty/pagerduty_test.go
+++ b/pkg/pagerduty/pagerduty_test.go
@@ -424,6 +424,215 @@ func TestParseFiringJSON(t *testing.T) {
 	}
 }
 
+// TestParseFiringJSONFromRealPDResponse simulates how PagerDuty's API actually
+// delivers firing_json — as deserialized JSON ([]interface{}) not a string.
+// Test data is from a real ConfigureAlertmanagerOperatorOfflineSRE alert with
+// sensitive fields scrubbed.
+func TestParseFiringJSONFromRealPDResponse(t *testing.T) {
+	// This is what Go's encoding/json produces when it deserializes the PD alert
+	// body — firing_json is []interface{}, num_firing is float64, not strings.
+	scrubbedPDAlertBody := `{
+		"alert_name": "ConfigureAlertmanagerOperatorOfflineSRE",
+		"cluster_id": "test-cluster-id-0000-0000-000000000000",
+		"firing": [
+			{
+				"annotations": {},
+				"endsAt": "0001-01-01T00:00:00Z",
+				"fingerprint": "abc123",
+				"labels": {
+					"alertname": "ConfigureAlertmanagerOperatorOfflineSRE",
+					"namespace": "openshift-monitoring",
+					"openshift_io_alert_source": "platform",
+					"prometheus": "openshift-monitoring/k8s",
+					"service": "configure-alertmanager-operator",
+					"severity": "critical"
+				},
+				"startsAt": "2026-07-23T20:19:08.743Z",
+				"status": "firing"
+			}
+		],
+		"firing_json": [
+			{
+				"annotations": {},
+				"endsAt": "0001-01-01T00:00:00Z",
+				"fingerprint": "abc123",
+				"labels": {
+					"alertname": "ConfigureAlertmanagerOperatorOfflineSRE",
+					"namespace": "openshift-monitoring",
+					"openshift_io_alert_source": "platform",
+					"prometheus": "openshift-monitoring/k8s",
+					"service": "configure-alertmanager-operator",
+					"severity": "critical"
+				},
+				"startsAt": "2026-07-23T20:19:08.743Z",
+				"status": "firing"
+			}
+		],
+		"link": "https://github.com/openshift/ops-sop/tree/master/v4/alerts/ConfigureAlertmanagerOperatorOfflineSRE.md",
+		"num_firing": 1,
+		"num_resolved": 0,
+		"ocm_link": "https://console.redhat.com/openshift/details/test-cluster-id",
+		"region": "us-east-1",
+		"resolved": null
+	}`
+
+	// Deserialize the same way Go's PD SDK does — into map[string]interface{}
+	var details map[string]interface{}
+	if err := json.Unmarshal([]byte(scrubbedPDAlertBody), &details); err != nil {
+		t.Fatalf("Failed to unmarshal test data: %v", err)
+	}
+
+	// Verify firing_json is []interface{}, not string — this is the bug we caught
+	if _, ok := details["firing_json"].(string); ok {
+		t.Fatal("firing_json should be []interface{} after JSON deserialization, not string")
+	}
+	if _, ok := details["firing_json"].([]interface{}); !ok {
+		t.Fatalf("firing_json should be []interface{}, got %T", details["firing_json"])
+	}
+
+	// Verify num_firing is float64, not string
+	if _, ok := details["num_firing"].(string); ok {
+		t.Fatal("num_firing should be float64 after JSON deserialization, not string")
+	}
+
+	// Test stringFromDetails handles numeric values
+	numFiring := stringFromDetails(details, "num_firing")
+	if numFiring != "1" {
+		t.Errorf("stringFromDetails(num_firing) = %q, want \"1\"", numFiring)
+	}
+	numResolved := stringFromDetails(details, "num_resolved")
+	if numResolved != "0" {
+		t.Errorf("stringFromDetails(num_resolved) = %q, want \"0\"", numResolved)
+	}
+
+	// Test stringFromDetails still works for actual strings
+	link := stringFromDetails(details, "link")
+	if link != "https://github.com/openshift/ops-sop/tree/master/v4/alerts/ConfigureAlertmanagerOperatorOfflineSRE.md" {
+		t.Errorf("stringFromDetails(link) = %q, want SOP URL", link)
+	}
+
+	// Test the firing_json extraction path — re-marshal []interface{} then parse
+	raw := details["firing_json"]
+	jsonBytes, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("Failed to re-marshal firing_json: %v", err)
+	}
+
+	alerts, err := ParseFiringJSON(string(jsonBytes))
+	if err != nil {
+		t.Fatalf("ParseFiringJSON failed: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("Expected 1 alert, got %d", len(alerts))
+	}
+
+	alert := alerts[0]
+	if alert.Labels["alertname"] != "ConfigureAlertmanagerOperatorOfflineSRE" {
+		t.Errorf("alertname = %q, want ConfigureAlertmanagerOperatorOfflineSRE", alert.Labels["alertname"])
+	}
+	if alert.Labels["namespace"] != "openshift-monitoring" {
+		t.Errorf("namespace = %q, want openshift-monitoring", alert.Labels["namespace"])
+	}
+	if alert.Labels["severity"] != "critical" {
+		t.Errorf("severity = %q, want critical", alert.Labels["severity"])
+	}
+	if alert.StartsAt != "2026-07-23T20:19:08.743Z" {
+		t.Errorf("startsAt = %q, want 2026-07-23T20:19:08.743Z", alert.StartsAt)
+	}
+}
+
+// TestParseFiringJSONMultiAlertIncident verifies parsing when a single PD
+// incident contains multiple firing alerts with different alertnames — a
+// real-world scenario where alerts group into one incident.
+func TestParseFiringJSONMultiAlertIncident(t *testing.T) {
+	multiAlertDetails := `{
+		"firing_json": [
+			{
+				"labels": {
+					"alertname": "KubePersistentVolumeFillingUp",
+					"namespace": "openshift-monitoring",
+					"persistentvolumeclaim": "prometheus-data-prometheus-k8s-0",
+					"severity": "critical"
+				},
+				"annotations": {
+					"summary": "PersistentVolume is filling up.",
+					"runbook_url": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubePersistentVolumeFillingUp.md"
+				},
+				"startsAt": "2026-07-23T10:00:00.000Z",
+				"status": "firing"
+			},
+			{
+				"labels": {
+					"alertname": "KubePersistentVolumeFillingUp",
+					"namespace": "openshift-monitoring",
+					"persistentvolumeclaim": "prometheus-data-prometheus-k8s-1",
+					"severity": "critical"
+				},
+				"annotations": {
+					"summary": "PersistentVolume is filling up.",
+					"runbook_url": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubePersistentVolumeFillingUp.md"
+				},
+				"startsAt": "2026-07-23T10:01:00.000Z",
+				"status": "firing"
+			},
+			{
+				"labels": {
+					"alertname": "PrometheusRemoteWriteBehind",
+					"namespace": "openshift-monitoring",
+					"severity": "warning"
+				},
+				"annotations": {
+					"summary": "Prometheus remote write is behind.",
+					"runbook_url": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/PrometheusRemoteWriteBehind.md"
+				},
+				"startsAt": "2026-07-23T10:05:00.000Z",
+				"status": "firing"
+			}
+		],
+		"num_firing": 3
+	}`
+
+	var details map[string]interface{}
+	if err := json.Unmarshal([]byte(multiAlertDetails), &details); err != nil {
+		t.Fatalf("Failed to unmarshal test data: %v", err)
+	}
+
+	// Re-marshal the []interface{} back to JSON (simulating the extraction path)
+	jsonBytes, err := json.Marshal(details["firing_json"])
+	if err != nil {
+		t.Fatalf("Failed to re-marshal firing_json: %v", err)
+	}
+
+	alerts, err := ParseFiringJSON(string(jsonBytes))
+	if err != nil {
+		t.Fatalf("ParseFiringJSON failed: %v", err)
+	}
+
+	if len(alerts) != 3 {
+		t.Fatalf("Expected 3 alerts, got %d", len(alerts))
+	}
+
+	// Verify different alertnames are preserved
+	alertNames := map[string]int{}
+	for _, a := range alerts {
+		alertNames[a.Labels["alertname"]]++
+	}
+	if alertNames["KubePersistentVolumeFillingUp"] != 2 {
+		t.Errorf("Expected 2 KubePersistentVolumeFillingUp alerts, got %d", alertNames["KubePersistentVolumeFillingUp"])
+	}
+	if alertNames["PrometheusRemoteWriteBehind"] != 1 {
+		t.Errorf("Expected 1 PrometheusRemoteWriteBehind alert, got %d", alertNames["PrometheusRemoteWriteBehind"])
+	}
+
+	// Verify annotations (including runbook_url) are preserved
+	if alerts[0].Annotations["runbook_url"] != "https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubePersistentVolumeFillingUp.md" {
+		t.Errorf("runbook_url not preserved on first alert")
+	}
+	if alerts[2].Annotations["runbook_url"] != "https://github.com/openshift/ops-sop/blob/master/v4/alerts/PrometheusRemoteWriteBehind.md" {
+		t.Errorf("runbook_url not preserved on third alert")
+	}
+}
+
 func mustMarshal(v interface{}) string {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/pkg/pagerduty/pagerduty_test.go
+++ b/pkg/pagerduty/pagerduty_test.go
@@ -1,9 +1,11 @@
 package pagerduty
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -366,6 +368,69 @@ var _ = Describe("Pagerduty", func() {
 		})
 	})
 })
+
+func TestParseFiringJSON(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedCount int
+		expectErr     bool
+	}{
+		{
+			name:          "single alert",
+			input:         mustMarshal([]FiringAlert{{Labels: map[string]string{"alertname": "KubePersistentVolumeFillingUp", "namespace": "openshift-monitoring", "severity": "critical"}}}),
+			expectedCount: 1,
+		},
+		{
+			name:          "empty string",
+			input:         "",
+			expectedCount: 0,
+		},
+		{
+			name:      "invalid JSON",
+			input:     "not json",
+			expectErr: true,
+		},
+		{
+			name:          "empty array",
+			input:         "[]",
+			expectedCount: 0,
+		},
+		{
+			name:          "multiple firing alerts",
+			input:         mustMarshal([]FiringAlert{{Labels: map[string]string{"alertname": "Alert1", "namespace": "ns1"}}, {Labels: map[string]string{"alertname": "Alert2", "namespace": "ns2"}}}),
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseFiringJSON(tt.input)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if len(result) != tt.expectedCount {
+				t.Errorf("Expected %d alerts, got %d", tt.expectedCount, len(result))
+			}
+		})
+	}
+}
+
+func mustMarshal(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
 
 /*
 these were pulled from https://github.com/PagerDuty/go-pagerduty/blob/c6785b92c2c4e24a0009298ad2b9bc457e6df1e7/client.go, if you need the other functions feel free to re-import them

--- a/pkg/pagerduty/pagerduty_test.go
+++ b/pkg/pagerduty/pagerduty_test.go
@@ -424,11 +424,11 @@ func TestParseFiringJSON(t *testing.T) {
 	}
 }
 
-// TestParseFiringJSONFromRealPDResponse simulates how PagerDuty's API actually
+// TestParseFiringJSONFromPDResponse simulates how PagerDuty's API actually
 // delivers firing_json — as deserialized JSON ([]interface{}) not a string.
-// Test data is from a real ConfigureAlertmanagerOperatorOfflineSRE alert with
-// sensitive fields scrubbed.
-func TestParseFiringJSONFromRealPDResponse(t *testing.T) {
+// Test data is modeled after a ConfigureAlertmanagerOperatorOfflineSRE alert
+// with sensitive fields scrubbed.
+func TestParseFiringJSONFromPDResponse(t *testing.T) {
 	// This is what Go's encoding/json produces when it deserializes the PD alert
 	// body — firing_json is []interface{}, num_firing is float64, not strings.
 	scrubbedPDAlertBody := `{

--- a/pkg/pagerduty/types.go
+++ b/pkg/pagerduty/types.go
@@ -20,3 +20,28 @@ type NewAlert struct {
 	Description string
 	Details     NewAlertCustomDetails
 }
+
+// FiringAlert represents a single firing alert from the firing_json PagerDuty custom detail field.
+type FiringAlert struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	StartsAt    string            `json:"startsAt"`
+	EndsAt      string            `json:"endsAt"`
+}
+
+// FiringAlertsResult holds the result of parsing firing_json from all PD alerts.
+type FiringAlertsResult struct {
+	Alerts       []FiringAlert
+	RawFallbacks []string
+	Partial      bool
+}
+
+// AlertCustomDetails holds the known custom detail fields from a PD alert's Body["details"].
+type AlertCustomDetails struct {
+	Link        string
+	NumFiring   string
+	NumResolved string
+	OCMLink     string
+	Region      string
+	Dashboard   string
+}

--- a/test/generate_camo_style_incident.sh
+++ b/test/generate_camo_style_incident.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -e
+
+# Creates a PD test incident with custom_details matching what CAMO produces,
+# including firing_json, link, num_firing, etc. This exercises the full
+# GetAlertContext → buildInvestigationPayload extraction path in CAD.
+#
+# Usage: ./test/generate_incident_with_alert_context.sh <clusterid>
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <clusterid>"
+    echo "Creates a test incident with CAMO-style custom_details (firing_json, link, etc.)"
+    exit 1
+fi
+
+cluster_id=$1
+alert_name="ConfigureAlertmanagerOperatorOfflineSRE"
+alert_title="${alert_name} CRITICAL (1)"
+time_current=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Load testing routing key and test service url from vault
+export VAULT_ADDR="https://vault.devshift.net"
+export VAULT_TOKEN="$(vault login -method=oidc -token-only)"
+for v in $(vault kv get -format=json osd-sre/configuration-anomaly-detection/cad-testing | jq -r ".data.data|to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]"); do export $v; done
+unset VAULT_ADDR VAULT_TOKEN
+echo
+
+dedup_key=$(uuidgen)
+
+# Build custom_details matching CAMO's Alertmanager template output.
+# firing_json is a JSON array — PD will deserialize it into []interface{},
+# which is the real wire format CAD must handle.
+read -r -d '' custom_details << 'DETAILS' || true
+{
+  "alert_name": "ConfigureAlertmanagerOperatorOfflineSRE",
+  "cluster_id": "CLUSTER_ID_PLACEHOLDER",
+  "link": "https://github.com/openshift/ops-sop/tree/master/v4/alerts/ConfigureAlertmanagerOperatorOfflineSRE.md",
+  "num_firing": 1,
+  "num_resolved": 0,
+  "firing_json": [
+    {
+      "labels": {
+        "alertname": "ConfigureAlertmanagerOperatorOfflineSRE",
+        "namespace": "openshift-monitoring",
+        "openshift_io_alert_source": "platform",
+        "prometheus": "openshift-monitoring/k8s",
+        "service": "configure-alertmanager-operator",
+        "severity": "critical"
+      },
+      "annotations": {
+        "summary": "configure-alertmanager-operator has been offline for more than 15 minutes.",
+        "description": "The configure-alertmanager-operator pod in openshift-monitoring is not running.",
+        "runbook_url": "https://github.com/openshift/ops-sop/tree/master/v4/alerts/ConfigureAlertmanagerOperatorOfflineSRE.md"
+      },
+      "startsAt": "TIMESTAMP_PLACEHOLDER",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "fingerprint": "abc123test",
+      "status": "firing"
+    }
+  ]
+}
+DETAILS
+
+# Substitute placeholders
+custom_details="${custom_details//CLUSTER_ID_PLACEHOLDER/$cluster_id}"
+custom_details="${custom_details//TIMESTAMP_PLACEHOLDER/$time_current}"
+
+echo "Creating incident for $alert_name with CAMO-style custom_details"
+response=$(curl --silent --request POST \
+  --url https://events.pagerduty.com/v2/enqueue \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data "$(jq -n \
+    --arg summary "$alert_title" \
+    --arg timestamp "$time_current" \
+    --arg routing_key "$pd_test_routing_key" \
+    --arg dedup_key "$dedup_key" \
+    --argjson custom_details "$custom_details" \
+    '{
+      payload: {
+        summary: $summary,
+        timestamp: $timestamp,
+        severity: "critical",
+        source: "cad-integration-testing",
+        custom_details: $custom_details
+      },
+      routing_key: $routing_key,
+      event_action: "trigger",
+      dedup_key: $dedup_key
+    }')")
+
+if [[ $response != *"Event processed"* ]]; then
+  echo "Error: Couldn't create the incident"
+  echo "$response"
+  exit 1
+fi
+echo "Incident created"
+echo
+
+# PD needs a moment to create the incident
+sleep 2
+
+INCIDENT_ID=$(curl --silent --request GET \
+  --url "https://api.pagerduty.com/incidents?incident_key=${dedup_key}" \
+  --header 'Accept: application/json' \
+  --header "Authorization: Token token=${pd_test_token}" \
+  --header 'Content-Type: application/json' | jq -r '.incidents[0].id')
+
+echo "Incident ID: $INCIDENT_ID"
+echo '{"__pd_metadata":{"incident":{"id":"'$INCIDENT_ID'"}}}' > ./payload
+echo "Created ./payload"


### PR DESCRIPTION
## Summary
Populates the previously empty `investigation_payload` (`"{}"`) with structured alert data from PagerDuty, enabling Cora to target specific resources instead of scanning all namespaces.

Per review feedback, PD wire-format parsing lives in `pkg/pagerduty` as shared helpers. The `aiassisted` package consumes typed data from the PD client instead of directly accessing raw SDK alert bodies.

## Changes

**`pkg/pagerduty/types.go`**
- `FiringAlert` struct — matches `{{ .Alerts.Firing | toJson }}` (labels, annotations, timestamps)
- `FiringAlertsResult` — bundles parsed alerts, raw fallback strings, and partial-failure flag
- `AlertCustomDetails` — typed struct for known PD custom detail fields (replaces `map[string]interface{}`)

**`pkg/pagerduty/pagerduty.go`**
- `GetAlertContext(incidentID)` on `Client` interface — single API call returns both `AlertCustomDetails` (from first alert) and `*FiringAlertsResult` (from all alerts)
- `ParseFiringJSON()` — exported function, deserializes `firing_json` into `[]FiringAlert`
- `getRawAlertDetails()` — private helper, loops all PD alerts and extracts `Body["details"]`

**`pkg/pagerduty/pagerduty_test.go`**
- `TestParseFiringJSON` — 5 subtests: single alert, empty string, invalid JSON, empty array, multiple alerts

**`pkg/investigations/aiassisted/aiassisted.go`**
- Call site uses `r.PdClient.GetAlertContext()` (through interface) instead of directly accessing alert bodies

**`pkg/investigations/aiassisted/alert_parser.go`**
- `buildInvestigationPayload()` — consumes `*pagerduty.FiringAlertsResult` and `*pagerduty.AlertCustomDetails`, shapes the AI-specific payload

**`pkg/investigations/aiassisted/alert_parser_test.go`**
- `TestPayloadStructure` — firing alerts + typed details, validates payload shape
- `TestPayloadMultiplePDAlerts` — 3 alerts from multiple PD alerts merged
- `TestPayloadPartialFailure` — mix of parsed alerts and raw fallbacks
- `TestPayloadFallbackRawJSON` — total parse failure, raw string preserved
- `TestPayloadWithRealisticPDJSON` — realistic PD alert body with all detail fields
- `TestPayloadNilInputs` — graceful degradation with nil inputs

## Example payload sent to Cora

```json
{
  "investigation_id": "Q3OFA2AM9FYDAB",
  "investigation_payload": {
    "incident_url": "https://redhat.pagerduty.com/incidents/Q3OFA2AM9FYDAB",
    "firing_alerts": [
      {
        "labels": {"alertname": "KubePersistentVolumeFillingUp", "namespace": "openshift-monitoring", "severity": "critical", "persistentvolumeclaim": "prometheus-data-prometheus-k8s-0"},
        "annotations": {"summary": "...", "runbook_url": "https://..."},
        "startsAt": "2026-07-14T10:00:00Z"
      },
      {
        "labels": {"alertname": "KubePersistentVolumeFillingUp", "namespace": "openshift-monitoring", "severity": "critical", "persistentvolumeclaim": "prometheus-data-prometheus-k8s-1"},
        "annotations": {"summary": "...", "runbook_url": "https://..."},
        "startsAt": "2026-07-14T10:05:00Z"
      }
    ],
    "alert_details": {"link": "https://...", "num_firing": "2", "region": "us-west-2"}
  },
  "alert_name": "KubePersistentVolumeFillingUp CRITICAL (2)",
  "cluster_id": "d9045cbe-..."
}
```

## Dependencies

- Requires `firing_json` field from configure-alertmanager-operator — merged in https://github.com/openshift/configure-alertmanager-operator/pull/588, pending promotion

## Related

- Cora prompt update to use `firing_alerts`: https://github.com/openshift-online/rosa-cora-agent/pull/58 (DRAFT)

cc @clcollins @AlexSmithGH