### PR TITLE
Add network policy for interceptor.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -27,6 +27,31 @@ parameters:
 - name: CAD_SA_ROLE_ARN
   value: ""
 objects:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: cad-interceptor-network-policy
+  spec:
+    podSelector:
+      matchLabels:
+        app: cad-interceptor
+    policyTypes:
+    - Ingress
+    ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            eventlistener: cad-event-listener
+      ports:
+      - protocol: TCP
+        port: 8080
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+      - protocol: TCP
+        port: 8080
 - apiVersion: apps/v1
   kind: Deployment
   metadata:


### PR DESCRIPTION
Only traffic from the event listener should be able to reach our interceptor.

### What type of PR is this?

feature

### What this PR does / Why we need it?

Minor update to our deployment so the interceptor only accepts traffic from the event-listener. No other service really needs to reach that service.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network access controls for the CAD interceptor.
  * Restricted incoming TCP traffic on port 8080 to the designated event listener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->