### PR TITLE
More errors and logging for ID extraction.

### DIFF
--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -430,13 +430,16 @@ func extractClusterIDFromAlertBody(data map[string]interface{}) (string, error) 
 	for _, extractor := range extractors {
 		id, err := extractor(details)
 		if err != nil {
+			logging.Info("failed to extract cluster id (continuing): %s", err)
 			errs = append(errs, err)
 		}
 		if id != "" {
 			return id, nil
 		}
 	}
-	return "", errors.Join(errs...)
+	mergedErr := errors.Join(errs...)
+	logging.Info("failed to extract cluster id ( terminally ): %s", mergedErr)
+	return "", mergedErr
 }
 
 // PARSE OPTION 1 (new format): cluster_id directly contained in custom details
@@ -447,7 +450,7 @@ func parseClusterIdFromField(details map[string]interface{}) (string, error) {
 	} else {
 		return clusterID, nil
 	}
-	return "", nil
+	return "", errors.New("'cluster_id' field not found")
 }
 
 // PARSE OPTION 2 (old format: OSD-18006): cluster_id contained in custom_details[notes]
@@ -459,7 +462,7 @@ func parseClusterIdFromField(details map[string]interface{}) (string, error) {
 func parseClusterIdFromNotes(details map[string]interface{}) (string, error) {
 	notes, found := details["notes"].(string)
 	if !found {
-		return "", nil
+		return "", errors.New("'notes' field not found")
 	}
 	logging.Warn("Trying to parse cluster_id from the notes field...")
 	var notesUnmarshalled notesData

--- a/pkg/pagerduty/pagerduty_test.go
+++ b/pkg/pagerduty/pagerduty_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -400,6 +401,22 @@ var _ = Describe("Pagerduty", func() {
 
 					_, err := p.RetrieveClusterID()
 					Expect(err).Should(HaveOccurred())
+				})
+			})
+
+			When("the payload is a real-world alert exported from PagerDuty (testdata/alert.json)", func() {
+				It("should succeed and pull the clusterID", func() {
+					// Arrange
+					alertJSON, err := os.ReadFile("testdata/alert.json")
+					Expect(err).ShouldNot(HaveOccurred())
+					mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {
+						_, _ = fmt.Fprintf(w, `{"alerts":%s}`, alertJSON)
+					})
+					// Act
+					res, err := p.RetrieveClusterID()
+					// Assert
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(res).Should(Equal("my-test-cluster-id"))
 				})
 			})
 		})

--- a/pkg/pagerduty/testdata/alert.json
+++ b/pkg/pagerduty/testdata/alert.json
@@ -1,0 +1,29 @@
+
+[
+  {
+    "id": "test",
+    "status": "resolved",
+    "type": "alert",
+    "self": "https://api.pagerduty.com/alerts/Q3ES7YLSVBOMTB",
+    "service": {
+      "id": "test",
+      "type": "service_reference",
+      "self": "https://api.pagerduty.com/services/test",
+      "summary": "CAD Event Based Automation",
+      "html_url": "https://my.pagerduty.com/service-directory/test"
+    },
+    "body": {
+      "type": "alert_body",
+      "details": {
+        "alert_name": "CreateMustGather",
+        "cluster_id": "my-test-cluster-id",
+        "firing": "",
+        "link": "",
+        "num_firing": "1",
+        "num_resolved": "0",
+        "region": "us-east-1",
+        "resolved": ""
+      }
+    }
+  }
+]


### PR DESCRIPTION
Add test case for failing prod alert.

### What type of PR is this?

bug

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [x] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster ID extraction when alert fields are missing or incomplete.
  * Reports detailed parsing failures when no supported extraction method succeeds.
  * Prevents missing cluster IDs or notes from being treated as successful empty results.

* **Tests**
  * Added coverage for extracting a cluster ID from a PagerDuty alert response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->