### PR TITLE
Fix: escalate when fallback ai-assisted investigation is filtered out

### DIFF
--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -75,7 +75,9 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 			AlertTitle:  alertTitle,
 			ServiceName: c.pdClient.GetServiceName(),
 		}
-		return c.runChain(ctx, clusterID, alertConfig, filterCtx, nil)
+		if err := c.runChain(ctx, clusterID, alertConfig, filterCtx, nil); err != nil {
+			return err
+		}
 	}
 
 	if escErr := c.pdClient.EscalateIncident(); escErr != nil {


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incident escalation now proceeds after a successful AI fallback investigation.
  * Investigation errors continue to be reported without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->