### PR TITLE
[ROSAENG-63126] Add support for multiple signatures to the interceptor.

### DIFF
--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -37,16 +39,16 @@ func init() {
 func main() {
 	logger := logging.InitLogger(logLevelEnv, pipelineNameEnv, "")
 
-	token := os.Getenv("PD_SIGNATURE")
-	if token == "" {
-		logger.Fatal("PD_SIGNATURE environment variable missing")
+	signatures, err := loadPDSignatures()
+	if err != nil {
+		logger.Fatal("failed to load PD signatures: %v", err)
 	}
 
 	// set up signals so we handle the first shutdown signal gracefully
 	ctx := signals.NewContext()
 
 	mux := http.NewServeMux()
-	mux.Handle("/", interceptor.CreateInterceptorHandler(token))
+	mux.Handle("/", interceptor.CreateInterceptorHandler(signatures))
 	mux.HandleFunc("/ready", readinessHandler)
 	mux.Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{Registry: metrics.Registry}))
 
@@ -90,4 +92,17 @@ func main() {
 
 func readinessHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
+}
+
+func loadPDSignatures() ([]string, error) {
+	var signatures []string
+	tokens := os.Getenv("PD_SIGNATURE")
+	if tokens == "" {
+		return signatures, errors.New("PD_SIGNATURE environment variable missing")
+	}
+	for _, sig := range strings.Split(tokens, ",") {
+		trim := strings.TrimSpace(sig)
+		signatures = append(signatures, trim)
+	}
+	return signatures, nil
 }

--- a/interceptor/main_test.go
+++ b/interceptor/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestLoadPDSignatures(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVar   string
+		wantErr  bool
+		wantSigs []string // every entry must appear in the returned slice
+	}{
+		{
+			name:    "empty env var returns an error",
+			envVar:  "",
+			wantErr: true,
+		},
+		{
+			name:     "single signature is loaded",
+			envVar:   "secret-one",
+			wantSigs: []string{"secret-one"},
+		},
+		{
+			name:     "two comma-separated signatures are both loaded",
+			envVar:   "secret-one,secret-two",
+			wantSigs: []string{"secret-one", "secret-two"},
+		},
+		{
+			name:     "two comma-separated signatures are both loaded even with extra whitespace",
+			envVar:   " secret-one , secret-two ",
+			wantSigs: []string{"secret-one", "secret-two"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PD_SIGNATURE", tt.envVar)
+
+			sigs, err := loadPDSignatures()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, want := range tt.wantSigs {
+				if !slices.Contains(sigs, want) {
+					t.Errorf("signature %q not found in result %v", want, sigs)
+				}
+			}
+		})
+	}
+}

--- a/interceptor/pkg/interceptor/pdinterceptor.go
+++ b/interceptor/pkg/interceptor/pdinterceptor.go
@@ -58,11 +58,11 @@ type Organization struct {
 }
 
 type interceptorHandler struct {
-	PDToken string
+	PDTokens []string
 }
 
-func CreateInterceptorHandler(pdToken string) http.Handler {
-	return &interceptorHandler{PDToken: pdToken}
+func CreateInterceptorHandler(pdTokens []string) http.Handler {
+	return &interceptorHandler{PDTokens: pdTokens}
 }
 
 func (pdi interceptorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -139,9 +139,18 @@ func (pdi *interceptorHandler) executeInterceptor(r *http.Request) ([]byte, *htt
 
 	logging.Debug("Unwrapped Request body: ", originalReq.Body)
 
-	err = webhookv3.VerifySignature(extractedRequest, pdi.PDToken)
-	if err != nil {
-		return nil, pdi.badRequest("failed to verify signature", err)
+	var sigErrs []error
+	for _, signature := range pdi.PDTokens {
+		err = webhookv3.VerifySignature(extractedRequest, signature)
+		if err != nil {
+			sigErrs = append(sigErrs, err)
+		} else {
+			// A signature successfully verified we can continue
+			break
+		}
+	}
+	if len(sigErrs) == len(pdi.PDTokens) {
+		return nil, pdi.badRequest("failed to verify signature against all signatures", errors.Join(sigErrs...))
 	}
 
 	logging.Info("Signature verified successfully")

--- a/interceptor/pkg/interceptor/pdinterceptor_test.go
+++ b/interceptor/pkg/interceptor/pdinterceptor_test.go
@@ -2,6 +2,10 @@ package interceptor
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -223,11 +227,137 @@ func TestOversizedRequestBodyIsRejected(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(oversizedBody))
 	rec := httptest.NewRecorder()
 
-	handler := CreateInterceptorHandler("TEST")
+	handler := CreateInterceptorHandler([]string{"TEST"})
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusRequestEntityTooLarge {
 		t.Errorf("expected status 413 for oversized body, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// pdSignatureFor computes the HMAC-SHA256 signature for a PagerDuty v3 webhook
+// body, returning it in the "v1=<hex>" format expected by X-PagerDuty-Signature.
+func pdSignatureFor(secret, body string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(body))
+	return "v1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// makeSignedRequest builds an interceptor HTTP request whose body is the
+// double-wrapped JSON that executeInterceptor expects:
+//
+//	{ "body": "<innerBody>", "header": { "X-PagerDuty-Signature": ["v1=<hmac>"] } }
+//
+// The HMAC is computed over innerBody using signingSecret, exactly as
+// webhookv3.VerifySignature validates incoming PagerDuty webhooks.
+func makeSignedRequest(t *testing.T, innerBody, signingSecret string) *http.Request {
+	t.Helper()
+	sig := pdSignatureFor(signingSecret, innerBody)
+
+	outer, err := json.Marshal(map[string]interface{}{
+		"body": innerBody,
+		"header": map[string][]string{
+			"X-PagerDuty-Signature": {sig},
+		},
+	})
+	if err != nil {
+		t.Fatalf("makeSignedRequest: marshal: %v", err)
+	}
+	return httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(outer))
+}
+
+// TestSignatureVerification covers the multiple-signature verification loop.
+//
+// Key behaviours under test:
+//   - Backwards compat: a single token still works exactly as before.
+//   - Any-one-wins: a request signed by any one of the configured tokens is
+//     accepted, even if other tokens don't match.
+//   - All-must-fail: a request is rejected only when every configured token
+//     fails to verify the signature.
+//   - Empty list: a handler with no tokens configured always rejects.
+//
+// A valid signature causes executeInterceptor to proceed past the 400-returning
+// guard and into process(), which always returns an InterceptorResponse (HTTP
+// 200). An invalid signature is caught before that and returns HTTP 400 with
+// "signature" in the body. This gives a clean binary signal for each case.
+//
+// Note: webhookv3.VerifySignature restores r.Body after reading it, so
+// iterating the same extractedRequest over multiple tokens is safe.
+func TestSignatureVerification(t *testing.T) {
+	const (
+		secret1   = "signing-secret-one"
+		secret2   = "signing-secret-two"
+		innerBody = `{"__pd_metadata":{"incident":{"id":"QTEST1"}}}`
+	)
+
+	tests := []struct {
+		name             string
+		tokens           []string
+		signingSecret    string // secret used to sign the outgoing request
+		wantStatus       int
+		wantBodyContains string // substring that must appear in the response on failure
+	}{
+		// Backwards-compatibility: existing single-token deployments must still work.
+		{
+			name:          "single valid token — request accepted",
+			tokens:        []string{secret1},
+			signingSecret: secret1,
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:             "single invalid token — request rejected",
+			tokens:           []string{"wrong-secret"},
+			signingSecret:    secret1,
+			wantStatus:       http.StatusBadRequest,
+			wantBodyContains: "signature",
+		},
+		// Multi-token: accepted when the first configured token matches.
+		{
+			name:          "multiple tokens, first matches — request accepted",
+			tokens:        []string{secret1, secret2},
+			signingSecret: secret1,
+			wantStatus:    http.StatusOK,
+		},
+		// Multi-token: accepted when the second configured token matches (first fails).
+		// This is the core new behaviour: the loop must continue past the first failure.
+		{
+			name:          "multiple tokens, second matches — request accepted",
+			tokens:        []string{secret2, secret1},
+			signingSecret: secret1,
+			wantStatus:    http.StatusOK,
+		},
+		// Multi-token: rejected only when every token fails.
+		{
+			name:             "multiple tokens, none match — request rejected",
+			tokens:           []string{"wrong-one", "wrong-two"},
+			signingSecret:    secret1,
+			wantStatus:       http.StatusBadRequest,
+			wantBodyContains: "signature",
+		},
+		// Edge case: no tokens configured — nothing can ever verify, reject all.
+		{
+			name:             "empty token list — request rejected",
+			tokens:           []string{},
+			signingSecret:    secret1,
+			wantStatus:       http.StatusBadRequest,
+			wantBodyContains: "signature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := makeSignedRequest(t, innerBody, tt.signingSecret)
+			rec := httptest.NewRecorder()
+
+			CreateInterceptorHandler(tt.tokens).ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if tt.wantBodyContains != "" && !stringContains(rec.Body.String(), tt.wantBodyContains) {
+				t.Errorf("body = %q, want it to contain %q", rec.Body.String(), tt.wantBodyContains)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
As the webhook might be called from multiple sources the interceptor should be able to verify against a set of signatures not just one.

### What type of PR is this?

feature

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [X] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple PagerDuty webhook signatures using comma-separated values.
  * Incoming webhook requests are accepted when signed with any configured signature.
  * Whitespace around configured signatures is handled automatically.

* **Bug Fixes**
  * Improved signature verification and rejection of requests with invalid signatures.
  * Startup now reports an error when the required signature configuration is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->