### PR TITLE
[ROSAENG-61687] Add clusteroperatordownhcp investigation for HCP ClusterOperatorDown

### DIFF
--- a/docs/investigation-config.example.yaml
+++ b/docs/investigation-config.example.yaml
@@ -174,6 +174,16 @@ alerts:
   #           - operator: sample
   #             values: ["0.10"]
 
+  # Cluster Operator Down (HCP)
+  # No alert-level `when`: the alert must always reach the investigation so a
+  # non-HCP occurrence escalates to a human rather than being filtered into the
+  # AI fallback. The HCP guard lives inside the investigation itself.
+  - alert_title: "ClusterOperatorDown"
+    name: clusteroperatordownhcp
+    investigations:
+      - precheck
+      - clusteroperatordownhcp
+
   # Insights Operator Down
   - alert_title: "InsightsOperatorDown"
     name: insightsoperatordown

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -94,6 +94,7 @@ type CLBInstanceHealth struct {
 type Client interface {
 	ListRunningInstances(infraID string) ([]ec2v2types.Instance, error)
 	ListNonRunningInstances(infraID string) ([]ec2v2types.Instance, error)
+	GetInstanceByID(ctx context.Context, instanceID string) (ec2v2types.Instance, error)
 	PollInstanceStopEventsFor(instances []ec2v2types.Instance, retryTimes int) ([]cloudtrailv2types.Event, error)
 	GetBaseConfig() *awsv2.Config
 	GetSecurityGroupID(infraID string) (string, error)
@@ -228,6 +229,28 @@ func (c *SdkClient) listInstancesWithFilter(filters []ec2v2types.Filter) ([]ec2v
 		in.NextToken = out.NextToken
 	}
 	return instances, nil
+}
+
+// Why not reuse ListNonRunningInstances: those filter on the cluster infraID
+// tag (kubernetes.io/cluster/<infraID>=owned), which HCP data plane nodes do
+// not carry — so a tag lookup can't find them. We already know the exact
+// instance ID from the AWSMachine's providerID, so we ask for it directly.
+//
+// The returned instance carries StateTransitionReason, which is what
+// PollInstanceStopEventsFor needs to attribute the CloudTrail stop event.
+func (c *SdkClient) GetInstanceByID(ctx context.Context, instanceID string) (ec2v2types.Instance, error) {
+	describeResp, err := c.Ec2Client.DescribeInstances(ctx, &ec2v2.DescribeInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	if err != nil {
+		return ec2v2types.Instance{}, fmt.Errorf("failed to describe instance %s: %w", instanceID, err)
+	}
+	for _, reservation := range describeResp.Reservations {
+		if len(reservation.Instances) > 0 {
+			return reservation.Instances[0], nil
+		}
+	}
+	return ec2v2types.Instance{}, fmt.Errorf("no instance found with id %s", instanceID)
 }
 
 // ListNonRunningInstances lists all non-running instances that belong to a cluster

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -1,6 +1,8 @@
 package aws_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
@@ -11,6 +13,96 @@ import (
 	cadaws "github.com/openshift/configuration-anomaly-detection/pkg/aws"
 	awsmock "github.com/openshift/configuration-anomaly-detection/pkg/aws/mock"
 )
+
+func setupInstanceMock(t *testing.T, describeResp *ec2v2.DescribeInstancesOutput, describeErr error) cadaws.EC2API {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	ec2api := awsmock.NewMockEC2API(ctrl)
+	ec2api.EXPECT().DescribeInstances(gomock.Any(), gomock.Any()).Return(describeResp, describeErr)
+	return ec2api
+}
+
+func TestSdkClient_GetInstanceByID(t *testing.T) {
+	type fields struct {
+		Region           string
+		StsClient        cadaws.StsAPI
+		Ec2Client        cadaws.EC2API
+		CloudTrailClient cadaws.CloudTrailAPI
+		BaseConfig       awsv2.Config
+	}
+	type args struct {
+		instanceID string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantID  string
+		wantErr bool
+	}{
+		{
+			name: "An existing instance ID returns the matching instance",
+			fields: fields{
+				Region:           "us-east-1",
+				StsClient:        nil,
+				Ec2Client:        setupInstanceMock(t, &ec2v2.DescribeInstancesOutput{Reservations: []ec2v2types.Reservation{{Instances: []ec2v2types.Instance{{InstanceId: awsv2.String("i-0abc123")}}}}}, nil),
+				CloudTrailClient: nil,
+				BaseConfig:       awsv2.Config{},
+			},
+			args:    args{instanceID: "i-0abc123"},
+			wantID:  "i-0abc123",
+			wantErr: false,
+		},
+		{
+			// AWS returns an empty reservation list rather than an error for an
+			// unknown instance ID, so the method must surface its own not-found error.
+			name: "An unknown instance ID returns an error",
+			fields: fields{
+				Region:           "us-east-1",
+				StsClient:        nil,
+				Ec2Client:        setupInstanceMock(t, &ec2v2.DescribeInstancesOutput{Reservations: []ec2v2types.Reservation{}}, nil),
+				CloudTrailClient: nil,
+				BaseConfig:       awsv2.Config{},
+			},
+			args:    args{instanceID: "i-0missing"},
+			wantErr: true,
+		},
+		{
+			name: "An SDK error is propagated",
+			fields: fields{
+				Region:           "us-east-1",
+				StsClient:        nil,
+				Ec2Client:        setupInstanceMock(t, nil, errors.New("api down")),
+				CloudTrailClient: nil,
+				BaseConfig:       awsv2.Config{},
+			},
+			args:    args{instanceID: "i-0abc123"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cadaws.SdkClient{
+				Region:           tt.fields.Region,
+				StsClient:        tt.fields.StsClient,
+				Ec2Client:        tt.fields.Ec2Client,
+				CloudtrailClient: tt.fields.CloudTrailClient,
+				BaseConfig:       &tt.fields.BaseConfig,
+			}
+			got, err := c.GetInstanceByID(context.Background(), tt.args.instanceID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SdkClient.GetInstanceByID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.InstanceId == nil || *got.InstanceId != tt.wantID {
+				t.Errorf("SdkClient.GetInstanceByID() = %v, want id %v", got.InstanceId, tt.wantID)
+			}
+		})
+	}
+}
 
 func setupSubnetMock(t *testing.T, gatewayId *string, mapPublicIps bool) cadaws.EC2API {
 	t.Helper()

--- a/pkg/aws/mock/aws.go
+++ b/pkg/aws/mock/aws.go
@@ -616,6 +616,21 @@ func (mr *MockClientMockRecorder) GetCLBInstanceHealth(ctx, lbName any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCLBInstanceHealth", reflect.TypeOf((*MockClient)(nil).GetCLBInstanceHealth), ctx, lbName)
 }
 
+// GetInstanceByID mocks base method.
+func (m *MockClient) GetInstanceByID(ctx context.Context, instanceID string) (types0.Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstanceByID", ctx, instanceID)
+	ret0, _ := ret[0].(types0.Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstanceByID indicates an expected call of GetInstanceByID.
+func (mr *MockClientMockRecorder) GetInstanceByID(ctx, instanceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceByID", reflect.TypeOf((*MockClient)(nil).GetInstanceByID), ctx, instanceID)
+}
+
 // GetInstanceSecurityGroupIDs mocks base method.
 func (m *MockClient) GetInstanceSecurityGroupIDs(ctx context.Context, instanceIDs []string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/executor/action_builders.go
+++ b/pkg/executor/action_builders.go
@@ -21,7 +21,7 @@ type ServiceLogActionBuilder struct {
 }
 
 // NewServiceLogAction creates a builder with required fields
-// severity: "Info", "Warning", "Major", "Critical"
+// severity (HCC names): "Low", "Moderate", "Important", "Critical"
 // summary: Brief title of the service log
 func NewServiceLogAction(severity, summary string) *ServiceLogActionBuilder {
 	return &ServiceLogActionBuilder{

--- a/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
+++ b/pkg/investigations/clustermonitoringerrorbudgetburn/clustermonitoringerrorbudgetburn.go
@@ -23,7 +23,7 @@ func newUwmConfigMapMisconfiguredSL(docLink string) *ocm.ServiceLog {
 	}
 
 	return &ocm.ServiceLog{
-		Severity:     "Major",
+		Severity:     "Important",
 		Summary:      "Action required: review user-workload-monitoring configuration",
 		ServiceName:  "SREManualAction",
 		Description:  fmt.Sprintf("Your cluster's user workload monitoring is misconfigured: please review the user-workload-monitoring-config ConfigMap in the openshift-user-workload-monitoring namespace. For more information, please refer to the product documentation: %s.", docLink),
@@ -37,7 +37,7 @@ func newUwmAMMisconfiguredSL(docLink string) *ocm.ServiceLog {
 	}
 
 	return &ocm.ServiceLog{
-		Severity:     "Major",
+		Severity:     "Important",
 		Summary:      "Action required: review user-workload-monitoring configuration",
 		ServiceName:  "SREManualAction",
 		Description:  fmt.Sprintf("Your cluster's user workload monitoring is misconfigured: please review the Alert Manager configuration in the opennshift-user-workload-monitoring namespace. For more information, please refer to the product documentation: %s.", docLink),
@@ -51,7 +51,7 @@ func newUwmGenericMisconfiguredSL(docLink string) *ocm.ServiceLog {
 	}
 
 	return &ocm.ServiceLog{
-		Severity:     "Major",
+		Severity:     "Important",
 		Summary:      "Action required: review user-workload-monitoring configuration",
 		ServiceName:  "SREManualAction",
 		Description:  fmt.Sprintf("Your cluster's user workload monitoring is misconfigured: please review the cluster operator status and correct the configuration in the opennshift-user-workload-monitoring namespace. For more information, please refer to the product documentation: %s.", docLink),

--- a/pkg/investigations/clusteroperatordownhcp/clusteroperatordownhcp.go
+++ b/pkg/investigations/clusteroperatordownhcp/clusteroperatordownhcp.go
@@ -1,0 +1,193 @@
+// Package clusteroperatordownhcp investigates the ClusterOperatorDown alert for
+// HCP clusters, where a data plane ClusterOperator is degraded because the
+// worker node's backing EC2 instance was stopped.
+package clusteroperatordownhcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	ec2v2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/openshift/configuration-anomaly-detection/pkg/aws"
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Investigation struct{}
+
+func (c *Investigation) Name() string {
+	return "clusteroperatordownhcp"
+}
+
+// awsMachineStopped is the value of an AWSMachine's status.instanceState when
+// its backing EC2 instance has been stopped.
+const awsMachineStopped = "stopped"
+
+func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.InvestigationResult, error) {
+	result := investigation.InvestigationResult{}
+	ctx := context.Background()
+
+	// WithAwsClient authenticates to the HCP's own (customer) AWS account, which
+	// is where the data plane EC2 instances live — not the management cluster's.
+	r, err := rb.WithCluster().WithManagementK8sClient().WithAwsClient().WithNotes().Build()
+	if err != nil {
+		return result, err
+	}
+
+	// This alert is only actionable on HCP. On classic clusters the AWSMachine /
+	// management-cluster model below does not exist, so hand it to a human rather
+	// than letting it fall through to the generic AI fallback.
+	if !r.IsHCP {
+		r.Notes.AppendWarning("ClusterOperatorDown on a non-HCP cluster - this investigation only handles HCP")
+		result.Actions = append(
+			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), c.Name()),
+			executor.Escalate("ClusterOperatorDown on non-HCP cluster - manual investigation required"),
+		)
+		return result, nil
+	}
+
+	machine, instanceID, err := firstStoppedAWSMachine(ctx, r.ManagementK8sClient, r.HCPNamespace)
+	if err != nil {
+		return result, investigation.WrapInfrastructure(
+			fmt.Errorf("failed to list AWSMachines in %s: %w", r.HCPNamespace, err),
+			"could not read AWSMachines on the management cluster")
+	}
+
+	// No stopped data plane instance means the ClusterOperator is degraded for
+	// some other reason CAD can't remediate here.
+	if machine == "" {
+		r.Notes.AppendWarning("No stopped AWSMachine found in %s - the degraded operator is not caused by a stopped worker instance", r.HCPNamespace)
+		result.Actions = append(
+			executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), c.Name()),
+			executor.Escalate("No stopped worker instance found - manual investigation required"),
+		)
+		return result, nil
+	}
+
+	// On HCP, SRE never stops data plane instances, so a stopped instance is a
+	// customer action by definition. CloudTrail attribution is recorded in the
+	// PD note for SRE visibility, but does not change the action taken.
+	attribution := stopAttribution(ctx, r.AwsClient, instanceID)
+	r.Notes.AppendWarning("AWSMachine %q is stopped (instance %s). %s", machine, instanceID, attribution)
+
+	sl := newWorkerNodesStoppedSL()
+	result.Actions = append(
+		executor.NoteAndReportFrom(r.Notes, r.Cluster.ID(), c.Name()),
+		executor.NewServiceLogAction(sl.Severity, sl.Summary).
+			WithDescription(sl.Description).
+			WithServiceName(sl.ServiceName).
+			Build(),
+		executor.Silence("Customer stopped worker instance on HCP - service log sent"),
+	)
+	return result, nil
+}
+
+// firstStoppedAWSMachine returns the name and backing EC2 instance ID of the
+// first AWSMachine in the namespace whose instance is stopped. It returns an
+// empty name (with nil error) when none are stopped.
+//
+// All AWSMachines in an HCP namespace are data plane nodes, so no role filtering
+// is applied — the first stopped one is enough to act on.
+func firstStoppedAWSMachine(ctx context.Context, mgmt client.Client, namespace string) (name string, instanceID string, err error) {
+	list := &unstructured.UnstructuredList{}
+	// v1beta2 is the only served version of the CAPA AWSMachine CRD; v1beta1
+	// exists in the schema but is served: false.
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "AWSMachineList",
+	})
+
+	if err := mgmt.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return "", "", err
+	}
+
+	for i := range list.Items {
+		m := &list.Items[i]
+		state, _, _ := unstructured.NestedString(m.Object, "status", "instanceState")
+		if state != awsMachineStopped {
+			continue
+		}
+		id := instanceIDForMachine(m)
+		if id == "" {
+			continue
+		}
+		return m.GetName(), id, nil
+	}
+	return "", "", nil
+}
+
+// instanceIDForMachine reads the EC2 instance ID from an AWSMachine, preferring
+// the explicit spec.instanceID field and falling back to parsing spec.providerID.
+// It returns an empty string when neither yields a valid id.
+//
+// spec.instanceID is the direct, canonical field on CAPA AWSMachines; providerID
+// is kept as a fallback because it is populated slightly later in the machine
+// lifecycle and is the more universally-present field across CAPI providers.
+func instanceIDForMachine(m *unstructured.Unstructured) string {
+	if id, _, _ := unstructured.NestedString(m.Object, "spec", "instanceID"); strings.HasPrefix(id, "i-") {
+		return id
+	}
+	providerID, _, _ := unstructured.NestedString(m.Object, "spec", "providerID")
+	return instanceIDFromProviderID(providerID)
+}
+
+// instanceIDFromProviderID extracts the EC2 instance ID from an AWSMachine
+// providerID of the form "aws:///<availability-zone>/<instance-id>". It returns
+// an empty string when the providerID is missing or malformed.
+func instanceIDFromProviderID(providerID string) string {
+	if providerID == "" {
+		return ""
+	}
+	segments := strings.Split(providerID, "/")
+	lastSegment := segments[len(segments)-1]
+	if !strings.HasPrefix(lastSegment, "i-") {
+		return ""
+	}
+	return lastSegment
+}
+
+// stopAttribution returns a human-readable "stopped by <user> at <time>" string
+// from CloudTrail for the PD note. Attribution is best-effort: CloudTrail only
+// retains ~2h of lookup events, so an older stop yields a fallback message
+// rather than an error — we still act on the stopped state regardless.
+func stopAttribution(ctx context.Context, awsCli aws.Client, instanceID string) string {
+	inst, err := awsCli.GetInstanceByID(ctx, instanceID)
+	if err != nil {
+		return fmt.Sprintf("CloudTrail attribution unavailable: %v", err)
+	}
+
+	events, err := awsCli.PollInstanceStopEventsFor([]ec2v2types.Instance{inst}, 5)
+	if err != nil || len(events) == 0 {
+		return "CloudTrail stop event not found (instance may have been stopped more than 2h ago)."
+	}
+
+	stopEvent := events[0]
+	stoppedBy := "unknown"
+	if stopEvent.Username != nil {
+		stoppedBy = *stopEvent.Username
+	}
+	stoppedAt := "unknown time"
+	if stopEvent.EventTime != nil {
+		stoppedAt = stopEvent.EventTime.UTC().String()
+	}
+	return fmt.Sprintf("Stopped by %s at %s (per CloudTrail).", stoppedBy, stoppedAt)
+}
+
+// newWorkerNodesStoppedSL mirrors the managed-notifications template
+// hcp/WorkerNodes_Stopped_error.json. Severity uses the new HCC name
+// "Important" (formerly "Major" in the template).
+func newWorkerNodesStoppedSL() *ocm.ServiceLog {
+	return &ocm.ServiceLog{
+		Severity:     "Important",
+		ServiceName:  "SREManualAction",
+		Summary:      "Worker node(s) stopped, action required",
+		Description:  "Your cluster's worker nodes are stopped due to manual action in AWS which is not supported. Please remediate the issue by starting the instances again. If you would like to change the number of worker instances, please refer to the documentation https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#rosa-scaling-worker-nodes_rosa-managing-worker-nodes.",
+		InternalOnly: false,
+	}
+}

--- a/pkg/investigations/clusteroperatordownhcp/clusteroperatordownhcp.go
+++ b/pkg/investigations/clusteroperatordownhcp/clusteroperatordownhcp.go
@@ -180,8 +180,8 @@ func stopAttribution(ctx context.Context, awsCli aws.Client, instanceID string) 
 }
 
 // newWorkerNodesStoppedSL mirrors the managed-notifications template
-// hcp/WorkerNodes_Stopped_error.json. Severity uses the new HCC name
-// "Important" (formerly "Major" in the template).
+// hcp/WorkerNodes_Stopped_error.json. Severity uses the HCC name "Important"
+// (equivalent to the legacy "Major" the template is authored with).
 func newWorkerNodesStoppedSL() *ocm.ServiceLog {
 	return &ocm.ServiceLog{
 		Severity:     "Important",

--- a/pkg/investigations/clusteroperatordownhcp/clusteroperatordownhcp_test.go
+++ b/pkg/investigations/clusteroperatordownhcp/clusteroperatordownhcp_test.go
@@ -1,0 +1,230 @@
+package clusteroperatordownhcp
+
+import (
+	"errors"
+	"testing"
+
+	ec2v2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
+	awsmock "github.com/openshift/configuration-anomaly-detection/pkg/aws/mock"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
+	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func hasActionType(actions []types.Action, actionType string) bool {
+	for _, action := range actions {
+		if action.Type() == actionType {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEscalateAction(actions []types.Action) bool {
+	return hasActionType(actions, string(executor.ActionTypeEscalateIncident))
+}
+
+func hasSilenceAction(actions []types.Action) bool {
+	return hasActionType(actions, string(executor.ActionTypeSilenceIncident))
+}
+
+func hasServiceLogAction(actions []types.Action) bool {
+	return hasActionType(actions, string(executor.ActionTypeServiceLog))
+}
+
+// awsMachine builds an unstructured AWSMachine for the fake management client,
+// mirroring the real CAPA shape (spec.instanceID + spec.providerID +
+// status.instanceState). instanceID may be empty to simulate a machine whose
+// instance ID is not yet populated.
+func awsMachine(namespace, name, instanceState, instanceID string) *unstructured.Unstructured {
+	m := &unstructured.Unstructured{}
+	m.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "AWSMachine",
+	})
+	m.SetNamespace(namespace)
+	m.SetName(name)
+	if instanceID != "" {
+		_ = unstructured.SetNestedField(m.Object, instanceID, "spec", "instanceID")
+		_ = unstructured.SetNestedField(m.Object, "aws:///us-east-2a/"+instanceID, "spec", "providerID")
+	}
+	_ = unstructured.SetNestedField(m.Object, instanceState, "status", "instanceState")
+	return m
+}
+
+func TestInvestigation_Name(t *testing.T) {
+	assert.Equal(t, "clusteroperatordownhcp", (&Investigation{}).Name())
+}
+
+func TestInstanceIDFromProviderID(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID string
+		want       string
+	}{
+		{
+			name:       "A well-formed providerID yields the instance ID",
+			providerID: "aws:///us-east-1a/i-0abc123def456",
+			want:       "i-0abc123def456",
+		},
+		{
+			name:       "A short instance ID is still extracted",
+			providerID: "aws:///eu-west-2b/i-1",
+			want:       "i-1",
+		},
+		{
+			name:       "An empty providerID yields an empty ID",
+			providerID: "",
+			want:       "",
+		},
+		{
+			name:       "A providerID without an instance segment yields an empty ID",
+			providerID: "aws:///us-east-1a/",
+			want:       "",
+		},
+		{
+			name:       "A providerID without slashes yields an empty ID",
+			providerID: "garbage-without-slashes",
+			want:       "",
+		},
+		{
+			name:       "A last segment that is not an i- ID yields an empty ID",
+			providerID: "aws:///us-east-1a/notaninstance",
+			want:       "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, instanceIDFromProviderID(tt.providerID))
+		})
+	}
+}
+
+func TestInvestigation_Run_BuildError(t *testing.T) {
+	buildErr := errors.New("build failed")
+	rb := &investigation.ResourceBuilderMock{Resources: nil, BuildError: buildErr}
+
+	result, err := (&Investigation{}).Run(rb)
+	assert.Empty(t, result)
+	assert.Equal(t, buildErr, err)
+}
+
+// A non-HCP occurrence must reach a human, not the AI fallback, so it escalates
+// rather than silences.
+func TestInvestigation_Run_NonHCPEscalates(t *testing.T) {
+	cluster, err := cmv1.NewCluster().ID("test-123").Build()
+	require.NoError(t, err)
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			IsHCP:   false,
+			Cluster: cluster,
+			Notes:   notewriter.New("test", logging.RawLogger),
+		},
+	}
+
+	result, err := (&Investigation{}).Run(rb)
+	assert.NoError(t, err)
+	assert.True(t, hasEscalateAction(result.Actions), "non-HCP should escalate to a human")
+	assert.False(t, hasSilenceAction(result.Actions), "non-HCP must not silence")
+	assert.False(t, hasServiceLogAction(result.Actions), "non-HCP must not send a service log")
+}
+
+// When no data plane instance is stopped the degraded operator has another
+// cause, so CAD escalates instead of remediating.
+func TestInvestigation_Run_NoStoppedMachineEscalates(t *testing.T) {
+	cluster, err := cmv1.NewCluster().ID("test-123").Build()
+	require.NoError(t, err)
+
+	hcpNamespace := "ocm-test-hcp-namespace"
+	running := awsMachine(hcpNamespace, "worker-1", "running", "i-0running")
+	fakeK8s := fake.NewClientBuilder().WithObjects(running).Build()
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			IsHCP:               true,
+			Cluster:             cluster,
+			HCPNamespace:        hcpNamespace,
+			ManagementK8sClient: fakeK8s,
+			Notes:               notewriter.New("test", logging.RawLogger),
+		},
+	}
+
+	result, err := (&Investigation{}).Run(rb)
+	assert.NoError(t, err)
+	assert.True(t, hasEscalateAction(result.Actions), "no stopped machine should escalate")
+	assert.False(t, hasServiceLogAction(result.Actions), "no service log when nothing is stopped")
+}
+
+// An empty AWSMachine list (no data plane machines in the namespace) is treated
+// the same as "none stopped": escalate, never remediate on absent data.
+func TestInvestigation_Run_EmptyMachineListEscalates(t *testing.T) {
+	cluster, err := cmv1.NewCluster().ID("test-123").Build()
+	require.NoError(t, err)
+
+	fakeK8s := fake.NewClientBuilder().Build()
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			IsHCP:               true,
+			Cluster:             cluster,
+			HCPNamespace:        "ocm-test-hcp-namespace",
+			ManagementK8sClient: fakeK8s,
+			Notes:               notewriter.New("test", logging.RawLogger),
+		},
+	}
+
+	result, err := (&Investigation{}).Run(rb)
+	assert.NoError(t, err)
+	assert.True(t, hasEscalateAction(result.Actions), "empty machine list should escalate")
+	assert.False(t, hasServiceLogAction(result.Actions), "no service log on an empty list")
+	assert.False(t, hasSilenceAction(result.Actions), "must not silence on an empty list")
+}
+
+// A stopped data plane instance is a customer action on HCP: send the service
+// log and silence, with CloudTrail attribution recorded in the note.
+func TestInvestigation_Run_StoppedMachineSendsServiceLogAndSilences(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cluster, err := cmv1.NewCluster().ID("test-123").Build()
+	require.NoError(t, err)
+
+	hcpNamespace := "ocm-test-hcp-namespace"
+	instanceID := "i-0stopped456"
+	stopped := awsMachine(hcpNamespace, "worker-1", "stopped", instanceID)
+	fakeK8s := fake.NewClientBuilder().WithObjects(stopped).Build()
+
+	awsCli := awsmock.NewMockClient(mockCtrl)
+	stoppedInstance := ec2v2types.Instance{InstanceId: &instanceID}
+	awsCli.EXPECT().GetInstanceByID(gomock.Any(), instanceID).Return(stoppedInstance, nil)
+	// Attribution is best-effort; returning no events still yields the remediation.
+	awsCli.EXPECT().PollInstanceStopEventsFor(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	rb := &investigation.ResourceBuilderMock{
+		Resources: &investigation.Resources{
+			IsHCP:               true,
+			Cluster:             cluster,
+			HCPNamespace:        hcpNamespace,
+			ManagementK8sClient: fakeK8s,
+			AwsClient:           awsCli,
+			Notes:               notewriter.New("test", logging.RawLogger),
+		},
+	}
+
+	result, err := (&Investigation{}).Run(rb)
+	assert.NoError(t, err)
+	assert.True(t, hasServiceLogAction(result.Actions), "stopped machine should send a service log")
+	assert.True(t, hasSilenceAction(result.Actions), "stopped machine should silence")
+	assert.False(t, hasEscalateAction(result.Actions), "stopped machine should not escalate")
+}

--- a/pkg/investigations/clusteroperatordownhcp/clusteroperatordownhcp_test.go
+++ b/pkg/investigations/clusteroperatordownhcp/clusteroperatordownhcp_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	awsmock "github.com/openshift/configuration-anomaly-detection/pkg/aws/mock"
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"

--- a/pkg/investigations/clusteroperatordownhcp/metadata.yaml
+++ b/pkg/investigations/clusteroperatordownhcp/metadata.yaml
@@ -1,0 +1,10 @@
+name: clusteroperatordownhcp
+managementClusterRbac:
+  hcpNamespace:
+    - verbs:
+        - "get"
+        - "list"
+      apiGroups:
+        - "infrastructure.cluster.x-k8s.io"
+      resources:
+        - "awsmachines"

--- a/pkg/investigations/cpd/cpd.go
+++ b/pkg/investigations/cpd/cpd.go
@@ -23,7 +23,7 @@ func newBYOVPCRoutingSL(docLink string) *ocm.ServiceLog {
 	}
 
 	return &ocm.ServiceLog{
-		Severity:     "Major",
+		Severity:     "Important",
 		Summary:      "Installation blocked: Missing route to internet",
 		Description:  fmt.Sprintf("Your cluster's installation is blocked because of the missing route to internet in the route table(s) associated with the supplied subnet(s) for cluster installation. Please review and validate the routes by following documentation and re-install the cluster: %s.", docLink),
 		InternalOnly: false,

--- a/pkg/investigations/registry.go
+++ b/pkg/investigations/registry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/chgm"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clusterhealthcheck"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clustermonitoringerrorbudgetburn"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/clusteroperatordownhcp"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/consoleerrorbudgetburn"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/cpd"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/describenodes"
@@ -30,6 +31,7 @@ var availableInvestigations = []investigation.Investigation{
 	&aiassisted.Investigation{},
 	&chgm.Investigation{},
 	&clustermonitoringerrorbudgetburn.Investigation{},
+	&clusteroperatordownhcp.Investigation{},
 	&cpd.Investigation{},
 	&etcddatabasequotalowspace.Investigation{},
 	&insightsoperatordown.Investigation{},

--- a/test/generate_incident.sh
+++ b/test/generate_incident.sh
@@ -8,6 +8,7 @@ declare -A alert_mapping=(
     ["ClusterProvisioningDelay"]="ClusterProvisioningDelay -"
     ["ClusterMonitoringErrorBudgetBurnSRE"]="ClusterMonitoringErrorBudgetBurnSRE Critical (1)"
     ["InsightsOperatorDown"]="InsightsOperatorDown"
+    ["ClusterOperatorDown"]="ClusterOperatorDown"
     ["MachineHealthCheckUnterminatedShortCircuitSRE"]="MachineHealthCheckUnterminatedShortCircuitSRE CRITICAL (1)"
     ["CreateMustGather"]="CreateMustGather"
     ["CannotRetrieveUpdatesSRE"]="CannotRetrieveUpdatesSRE"


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

Adds a new `clusteroperatordownhcp` investigation that handles the `ClusterOperatorDown` alert on HCP clusters, where a data plane ClusterOperator degrades because a worker node's backing EC2 instance was stopped (a customer action — SRE never stops HCP data plane instances).

Decision logic:
- **Stopped AWSMachine** in the HCP namespace (read from the management cluster): record CloudTrail stop attribution in the PD note, send the "Worker node(s) stopped, action required" service log, and silence.
- **No stopped AWSMachine** (running/none): note + escalate to a human.
- **Non-HCP cluster**: note + escalate to a human — never silenced and never allowed to fall through to the generic AI fallback. The alert is intentionally mapped with no alert-level `when` so it always reaches the investigation; the HCP guard lives inside the investigation.

AWSMachines are read from the HCP namespace on the **management cluster** via `WithManagementK8sClient()`; the CloudTrail lookup uses the HCP's own (customer) AWS account where the data plane instances actually live. `metadata.yaml` grants `get`/`list` on `infrastructure.cluster.x-k8s.io/awsmachines` in the management cluster namespace.

Also migrates all ServiceLog severities across investigations to the new HCC naming (`Major` → `Important`; `Critical` unchanged) for consistency.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [X] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HCP-specific handling for `ClusterOperatorDown` alerts.
  * Detects stopped data-plane nodes, records available stop-event details, creates a worker-nodes-stopped service log, and silences the alert when appropriate.
  * Escalates non-HCP clusters and cases where no stopped node is found.

* **Improvements**
  * Added `ClusterOperatorDown` to the example investigation configuration.
  * Updated selected service-log severities from “Major” to “Important” for clearer prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->