### PR TITLE
ROSAENG-4316: Send a SL if a SCP dienies ec2:RunInstances

### DIFF
--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre.go
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre.go
@@ -18,6 +18,7 @@ import (
 	nodeutil "github.com/openshift/configuration-anomaly-detection/pkg/investigations/utils/node"
 	k8sclient "github.com/openshift/configuration-anomaly-detection/pkg/k8s"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
 	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,16 @@ const (
 	alertname = "MachineHealthCheckUnterminatedShortCircuitSRE"
 )
 
+// scpSL mirrors the managed-notifications template:
+// https://github.com/openshift/managed-notifications/blob/master/osd/rosa_cluster_cant_manage_instances.json
+var scpSL = ocm.ServiceLog{
+	Severity:     "Major",
+	ServiceName:  "SREManualAction",
+	Summary:      "Cluster degraded, action required",
+	Description:  "Your cluster is unable to manage its AWS EC2 instances using AWS API operations such as ec2:RunInstances and ec2:TerminateInstances, which prevents critical cluster functions from operating. This can be caused by insufficient AWS IAM permissions, insufficient AWS quota, or ABAC policies blocking AWS instance operations. Please review the product documentation and ensure your cluster fulfils all prerequisites: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/prepare_your_environment/rosa-sts-aws-prereqs.",
+	InternalOnly: false,
+}
+
 type Investigation struct {
 	// k8scli provides access to on-cluster resources
 	k8scli k8sclient.Client
@@ -35,6 +46,8 @@ type Investigation struct {
 	notes *notewriter.NoteWriter
 	// recommendations holds the set of actions CAD recommends primary to take
 	recommendations investigationRecommendations
+	// scpMisconfigured is true when a misconfigured SCP prevents AWS access (e.g. runInstances)
+	scpMisconfigured bool
 }
 
 // Run investigates the MachineHealthCheckUnterminatedShortCircuitSRE alert
@@ -61,6 +74,7 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	i.k8scli = r.K8sClient
 	i.notes = r.Notes
 	i.recommendations = investigationRecommendations{}
+	i.scpMisconfigured = false
 
 	targetMachines, err := i.getMachinesFromFailingMHC(ctx)
 	if err != nil {
@@ -105,6 +119,17 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		}
 	}
 
+	if i.scpMisconfigured {
+		i.notes.AppendWarning("a misconfigured SCP is denying ec2:RunInstances; a service log has been sent to the customer to review the AWS permissions required to manage cluster instances")
+		result.Actions = append(
+			result.Actions,
+			executor.NewServiceLogAction(scpSL.Severity, scpSL.Summary).
+				WithDescription(scpSL.Description).
+				WithServiceName(scpSL.ServiceName).
+				Build(),
+		)
+	}
+
 	// Summarize recommendations from investigation in PD notes, if any found
 	if len(i.recommendations) > 0 {
 		i.notes.AppendWarning("%s", i.recommendations.summarize())
@@ -113,9 +138,24 @@ func (i *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 
 	result.Actions = append(
-		executor.NoteAndReportFrom(i.notes, r.Cluster.ID(), i.Name()),
-		executor.Escalate("MachineHealthCheck investigation complete"),
+		result.Actions,
+		executor.NoteAndReportFrom(i.notes, r.Cluster.ID(), i.Name())...,
 	)
+
+	// A SL is queued to be sent already for the SCP, no other actionable items
+	if i.scpMisconfigured && len(i.recommendations) == 0 {
+		result.Actions = append(
+			result.Actions,
+			executor.Silence("Unactionable by SRE"),
+		)
+	} else {
+		// A SL is queued to be sent out for a misconfigured SCP, but there are other findings
+		// to be addressed by primary.
+		result.Actions = append(
+			result.Actions,
+			executor.Escalate("MachineHealthCheck investigation complete"),
+		)
+	}
 	return result, nil
 }
 
@@ -187,6 +227,12 @@ func (i *Investigation) investigateFailingMachine(machine machinev1beta1.Machine
 	var errorMsg string
 	if machine.Status.ErrorMessage != nil {
 		errorMsg = *machine.Status.ErrorMessage
+	}
+
+	// A SCP prevents runInstances
+	if isSCPRunInstancesDeny(errorMsg) {
+		i.scpMisconfigured = true
+		return nil
 	}
 
 	if role != machineutil.WorkerRoleLabelValue {
@@ -317,4 +363,10 @@ func (i *Investigation) InvestigateNode(node corev1.Node) {
 
 func (i *Investigation) Name() string {
 	return strings.ToLower(alertname)
+}
+
+// isSCPRunInstancesDeny verifies if the error message is due to a SCP denying RunInstances events
+func isSCPRunInstancesDeny(errorMsg string) bool {
+	return strings.Contains(errorMsg, "is not authorized to perform: ec2:RunInstances") &&
+		strings.Contains(errorMsg, "with an explicit deny in a service control policy")
 }

--- a/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre_test.go
+++ b/pkg/investigations/machinehealthcheckunterminatedshortcircuitsre/machinehealthcheckunterminatedshortcircuitsre_test.go
@@ -8,10 +8,14 @@ import (
 	"testing"
 	"time"
 
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	machineutil "github.com/openshift/configuration-anomaly-detection/pkg/investigations/utils/machine"
 	nodeutil "github.com/openshift/configuration-anomaly-detection/pkg/investigations/utils/node"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/notewriter"
+	"github.com/openshift/configuration-anomaly-detection/pkg/types"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
@@ -516,6 +520,159 @@ func TestInvestigation_InvestigateNode(t *testing.T) {
 	}
 }
 
+func Test_isSCPRunInstancesDeny(t *testing.T) {
+	tests := []struct {
+		name     string
+		errorMsg string
+		want     bool
+	}{
+		{
+			name:     "empty-error",
+			errorMsg: "",
+			want:     false,
+		},
+		{
+			name:     "generic-error",
+			errorMsg: "Generic error message",
+			want:     false,
+		},
+		{
+			name:     "scp-denies-runInstances",
+			errorMsg: "error launching instance: You are not authorized to perform this operation. User: arn:aws:sts::0123456789:assumed-role/example-cluster-xxxx-openshift-machine-api-aws-cloud-credentials/0123456789012345 is not authorized to perform: ec2:RunInstances on resource: arn:aws:ec2:ap-southeast-3:0123456789:instance/* with an explicit deny in a service control policy. Encoded authorization failure message: [...]",
+			want:     true,
+		},
+		{
+			name:     "scp-denies-DescribeInstances",
+			errorMsg: "error launching instance: You are not authorized to perform this operation. User: arn:aws:sts::0123456789:assumed-role/example-cluster-xxxx-openshift-machine-api-aws-cloud-credentials/0123456789012345 is not authorized to perform: ec2:DescribeInstances on resource: arn:aws:ec2:ap-southeast-3:0123456789:instance/* with an explicit deny in a service control policy. Encoded authorization failure message: [...]",
+			want:     false,
+		},
+		{
+			name:     "runInstance-denied-not-scp",
+			errorMsg: "error launching instance: You are not authorized to perform this operation. User: arn:aws:sts::0123456789:assumed-role/example-cluster-xxxx-openshift-machine-api-aws-cloud-credentials/0123456789012345 is not authorized to perform: ec2:RunInstances on resource: arn:aws:ec2:ap-southeast-3:0123456789:instance/* due to some reason",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSCPRunInstancesDeny(tt.errorMsg)
+
+			if got != tt.want {
+				t.Errorf("got %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestInvestigation_investigateFailingMachine_SCPDeny verifies that a machine failing to provision
+// due to an SCP deny on ec2:RunInstances flips the scpMisconfigured flag and short-circuits before
+// producing a (misleading) recommendation.
+func TestInvestigation_investigateFailingMachine_SCPDeny(t *testing.T) {
+	machine := newWorkerMachine("scp-denied")
+	errorMsg := "error launching instance: You are not authorized to perform this operation. User: arn:aws:sts::0123456789:assumed-role/example-cluster-xxxx-openshift-machine-api-aws-cloud-credentials/0123456789012345 is not authorized to perform: ec2:RunInstances on resource: arn:aws:ec2:ap-southeast-3:0123456789:instance/* with an explicit deny in a service control policy. Encoded authorization failure message: [...]"
+	machine.Status.ErrorMessage = &errorMsg
+
+	i, err := newTestInvestigation(machine)
+	if err != nil {
+		t.Fatalf("failed to create test investigation: %v", err)
+	}
+
+	if err := i.investigateFailingMachine(*machine); err != nil {
+		t.Errorf("unexpected error investigating SCP-denied machine: %v", err)
+	}
+
+	if !i.scpMisconfigured {
+		t.Errorf("expected scpMisconfigured to be true for an SCP RunInstances deny")
+	}
+
+	// The SCP branch must short-circuit before the switch, so no recommendation should be added
+	if len(i.recommendations) != 0 {
+		t.Errorf("expected no recommendations for an SCP deny (short-circuit), got %d", len(i.recommendations))
+	}
+}
+
+// TestInvestigation_Run_SCPDisposition verifies the end-to-end action disposition for
+// an SCP RunInstances deny: an SCP deny always queues the customer-facing service log,
+// and it silences only when the SCP is the *sole* finding. If any other machine yields a
+// recommendation, the incident is escalated so Primary addresses the remaining findings.
+func TestInvestigation_Run_SCPDisposition(t *testing.T) {
+	scpErr := "error launching instance: ... is not authorized to perform: ec2:RunInstances on resource: ... with an explicit deny in a service control policy. Encoded authorization failure message: [...]"
+
+	// A machine only reaches investigateFailingMachine when Phase==Failed or ErrorReason!=nil,
+	// so give the SCP machine a (non-SCP-relevant) ErrorReason to enter the failing path.
+	newSCPMachine := func() *machinev1beta1.Machine {
+		m := newWorkerMachine("scp-denied")
+		reason := machinev1beta1.CreateMachineError
+		m.Status.ErrorReason = &reason
+		m.Status.ErrorMessage = &scpErr
+		return m
+	}
+
+	tests := []struct {
+		name        string
+		objects     []client.Object
+		wantSilence bool // else Escalate
+	}{
+		{
+			name:        "SCP deny alone silences",
+			objects:     []client.Object{newFailingMachineHealthCheck(), newSCPMachine()},
+			wantSilence: true,
+		},
+		{
+			name: "SCP deny plus another finding escalates",
+			objects: []client.Object{
+				newFailingMachineHealthCheck(),
+				newSCPMachine(),
+				func() *machinev1beta1.Machine {
+					m := newWorkerMachine("create-failed")
+					reason := machinev1beta1.CreateMachineError
+					m.Status.ErrorReason = &reason
+					return m
+				}(),
+			},
+			wantSilence: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient, err := newFakeClient(tt.objects...)
+			if err != nil {
+				t.Fatalf("failed to create fake client: %v", err)
+			}
+
+			rb := &investigation.ResourceBuilderMock{
+				Resources: &investigation.Resources{
+					Cluster:   newTestCluster("test-cluster"),
+					K8sClient: clientImpl{fakeClient},
+					Notes:     notewriter.New("testing", logging.RawLogger),
+				},
+			}
+
+			i := &Investigation{}
+			result, err := i.Run(rb)
+			if err != nil {
+				t.Fatalf("unexpected error from Run(): %v", err)
+			}
+
+			// An SCP deny must always queue the customer-facing service log.
+			if !hasActionType(result.Actions, executor.ActionTypeServiceLog) {
+				t.Errorf("expected a ServiceLog action for an SCP deny")
+			}
+
+			gotSilence := hasActionType(result.Actions, executor.ActionTypeSilenceIncident)
+			gotEscalate := hasActionType(result.Actions, executor.ActionTypeEscalateIncident)
+
+			if tt.wantSilence && (!gotSilence || gotEscalate) {
+				t.Errorf("expected Silence and no Escalate; got silence=%t escalate=%t", gotSilence, gotEscalate)
+			}
+			if !tt.wantSilence && (!gotEscalate || gotSilence) {
+				t.Errorf("expected Escalate and no Silence; got silence=%t escalate=%t", gotSilence, gotEscalate)
+			}
+		})
+	}
+}
+
 func newFailingMachineHealthCheck() *machinev1beta1.MachineHealthCheck {
 	mhc := &machinev1beta1.MachineHealthCheck{
 		ObjectMeta: metav1.ObjectMeta{
@@ -577,6 +734,17 @@ type clientImpl struct {
 
 func (client clientImpl) Clean() error {
 	return nil
+}
+
+func newTestCluster(id string) *cmv1.Cluster {
+	cluster, _ := cmv1.NewCluster().ID(id).Build()
+	return cluster
+}
+
+func hasActionType(actions []types.Action, want executor.ActionType) bool {
+	return slices.ContainsFunc(actions, func(a types.Action) bool {
+		return a.Type() == string(want)
+	})
 }
 
 func newTestInvestigation(testObjects ...client.Object) (Investigation, error) {


### PR DESCRIPTION
### What type of PR is this?

(feature/bug/documentation/other)

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for AWS service control policies that block instance launches.
  * Added customer-facing remediation guidance with AWS service log details.
  * Investigations now remain silent when this is the only finding; cases with additional findings continue through escalation.

* **Bug Fixes**
  * Prevented a standard machine recommendation from being generated when an SCP blocks instance creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->