### PR TITLE
ROSAENG-65741: increase investigation pod memory

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,7 +20,7 @@ ARG OC_VERSION=4.22.6
 ARG OC_HASH=3bbf6bdf7e8fd7ea1a18c6ff9454cfaed29e64e55af0d080d7d260418ffce16b
 
 RUN microdnf update -y && \
-    microdnf install wget tar gzip -y
+    microdnf install wget tar gzip rsync -y
 RUN wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux-${OC_VERSION}.tar.gz -O /tmp/oc.tar.gz && \
     echo "${OC_HASH} /tmp/oc.tar.gz" | sha256sum --check --status && \
     tar -zxvf /tmp/oc.tar.gz -C /tmp && \

--- a/examples/manual-investigation-pipelinerun.yaml
+++ b/examples/manual-investigation-pipelinerun.yaml
@@ -38,9 +38,9 @@ spec:
   - computeResources:
       limits:
         cpu: 500m
-        memory: 256Mi
+        memory: 512Mi
       requests:
         cpu: 100m
-        memory: 64Mi
+        memory: 256Mi
     pipelineTaskName: run-manual-investigation
   timeout: 30m

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -195,10 +195,10 @@ objects:
         - computeResources:
             limits:
               cpu: 500m
-              memory: 256Mi
+              memory: 512Mi
             requests:
               cpu: 100m
-              memory: 64Mi
+              memory: 256Mi
           pipelineTaskName: perform-cad-checks
         timeout: 30m
 - apiVersion: triggers.tekton.dev/v1beta1
@@ -437,10 +437,10 @@ objects:
       resources:
         limits:
           cpu: 100m
-          memory: 256Mi
+          memory: 512Mi
         requests:
           cpu: 20m
-          memory: 128Mi
+          memory: 256Mi
       volumeMounts:
       - name: cad-config
         mountPath: /config
@@ -508,10 +508,10 @@ objects:
       resources:
         limits:
           cpu: 100m
-          memory: 256Mi
+          memory: 512Mi
         requests:
           cpu: 20m
-          memory: 128Mi
+          memory: 256Mi
       volumeMounts:
       - name: cad-config
         mountPath: /config


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

 - Increase memory limits from 256Mi to 512Mi and requests from 128Mi/64Mi to 256Mi for investigation task pods
 - Applies to webhook-triggered runs (TriggerTemplate taskRunSpecs), cad-checks task, and cad-manual-investigation task
 - Install rsync in investigation pod images

Fixes [ROSAENG-65741](https://redhat.atlassian.net/browse/ROSAENG-65741)

[ROSAENG-65741]: https://redhat.atlassian.net/browse/ROSAENG-65741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased memory allocations for CAD pipeline checks, manual investigations, and CAD check triggers to improve resource availability and reliability.
  * Updated manual investigation examples to reflect the new resource allocations.
  * Added `rsync` support to the pipeline runner environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->