### PR TITLE
ROSAENG-66024: remove rsync from dockerfile and push metrics early

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,7 +20,8 @@ ARG OC_VERSION=4.22.10
 ARG OC_HASH=f426abdc0bafd712ddac75444e88cd01bb47a331f1a9a3128419afd19848670b
 
 RUN microdnf update -y && \
-    microdnf install wget tar gzip rsync -y
+    microdnf install wget tar gzip -y && \
+    microdnf clean all
 RUN wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux-${OC_VERSION}.tar.gz -O /tmp/oc.tar.gz && \
     echo "${OC_HASH} /tmp/oc.tar.gz" | sha256sum --check --status && \
     tar -zxvf /tmp/oc.tar.gz -C /tmp && \

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -299,6 +299,9 @@ func (c *investigationRunner) runChain(
 ) (err error) {
 	if len(alertConfig.Investigations) > 0 {
 		metrics.Inc(metrics.Alerts, alertConfig.GetName())
+		// Push early so the alert count is recorded even if the pod is OOM-killed
+		// before the investigation completes.
+		metrics.Push()
 	}
 
 	var latestBuilder investigation.ResourceBuilder

--- a/pkg/investigations/mustgather/README.md
+++ b/pkg/investigations/mustgather/README.md
@@ -148,6 +148,14 @@ Integration testing requires:
 
 Common issues and solutions are documented in [testing/README.md](./testing/README.md#troubleshooting).
 
+### Do not install rsync in the CAD container image
+
+`oc adm must-gather` copies results from the must-gather pod to the local filesystem using `oc rsync` internally. When rsync is available on both sides, it uses the rsync protocol; otherwise it falls back to tar streaming.
+
+The rsync strategy builds in-memory file lists and buffers whose size scales with the must-gather output. Large must-gathers (clusters with many rotated logs) can push the CAD pod past its memory limit, causing an OOM kill. An OOM kill prevents completion metrics from being emitted, but the alert metric is pushed early so the dashboard shows a success-rate drop.
+
+The tar fallback streams files sequentially with constant memory overhead regardless of must-gather size. Since must-gather is always a fresh full copy (no pre-existing data to diff against), rsync's delta-transfer advantage does not apply.
+
 ## Future Enhancements
 
 Potential improvements when graduating from experimental:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -2,13 +2,17 @@
 package metrics
 
 import (
+	"context"
 	"os"
+	"time"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/prometheus/common/expfmt"
 )
+
+const pushTimeout = 10 * time.Second
 
 // Push collects and pushes metrics to the configured pushgateway
 func Push() {
@@ -25,7 +29,9 @@ func Push() {
 		promPusher.Collector(EtcdSnapshotCleanup)
 		promPusher.Collector(ManualInvestigationStarted)
 		promPusher.Collector(ManualInvestigationCompleted)
-		err := promPusher.Add()
+		ctx, cancel := context.WithTimeout(context.Background(), pushTimeout)
+		defer cancel()
+		err := promPusher.AddContext(ctx)
 		if err != nil {
 			logging.Errorf("failed to push metrics: %w", err)
 		}


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Remove rsync from the CAD container image to prevent OOM kills during must-gather collection. oc adm must-gather falls back to tar streaming which uses constant memory. Also push metrics early so that OOM kills show up as a success rate drop in the dashboard instead of being silently invisible.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Alert metrics are now reported immediately when an investigation starts, improving monitoring accuracy.
  * Metric delivery now times out after 10 seconds instead of waiting indefinitely.
  * Must-gather collection avoids unnecessary memory growth and potential out-of-memory failures during large data captures.
  * Large data transfers now use memory-efficient tar streaming for improved reliability.

* **Documentation**
  * Added troubleshooting guidance for must-gather collection, container image requirements, and metric availability during failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->