### PR TITLE
Silence etcdDatabaseQuotaLowSpace alerts after CAD investigation

### DIFF
--- a/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace.go
+++ b/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace.go
@@ -215,10 +215,12 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	result.Actions = append(
 		executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
 		backplaneReportAction,
-		resolveOrEscalate(r.PdClient,
-			"etcd warning alert - analysis complete, silencing as compaction/defrag usually resolves this",
-			"etcd critical alert - analysis complete, see report for details"),
 	)
+	if isWarningAlert(r.PdClient) {
+		result.Actions = append(result.Actions, executor.Silence("etcd warning alert - investigation and analysis complete, see report for details"))
+	} else {
+		result.Actions = append(result.Actions, executor.Escalate("etcd critical alert - analysis complete, see report for details"))
+	}
 
 	return result, nil
 }
@@ -351,12 +353,12 @@ func (i *Investigation) runHCPEtcdAnalysis(ctx context.Context, rb investigation
 		Labels:    []string{"success", "completed"},
 	}
 
-	result.Actions = append(
-		executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
-		resolveOrEscalate(r.PdClient,
-			"HCP etcd warning alert - analysis complete, silencing as compaction/defrag usually resolves this",
-			"HCP etcd critical alert - analysis complete, see dynatrace logs for details"),
-	)
+	result.Actions = executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name())
+	if isWarningAlert(r.PdClient) {
+		result.Actions = append(result.Actions, executor.Silence("HCP etcd warning alert - investigation and analysis complete, see report for details"))
+	} else {
+		result.Actions = append(result.Actions, executor.Escalate("HCP etcd critical alert - analysis complete, see dynatrace logs for details"))
+	}
 	return result, nil
 }
 
@@ -377,8 +379,6 @@ func (i *Investigation) IsExperimental() bool {
 }
 
 // isWarningAlert checks if the PagerDuty incident title indicates a warning-severity alert.
-// The title is built from {{ .CommonLabels.severity | toUpper }} in the Alertmanager template,
-// so it preserves the original Prometheus severity even when make-it-critical rewrites the
 // PD event severity field. Warning alerts are silenced after investigation; critical alerts
 // are still escalated to SRE.
 func isWarningAlert(pdClient pagerduty.Client) bool {
@@ -386,14 +386,6 @@ func isWarningAlert(pdClient pagerduty.Client) bool {
 		return false
 	}
 	return strings.Contains(strings.ToUpper(pdClient.GetTitle()), "WARNING")
-}
-
-// resolveOrEscalate returns a Silence action for warning alerts or an Escalate action for critical alerts.
-func resolveOrEscalate(pdClient pagerduty.Client, silenceReason, escalateReason string) types.Action {
-	if isWarningAlert(pdClient) {
-		return executor.Silence(silenceReason)
-	}
-	return executor.Escalate(escalateReason)
 }
 
 // isHCPCluster checks if the cluster is a Hosted Control Plane (HCP) cluster

--- a/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace.go
+++ b/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/metrics"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 )
 
@@ -211,12 +212,12 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		Labels:    []string{"success", "completed"},
 	}
 
-	// Add the backplane report action and note/escalation to the result
-	// The report action will append to notes when executed, then note sends them to PagerDuty
 	result.Actions = append(
 		executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
-		backplaneReportAction, // write a second report here, as this contains the formatted results
-		executor.Escalate("etcd analysis complete - see report for details"),
+		backplaneReportAction,
+		resolveOrEscalate(r.PdClient,
+			"etcd warning alert - analysis complete, silencing as compaction/defrag usually resolves this",
+			"etcd critical alert - analysis complete, see report for details"),
 	)
 
 	return result, nil
@@ -352,7 +353,9 @@ func (i *Investigation) runHCPEtcdAnalysis(ctx context.Context, rb investigation
 
 	result.Actions = append(
 		executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), i.Name()),
-		executor.Escalate("HCP etcd analysis complete - see dynatrace logs for details"),
+		resolveOrEscalate(r.PdClient,
+			"HCP etcd warning alert - analysis complete, silencing as compaction/defrag usually resolves this",
+			"HCP etcd critical alert - analysis complete, see dynatrace logs for details"),
 	)
 	return result, nil
 }
@@ -371,6 +374,26 @@ func (i *Investigation) Description() string {
 
 func (i *Investigation) IsExperimental() bool {
 	return false
+}
+
+// isWarningAlert checks if the PagerDuty incident title indicates a warning-severity alert.
+// The title is built from {{ .CommonLabels.severity | toUpper }} in the Alertmanager template,
+// so it preserves the original Prometheus severity even when make-it-critical rewrites the
+// PD event severity field. Warning alerts are silenced after investigation; critical alerts
+// are still escalated to SRE.
+func isWarningAlert(pdClient pagerduty.Client) bool {
+	if pdClient == nil {
+		return false
+	}
+	return strings.Contains(strings.ToUpper(pdClient.GetTitle()), "WARNING")
+}
+
+// resolveOrEscalate returns a Silence action for warning alerts or an Escalate action for critical alerts.
+func resolveOrEscalate(pdClient pagerduty.Client, silenceReason, escalateReason string) types.Action {
+	if isWarningAlert(pdClient) {
+		return executor.Silence(silenceReason)
+	}
+	return executor.Escalate(escalateReason)
 }
 
 // isHCPCluster checks if the cluster is a Hosted Control Plane (HCP) cluster

--- a/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace_test.go
+++ b/pkg/investigations/etcddatabasequotalowspace/etcddatabasequotalowspace_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +17,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	pdmock "github.com/openshift/configuration-anomaly-detection/pkg/pagerduty/mock"
 )
 
 func TestIsHCPCluster(t *testing.T) {
@@ -92,6 +94,34 @@ func TestInvestigationMethods(t *testing.T) {
 		expected := "Takes etcd snapshots and performs database analysis for etcd quota issues"
 		got := inv.Description()
 		assert.Equal(t, expected, got)
+	})
+}
+
+func TestIsWarningAlert(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	tests := []struct {
+		name     string
+		title    string
+		expected bool
+	}{
+		{"warning in title", "etcdDatabaseQuotaLowSpace WARNING (1)", true},
+		{"critical in title", "etcdDatabaseQuotaLowSpace CRITICAL (1)", false},
+		{"lowercase warning", "etcdDatabaseQuotaLowSpace warning (1)", true},
+		{"no severity in title", "etcdDatabaseQuotaLowSpace (1)", false},
+		{"empty title", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockPD := pdmock.NewMockClient(ctrl)
+			mockPD.EXPECT().GetTitle().Return(tt.title)
+			assert.Equal(t, tt.expected, isWarningAlert(mockPD))
+		})
+	}
+
+	t.Run("nil pd client", func(t *testing.T) {
+		assert.False(t, isWarningAlert(nil))
 	})
 }
 
@@ -213,33 +243,20 @@ func TestGetEtcdctlContainerImage(t *testing.T) {
 	}
 }
 
-func TestRunHCPEtcdAnalysis_Success(t *testing.T) {
-	cluster, _ := cmv1.NewCluster().
-		ID("test-cluster-id").
-		ExternalID("external-cluster-id").
-		Hypershift(cmv1.NewHypershift().Enabled(true)).
-		Build()
+func setupHCPAnalysisTest(t *testing.T) (*corev1.Pod, client.WithWatch, context.Context) {
+	t.Helper()
 
 	etcdPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "etcd-0",
 			Namespace: "ocm-test-namespace",
-			Labels: map[string]string{
-				"k8s-app": "etcd",
-			},
+			Labels:    map[string]string{"k8s-app": "etcd"},
 		},
 		Spec: corev1.PodSpec{
-			NodeName: "test-node",
-			InitContainers: []corev1.Container{
-				{
-					Name:  "reset-member",
-					Image: "quay.io/openshift/etcd:v4.15",
-				},
-			},
+			NodeName:       "test-node",
+			InitContainers: []corev1.Container{{Name: "reset-member", Image: "quay.io/openshift/etcd:v4.15"}},
 		},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 
 	fakeK8s := fake.NewClientBuilder().
@@ -252,7 +269,6 @@ func TestRunHCPEtcdAnalysis_Success(t *testing.T) {
 	go func() {
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
-
 		for {
 			select {
 			case <-ctx.Done():
@@ -262,11 +278,9 @@ func TestRunHCPEtcdAnalysis_Success(t *testing.T) {
 				if err := fakeK8s.List(ctx, jobList, client.InNamespace("ocm-test-namespace")); err != nil {
 					continue
 				}
-
 				for i := range jobList.Items {
 					job := &jobList.Items[i]
 					if job.Status.Succeeded == 0 {
-						// Mark job as succeeded
 						job.Status.Succeeded = 1
 						_ = fakeK8s.Status().Update(ctx, job)
 					}
@@ -274,6 +288,22 @@ func TestRunHCPEtcdAnalysis_Success(t *testing.T) {
 			}
 		}
 	}()
+
+	return etcdPod, fakeK8s, ctx
+}
+
+func TestRunHCPEtcdAnalysis_WarningAlertSilenced(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockPD := pdmock.NewMockClient(ctrl)
+	mockPD.EXPECT().GetTitle().Return("etcdDatabaseQuotaLowSpace WARNING (1)").AnyTimes()
+
+	cluster, _ := cmv1.NewCluster().
+		ID("test-cluster-id").
+		ExternalID("external-cluster-id").
+		Hypershift(cmv1.NewHypershift().Enabled(true)).
+		Build()
+
+	_, fakeK8s, ctx := setupHCPAnalysisTest(t)
 
 	rb := &investigation.ResourceBuilderMock{
 		Resources: &investigation.Resources{
@@ -283,6 +313,7 @@ func TestRunHCPEtcdAnalysis_Success(t *testing.T) {
 			ManagementClusterName:         "test-management-cluster",
 			DynatraceManagementClusterURL: "https://hrm15629.apps.dynatrace.com/",
 			Notes:                         notewriter.New("etcddatabasequotalowspace_test", logging.RawLogger),
+			PdClient:                      mockPD,
 		},
 	}
 
@@ -292,16 +323,47 @@ func TestRunHCPEtcdAnalysis_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, result.EtcdDatabaseAnalysis.Performed)
 	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "success")
-	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "completed")
-	assert.Len(t, result.Actions, 3) // NoteAndReportFrom (2 actions) + Escalate (1 action)
+	assert.Len(t, result.Actions, 3) // NoteAndReportFrom (2 actions) + Silence (1 action)
+	assert.Equal(t, "silence_incident", result.Actions[2].Type())
 
-	// Verify Dynatrace URL appears in notes
 	notesContent := rb.Resources.Notes.String()
 	assert.Contains(t, notesContent, "Dynatrace Logs:")
-	assert.Contains(t, notesContent, "https://hrm15629.apps.dynatrace.com/")
-	assert.Contains(t, notesContent, "ui/apps/dynatrace.logs/#")
-	assert.Contains(t, notesContent, "ocm-test-namespace")
-	assert.Contains(t, notesContent, "etcd-analysis-") // Job name prefix
+	assert.Contains(t, notesContent, "etcd-analysis-")
+}
+
+func TestRunHCPEtcdAnalysis_CriticalAlertEscalated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockPD := pdmock.NewMockClient(ctrl)
+	mockPD.EXPECT().GetTitle().Return("etcdDatabaseQuotaLowSpace CRITICAL (1)").AnyTimes()
+
+	cluster, _ := cmv1.NewCluster().
+		ID("test-cluster-id").
+		ExternalID("external-cluster-id").
+		Hypershift(cmv1.NewHypershift().Enabled(true)).
+		Build()
+
+	_, fakeK8s, ctx := setupHCPAnalysisTest(t)
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			Cluster:                       cluster,
+			ManagementK8sClient:           fakeK8s,
+			HCPNamespace:                  "ocm-test-namespace",
+			ManagementClusterName:         "test-management-cluster",
+			DynatraceManagementClusterURL: "https://hrm15629.apps.dynatrace.com/",
+			Notes:                         notewriter.New("etcddatabasequotalowspace_test", logging.RawLogger),
+			PdClient:                      mockPD,
+		},
+	}
+
+	inv := &Investigation{}
+	result, err := inv.runHCPEtcdAnalysis(ctx, rb)
+
+	assert.NoError(t, err)
+	assert.True(t, result.EtcdDatabaseAnalysis.Performed)
+	assert.Contains(t, result.EtcdDatabaseAnalysis.Labels, "success")
+	assert.Len(t, result.Actions, 3) // NoteAndReportFrom (2 actions) + Escalate (1 action)
+	assert.Equal(t, "escalate_incident", result.Actions[2].Type())
 }
 
 func TestRunHCPEtcdAnalysis_NoEtcdPod(t *testing.T) {

--- a/pkg/pagerduty/mock/pagerdutymock.go
+++ b/pkg/pagerduty/mock/pagerdutymock.go
@@ -19,7 +19,6 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
-	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.


### PR DESCRIPTION
Most etcdDatabaseQuotaLowSpace alerts resolve with compaction/defrag and don't need SRE attention. Replace Escalate with Silence on success paths.

https://redhat.atlassian.net/browse/ROSAENG-61489

### What type of PR is this?

feature

### What this PR does / Why we need it?
SRE is being unnecessarily pinged on primary on call for etcdDatabaseQuotaLowSpace alerts. CAD handles the investigation already and creates the cluster report. Once that's done, we can just move it to silent test.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warning-level etcd quota alerts are now silenced after the investigation completes.
  * Critical alerts still escalate, with guidance tailored to the critical case.
  * HCP-specific investigations apply the same warning-versus-critical alert handling.
* **Tests**
  * Added unit coverage for severity/title detection and verifies the expected PagerDuty action sequence for both warning and critical paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->