### PR TITLE
ROSAENG-66017: Improve local backplane docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,28 +179,50 @@ It will run services on the following local ports:8001 8091 8443 8888
    ./test/generate_incident.sh <alertname> <clusterid>
    ```
 
-2. In a separate terminal start the local infrastructure
-> **Note:** You need to clone the backplane-api code repository to a local directory and copy ocm.json from a staging cluster to its ./configs dir.
+2. Clone the [backplane-api](https://github.com/openshift/backplane-api) repository to a local directory and fetch `ocm.json` from a staging cluster into its `./configs` dir.
+
+   > **Warning:** The local backplane **will not work** without a valid `ocm.json`. This step is required.
+
+   ```bash
+   # Login to OCM production
+   ocm login --use-auth-code --url "production"
+
+   # Login to a backplanes cluster (e.g. backplanes05ue1)
+   ocm backplane login backplanes05ue1
+
+   # Debug into a backplane-api pod (provide a ticket as justification)
+   ocm backplane elevate "<ticket-id>" -- debug pod/backplane-api-0 -n backplane
+
+   # Inside the debug pod, print the file content
+   cat /ocm/ocm.json
+
+   # On the host, save the output into your local backplane-api checkout, e.g.:
+   xclip -selection clipboard -o > /home/me/backplane-api/configs/ocm.json
    ```
+
+3. In a separate terminal start the local infrastructure
+
+   ```bash
    OCM_BACKPLANE_REPO_PATH=/home/me/backplane-api ./test/launch_local_env.sh
    ```
 
+   > **Note:** The local backplane does not log to the terminal it was started in. Check `test/testinfra/backplane-api.error.log` to troubleshoot any issues.
 
-3. Export the required env variables from vault
+4. Export the required env variables from vault
    > **Note:** For information on the envs see [required env variables](#required-env-variables).
 
-   ```
+   ```bash
    source test/set_stage_env.sh
    ```
 
-4. `make build`
-5. Run `cadctl` with the payload file created by `test/generate_incident.sh` and proxy as well as the backplane URL set to localhost
+5. `make build`
+6. Run `cadctl` with the payload file created by `test/generate_incident.sh` and proxy as well as the backplane URL set to localhost
 
    ```bash
    BACKPLANE_URL=https://localhost:8443 HTTP_PROXY=http://127.0.0.1:8888 HTTPS_PROXY=http://127.0.0.1:8888 BACKPLANE_PROXY=http://127.0.0.1:8888  ./bin/cadctl investigate --payload-path ./payload --log-level debug
    ```
 
-6. Close the local infrastructure when done by sending SIGINT (Ctrl+C) to the launch_local_env.sh
+7. Close the local infrastructure when done by sending SIGINT (Ctrl+C) to the launch_local_env.sh
 
 ## Run e2e test manually
 

--- a/test/launch_local_env.sh
+++ b/test/launch_local_env.sh
@@ -68,7 +68,7 @@ popd
 
 echo "Starting backplane-api on port 8001"
 pushd $OCM_BACKPLANE_REPO_PATH
-GIT_REPO=${CAD_REPO_PATH} make run-local-with-testremediation > ${CAD_REPO_PATH}/test/testinfra/backplan-api.log 2> ${CAD_REPO_PATH}/test/testinfra/backplan-api.error.log &
+GIT_REPO=${CAD_REPO_PATH} make run-local-with-testremediation > ${CAD_REPO_PATH}/test/testinfra/backplane-api.log 2> ${CAD_REPO_PATH}/test/testinfra/backplane-api.error.log &
 popd
 
 echo "Environment started. Check ${CAD_REPO_PATH}/test/testinfra/ directory for logs"


### PR DESCRIPTION
### What type of PR is this?

documentation

### What this PR does / Why we need it?

Improves docs on how to run the local backplane by better explaining a common source for errors.

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated local OCM Backplane testing instructions to cover cloning the API repository, authenticating with OCM, retrieving and transferring `ocm.json`, and validating required files before startup.
  - Added pod debugging guidance, correct Backplane error-log location, Bash syntax highlighting, and clarified setup, execution, troubleshooting, and shutdown steps.

- **Bug Fixes**
  - Corrected the Backplane API log filenames used during local environment testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->