### PR TITLE
ROSAENG-65920: Add PagerDuty note when an investigation is filtered a…

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -372,6 +372,9 @@ func (c *investigationRunner) runChain(
 			if !pass {
 				logging.Infof("Entry %q filtered out: %s", entry.Name, reason)
 				metrics.Inc(metrics.AlertsFiltered, entry.Name)
+				if err := c.notifier.AddNote(fmt.Sprintf("🤖 Investigation %q was filtered out by configuration: %s 🤖", entry.Name, reason)); err != nil {
+					logging.Errorf("Failed to add PD note for filtered entry %q: %v", entry.Name, err)
+				}
 				cleanupBuilder(builder)
 				continue
 			}

--- a/pkg/controller/notifier.go
+++ b/pkg/controller/notifier.go
@@ -10,6 +10,7 @@ import (
 // manual (non-PD) runs use a no-op implementation instead of
 // nil-checking a *pagerduty.SdkClient.
 type incidentNotifier interface {
+	AddNote(note string) error
 	EscalateWithNote(note string) error
 	AttachToBuilder(builder investigation.ResourceBuilder)
 	HasPagerDuty() bool
@@ -22,6 +23,10 @@ type pdIncidentNotifier struct {
 
 func newPDIncidentNotifier(client *pagerduty.SdkClient) incidentNotifier {
 	return &pdIncidentNotifier{client: client}
+}
+
+func (n *pdIncidentNotifier) AddNote(note string) error {
+	return n.client.AddNote(note)
 }
 
 func (n *pdIncidentNotifier) EscalateWithNote(note string) error {
@@ -41,6 +46,11 @@ type noopIncidentNotifier struct{}
 
 func newNoopIncidentNotifier() incidentNotifier {
 	return &noopIncidentNotifier{}
+}
+
+func (n *noopIncidentNotifier) AddNote(note string) error {
+	logging.Infof("Skipping PD note (manual mode): %s", note)
+	return nil
 }
 
 func (n *noopIncidentNotifier) EscalateWithNote(note string) error {


### PR DESCRIPTION
…s well

### What type of PR is this?

bug

### What this PR does / Why we need it?

Writes a PD note when an investigation is filtered as well

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PagerDuty notes explaining why investigation entries were filtered out.
  * Notes include details about the filtered entry and the applicable filter reason.

* **Bug Fixes**
  * Failures when adding explanatory notes are logged without interrupting the existing filtering process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->