### PR TITLE
Make GetAlert case-insensitive to prevent alert title mismatches

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -110,13 +110,15 @@ func ParseConfig(data []byte, validInvestigations []string) (*Config, error) {
 }
 
 // GetAlert returns the first AlertConfig whose AlertTitle is contained in the given alert title.
+// The match is case-insensitive to prevent mismatches between config values and PagerDuty titles.
 // Alerts marked experimental are only returned when experimentalEnabled is true.
 func (c *Config) GetAlert(alertTitle string, experimentalEnabled bool) *AlertConfig {
 	if c == nil {
 		return nil
 	}
+	alertTitleLower := strings.ToLower(alertTitle)
 	for i := range c.Alerts {
-		if strings.Contains(alertTitle, c.Alerts[i].AlertTitle) {
+		if strings.Contains(alertTitleLower, strings.ToLower(c.Alerts[i].AlertTitle)) {
 			if c.Alerts[i].Experimental && !experimentalEnabled {
 				continue
 			}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -572,6 +572,16 @@ alerts:
 		t.Fatal("expected chain for experimental alert with experimental=true")
 	}
 
+	// Case-insensitive match: config has "has gone missing" (lowercase),
+	// PD title has "Has Gone Missing" (mixed case).
+	ic = cfg.GetAlert("Cluster xyz Has Gone Missing", false)
+	if ic == nil {
+		t.Fatal("expected case-insensitive match for 'Has Gone Missing'")
+	}
+	if ic.AlertTitle != "has gone missing" {
+		t.Errorf("AlertTitle = %q, want 'has gone missing'", ic.AlertTitle)
+	}
+
 	// Nil config returns nil.
 	var nilCfg *Config
 	ic = nilCfg.GetAlert("has gone missing", false)


### PR DESCRIPTION
## Problem

The alert title matching in `GetAlert()` (`pkg/config/config.go:119`) used case-sensitive `strings.Contains`, which caused the `consoleerrorbudgetburn` investigation to **not fire** when the config had `alert_title: "console-errorbudgetburn"` but PagerDuty sent `"console-ErrorBudgetBurn"`.

Because no config entry matched, the AI fallback (CORA) ran instead of the traditional investigation chain (`precheck → ccam → expiredcertificates → consoleerrorbudgetburn`).

## Fix

Changed `GetAlert()` to use case-insensitive substring matching via `strings.ToLower()` on both the incoming alert title and each config entry's `AlertTitle`.

## Impact

Only `consoleerrorbudgetburn` was affected in the e2e config — all other `alert_title` entries already use exact casing that matches their PagerDuty titles. This fix prevents this class of bug for all current and future alerts.

## Testing

Added a case-insensitive match test to `TestGetAlert` that verifies a config entry with lowercase text matches a PD title with mixed case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert matching is now case-insensitive and supports configured titles appearing within alert titles.
  * Existing behavior for experimental alerts, missing configuration, and first-match selection remains unchanged.

* **Tests**
  * Added coverage for case-insensitive alert matching while preserving the configured title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->