### PR TITLE
base64-encode the test payload

### DIFF
--- a/test/generate_incident.sh
+++ b/test/generate_incident.sh
@@ -94,5 +94,5 @@ INCIDENT_ID=$(curl --silent --request GET \
   --header "Authorization: Token token=${pd_test_token}" \
   --header 'Content-Type: application/json' | jq -r '.incidents[0].id')
 echo $INCIDENT_ID
-echo '{"__pd_metadata":{"incident":{"id":"'$INCIDENT_ID'"}}}' > ./payload
+echo '{"__pd_metadata":{"incident":{"id":"'$INCIDENT_ID'"}}}' | base64 > ./payload
 echo "Created ./payload"


### PR DESCRIPTION
### What type of PR is this?

Base64-encode the test payload.

9c4ffee introduced base64-encoding of the PD webhook payload. As such, local testing fails unless the test payload is also base64-encoded:

```bash
$ ./bin/cadctl investigate --payload-path payload --config test-investigation-config.yaml
Error: failed to base64-decode webhook payload: illegal base64 data at input byte 0
```

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated incident payload output to use base64-encoded metadata for improved compatibility with downstream processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->