### PR TITLE
Limit interceptor request body to 5 MiB to prevent memory exhaustion

### DIFF
--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -105,12 +105,14 @@ func (pdi *interceptorHandler) executeInterceptor(r *http.Request) ([]byte, *htt
 	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
 	defer cancel()
 
-	var body bytes.Buffer
-	defer r.Body.Close() //nolint:errcheck
-	if _, err := io.Copy(&body, r.Body); err != nil {
+	const maxBodyBytes = 5 * 1024 * 1024 // 5 MiB
+	bodyBytes, err := io.ReadAll(io.LimitReader(r.Body, int64(maxBodyBytes)+1))
+	if err != nil {
 		return nil, pdi.internal("failed to read body", err)
 	}
-	r.Body = io.NopCloser(bytes.NewReader(body.Bytes()))
+	if len(bodyBytes) > maxBodyBytes {
+		return nil, pdi.httpError(http.StatusRequestEntityTooLarge, "request body too large", fmt.Errorf("exceeds %d bytes", maxBodyBytes))
+	}
 
 	// originalReq is the original request that was sent to the interceptor,
 	// due to be unwrapped into a new header and body for signature verification.
@@ -118,7 +120,7 @@ func (pdi *interceptorHandler) executeInterceptor(r *http.Request) ([]byte, *htt
 		Body   string              `json:"body"`
 		Header map[string][]string `json:"header"`
 	}
-	if err := json.Unmarshal(body.Bytes(), &originalReq); err != nil {
+	if err := json.Unmarshal(bodyBytes, &originalReq); err != nil {
 		return nil, pdi.badRequest("failed to parse body", err)
 	}
 
@@ -144,7 +146,7 @@ func (pdi *interceptorHandler) executeInterceptor(r *http.Request) ([]byte, *htt
 
 	logging.Info("Signature verified successfully")
 
-	if err := json.Unmarshal(body.Bytes(), &ireq); err != nil {
+	if err := json.Unmarshal(bodyBytes, &ireq); err != nil {
 		return nil, pdi.badRequest("failed to parse body as InterceptorRequest", err)
 	}
 	logging.Debugf("Interceptor request body is: %s", ireq.Body)

--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -1,7 +1,10 @@
 package interceptor
 
 import (
+	"bytes"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -213,6 +216,19 @@ func stringContains(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestOversizedRequestBodyIsRejected(t *testing.T) {
+	oversizedBody := bytes.Repeat([]byte("A"), 10*1024*1024) // 10 MiB
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(oversizedBody))
+	rec := httptest.NewRecorder()
+
+	handler := CreateInterceptorHandler("TEST")
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected status 413 for oversized body, got %d: %s", rec.Code, rec.Body.String())
+	}
 }
 
 func TestShouldRunAIInvestigation(t *testing.T) {


### PR DESCRIPTION
Replace unbounded io.Copy with io.LimitReader to reject oversized request bodies before parsing or signature verification.

### What type of PR is this?

bug


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against oversized request bodies.
  * Requests exceeding 5 MiB are now rejected with a clear “413 Request Entity Too Large” response.
  * Improved handling of request body read failures to return an internal error instead of processing incomplete data.

* **Tests**
  * Added coverage verifying that oversized requests are rejected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->