### PR TITLE
Ensure PD_SIGNATURE is set in main and pass it down.

### DIFF
--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -37,11 +37,16 @@ func init() {
 func main() {
 	logger := logging.InitLogger(logLevelEnv, pipelineNameEnv, "")
 
+	token := os.Getenv("PD_SIGNATURE")
+	if token == "" {
+		logger.Fatal("PD_SIGNATURE environment variable missing")
+	}
+
 	// set up signals so we handle the first shutdown signal gracefully
 	ctx := signals.NewContext()
 
 	mux := http.NewServeMux()
-	mux.Handle("/", interceptor.CreateInterceptorHandler())
+	mux.Handle("/", interceptor.CreateInterceptorHandler(token))
 	mux.HandleFunc("/ready", readinessHandler)
 	mux.Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{Registry: metrics.Registry}))
 

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -57,10 +57,12 @@ type Organization struct {
 	EscalationPolicy string   `json:"escalation_policy"`
 }
 
-type interceptorHandler struct{}
+type interceptorHandler struct {
+	PDToken string
+}
 
-func CreateInterceptorHandler() http.Handler {
-	return &interceptorHandler{}
+func CreateInterceptorHandler(pdToken string) http.Handler {
+	return &interceptorHandler{PDToken: pdToken}
 }
 
 func (pdi interceptorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -135,8 +137,7 @@ func (pdi *interceptorHandler) executeInterceptor(r *http.Request) ([]byte, *htt
 
 	logging.Debug("Unwrapped Request body: ", originalReq.Body)
 
-	token, _ := os.LookupEnv("PD_SIGNATURE")
-	err = webhookv3.VerifySignature(extractedRequest, token)
+	err = webhookv3.VerifySignature(extractedRequest, pdi.PDToken)
 	if err != nil {
 		return nil, pdi.badRequest("failed to verify signature", err)
 	}


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Currently the signature was retrieved again and again, but never checked to be actually present.

Instead retrieve it once and make sure it is set.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure validation of incoming interceptor requests using a PagerDuty signature token.
  * The service now consistently applies the configured signature token when handling requests.

* **Bug Fixes**
  * Improved startup validation by failing fast with a clear error if the required `PD_SIGNATURE` setting is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->