### PR TITLE
[ROSAENG-66542] - Parse the cluster ID from alerts' "firing" JSON payload

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -15,6 +15,7 @@ import (
 	servicelogsv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/utils"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
@@ -122,7 +123,13 @@ func (c *SdkClient) GetAWSAccountClaim(internalClusterID string) (*awsv1alpha1.A
 // GetClusterInfo returns cluster information from ocm by using either internal, external id or the cluster name
 // Returns a v1.Cluster object or an error
 func (c *SdkClient) GetClusterInfo(identifier string) (*cmv1.Cluster, error) {
-	q := fmt.Sprintf("(id like '%[1]s' or external_id like '%[1]s' or display_name like '%[1]s')", identifier)
+	// Validated before interpolation into the search expression below. This is the single choke
+	// point for every caller, including those passing identifiers extracted from alert payloads.
+	if !utils.IsValidClusterIdentifier(identifier) {
+		return nil, fmt.Errorf("invalid cluster identifier: %q", identifier)
+	}
+	// '=' rather than 'like': no wildcard matching is intended here.
+	q := fmt.Sprintf("(id = '%[1]s' or external_id = '%[1]s' or display_name = '%[1]s')", identifier)
 	resp, err := c.conn.ClustersMgmt().V1().Clusters().List().Search(q).Send()
 	if err != nil || resp.Error() != nil || resp.Status() != http.StatusOK {
 		return nil, fmt.Errorf("received error while fetch ClusterInfo from ocm: %w with resp %#v", err, resp)

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
+	"github.com/openshift/configuration-anomaly-detection/pkg/utils"
 	"gopkg.in/yaml.v3"
 
 	sdk "github.com/PagerDuty/go-pagerduty"
@@ -440,12 +441,21 @@ func extractClusterIDFromAlertBody(data map[string]interface{}) (string, error) 
 			logging.Infof("failed to extract cluster id (continuing): %v", err)
 			errs = append(errs, err)
 		}
+		// An extractor can pick up a value that is not an identifier at all (a free-text
+		// placeholder, a stray token). Discarding it here lets the remaining extractors run
+		// instead of committing to a value the OCM lookup will reject.
+		if id != "" && !utils.IsValidClusterIdentifier(id) {
+			err := fmt.Errorf("extracted cluster id %q is not a valid cluster identifier", id)
+			logging.Infof("%v (continuing)", err)
+			errs = append(errs, err)
+			continue
+		}
 		if id != "" {
 			return id, nil
 		}
 	}
 	mergedErr := errors.Join(errs...)
-	logging.Info("failed to extract cluster id ( terminally ): %v", mergedErr)
+	logging.Infof("failed to extract cluster id ( terminally ): %v", mergedErr)
 	return "", mergedErr
 }
 

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -411,6 +411,13 @@ type notesData struct {
 	ClusterID string `yaml:"cluster_id"`
 }
 
+// firingAlert is the subset of Alertmanager's template.Alert that CAD needs. Since the COO
+// cutover (app-interface !204683, 2026-09-02) the PagerDuty 'firing' custom detail carries a
+// JSON array of these instead of the plain-text 'pagerduty.default.instances' render.
+type firingAlert struct {
+	Labels map[string]string `json:"labels"`
+}
+
 // clusterIDFromFiringRe matches standalone "cluster_id = <value>" within a (potentially
 // multi-line) firing alert text. The named capture group "id" extracts the value.
 // (?:^|\s) requires either start-of-string or a whitespace character immediately before
@@ -430,7 +437,7 @@ func extractClusterIDFromAlertBody(data map[string]interface{}) (string, error) 
 	for _, extractor := range extractors {
 		id, err := extractor(details)
 		if err != nil {
-			logging.Info("failed to extract cluster id (continuing): %s", err)
+			logging.Infof("failed to extract cluster id (continuing): %v", err)
 			errs = append(errs, err)
 		}
 		if id != "" {
@@ -438,7 +445,7 @@ func extractClusterIDFromAlertBody(data map[string]interface{}) (string, error) 
 		}
 	}
 	mergedErr := errors.Join(errs...)
-	logging.Info("failed to extract cluster id ( terminally ): %s", mergedErr)
+	logging.Info("failed to extract cluster id ( terminally ): %v", mergedErr)
 	return "", mergedErr
 }
 
@@ -476,13 +483,26 @@ func parseClusterIdFromNotes(details map[string]interface{}) (string, error) {
 }
 
 // PARSE OPTION 3 (HCPNodepoolUpgradeDelay): these alerts have their own format and set neither
-// 'notes' nor 'cluster_id', so the ID must be extracted from the free-text 'firing' field.
+// 'notes' nor 'cluster_id', so the ID must be extracted from the 'firing' field (as a JSON
+// array of alerts post-COO-cutover, or as free-text on older incidents).
 func parseClusterIdFromFiring(details map[string]interface{}) (string, error) {
-	logging.Warn("Trying to parse 'cluster_id = <id>' free text from 'firing'")
+	logging.Warn("Trying to parse 'cluster_id' from JSON 'firing' field")
 	firing, found := details["firing"].(string)
 	if !found {
 		return "", errors.New("could not find firing field")
 	}
+
+	var alerts []firingAlert
+	if err := json.Unmarshal([]byte(firing), &alerts); err == nil {
+		for _, alert := range alerts {
+			if id := alert.Labels["cluster_id"]; id != "" {
+				return id, nil
+			}
+		}
+		return "", errors.New("no cluster_id label found in JSON firing field")
+	}
+
+	logging.Warn("Trying to parse 'cluster_id = <id>' free text from 'firing'")
 	match := clusterIDFromFiringRe.FindStringSubmatch(firing)
 	idIdx := clusterIDFromFiringRe.SubexpIndex("id")
 	if idIdx < 0 || idIdx >= len(match) {

--- a/pkg/pagerduty/pagerduty_test.go
+++ b/pkg/pagerduty/pagerduty_test.go
@@ -421,6 +421,46 @@ var _ = Describe("Pagerduty", func() {
 					Expect(res).Should(Equal("654321"))
 				})
 			})
+			When("the JSON firing field carries a cluster_id label outside the accepted character class", func() {
+				It("should reject the label and raise an error", func() {
+					// Arrange: labels are untrusted input, so a value that is not a valid cluster
+					// identifier must not be passed through to the OCM lookup.
+					mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {
+						_, _ = fmt.Fprint(w, `{"alerts":[{"id":"1234","body":{"details":{"firing":"[{\"labels\":{\"cluster_id\":\"x' or external_id like '654321\"}}]"}}}]}`)
+					})
+					// Act
+					_, err := p.RetrieveClusterID()
+					// Assert
+					Expect(err).Should(HaveOccurred())
+				})
+			})
+			When("the cluster_id field contains characters outside the accepted character class", func() {
+				It("should reject the value and raise an error", func() {
+					// Arrange: a value that is not a valid cluster identifier must be rejected
+					// rather than looked up.
+					mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {
+						_, _ = fmt.Fprint(w, `{"alerts":[{"id":"1234","body":{"details":{"cluster_id":"6543%"}}}]}`)
+					})
+					// Act
+					_, err := p.RetrieveClusterID()
+					// Assert
+					Expect(err).Should(HaveOccurred())
+				})
+			})
+			When("an earlier extractor yields an invalid value but a later one yields a valid id", func() {
+				It("should discard the invalid value and fall through", func() {
+					// Arrange: 'cluster_id' is a free-text placeholder, so extraction must continue
+					// to the notes field rather than committing to the first non-empty value.
+					mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {
+						_, _ = fmt.Fprint(w, `{"alerts":[{"id":"1234","body":{"details":{"cluster_id":"<no value>","notes":"cluster_id: 654321"}}}]}`)
+					})
+					// Act
+					res, err := p.RetrieveClusterID()
+					// Assert
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(res).Should(Equal("654321"))
+				})
+			})
 			When("the alert body does not have a 'details' nor 'firing' field", func() {
 				It("should raise an error", func() {
 					mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/pagerduty/pagerduty_test.go
+++ b/pkg/pagerduty/pagerduty_test.go
@@ -369,6 +369,20 @@ var _ = Describe("Pagerduty", func() {
 					Expect(res).Should(Equal("654321"))
 				})
 			})
+			When("[HCPNodepoolUpgradeDelay] the payload contains the cluster_id in the firing field (COO JSON)", func() {
+				It("should succeed and pull the clusterID from a JSON firing payload", func() {
+					// Arrange: since the COO cutover the firing field carries a JSON array of
+					// Alertmanager alerts, so cluster_id is a label rather than free text.
+					mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {
+						_, _ = fmt.Fprint(w, `{"alerts":[{"id":"1234","body":{"details":{"firing":"[{\"labels\":{\"alertname\":\"HCPNodepoolUpgradeDelay\",\"cluster_id\":\"654321\"}}]"}}}]}`)
+					})
+					// Act
+					res, err := p.RetrieveClusterID()
+					// Assert
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(res).Should(Equal("654321"))
+				})
+			})
 			When("[HCPNodepoolUpgradeDelay] the firing field only contains hosted_cluster_id (no standalone cluster_id)", func() {
 				It("should not match hosted_cluster_id and should raise an error", func() {
 					// Arrange: hosted_cluster_id must not be mistaken for cluster_id
@@ -379,6 +393,32 @@ var _ = Describe("Pagerduty", func() {
 					_, err := p.RetrieveClusterID()
 					// Assert
 					Expect(err).Should(HaveOccurred())
+				})
+			})
+			When("[HCPNodepoolUpgradeDelay] the JSON firing field has no cluster_id label", func() {
+				It("should not match hosted_cluster_id and should raise an error", func() {
+					// Arrange: hosted_cluster_id must not be mistaken for cluster_id
+					mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {
+						_, _ = fmt.Fprint(w, `{"alerts":[{"id":"1234","body":{"details":{"firing":"[{\"labels\":{\"hosted_cluster_id\":\"abc123\"}}]"}}}]}`)
+					})
+					// Act
+					_, err := p.RetrieveClusterID()
+					// Assert
+					Expect(err).Should(HaveOccurred())
+				})
+			})
+			When("[HCPNodepoolUpgradeDelay] the JSON firing field groups several alerts", func() {
+				It("should pull the clusterID from whichever alert carries it", func() {
+					// Arrange: Alertmanager groups on ['job', 'cluster', 'service'], so one
+					// incident can carry several alerts differing only by node_pool_id.
+					mux.HandleFunc(fmt.Sprintf("/incidents/%s/alerts", incidentID), func(w http.ResponseWriter, r *http.Request) {
+						_, _ = fmt.Fprint(w, `{"alerts":[{"id":"1234","body":{"details":{"firing":"[{\"labels\":{\"alertname\":\"HCPNodepoolUpgradeDelay\"}},{\"labels\":{\"alertname\":\"HCPNodepoolUpgradeDelay\",\"cluster_id\":\"654321\",\"node_pool_id\":\"r5-2xlarge-1b\"}}]"}}}]}`)
+					})
+					// Act
+					res, err := p.RetrieveClusterID()
+					// Assert
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(res).Should(Equal("654321"))
 				})
 			})
 			When("the alert body does not have a 'details' nor 'firing' field", func() {

--- a/pkg/utils/clusterid.go
+++ b/pkg/utils/clusterid.go
@@ -1,0 +1,18 @@
+package utils
+
+import "regexp"
+
+// clusterIdentifierRe constrains a cluster identifier to the characters shared by every form
+// OCM accepts for a cluster lookup: the internal ID (alphanumeric), the external ID (an RFC4122
+// UUID, so hexadecimal plus dashes) and the cluster display name.
+//
+// This deliberately validates the character class rather than the shape of either format, and
+// mainly serves as a guard against injections.
+var clusterIdentifierRe = regexp.MustCompile(`^[a-zA-Z0-9-]{1,64}$`)
+
+// IsValidClusterIdentifier reports whether the identifier is safe to interpolate into an OCM
+// search expression. Identifiers taken from untrusted sources (alert payloads, for example) must
+// pass this check before being used in a lookup.
+func IsValidClusterIdentifier(identifier string) bool {
+	return clusterIdentifierRe.MatchString(identifier)
+}

--- a/pkg/utils/clusterid_test.go
+++ b/pkg/utils/clusterid_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import "testing"
+
+func TestIsValidClusterIdentifier(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		want       bool
+	}{
+		{"internal id", "abcdef0123456789abcdef0123456789", true},
+		{"external id", "00000000-0000-4000-8000-000000000000", true},
+		{"cluster display name", "my-test-cluster-01", true},
+		{"management cluster name", "hs-mc-abc123xyz", true},
+
+		{"empty", "", false},
+		{"quote", "x' or external_id like '654321", false},
+		{"backslash and quote", `x\' or 1=1 --`, false},
+		{"percent", "6543%", false},
+		{"underscore", "654_21", false},
+		{"whitespace", "654321 or id = '1'", false},
+		{"newline", "654321\nid", false},
+		{"free-text placeholder", "<no value>", false},
+		{"trailing punctuation", "654321,", false},
+		{"over length limit", string(make([]byte, 65)), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidClusterIdentifier(tt.identifier); got != tt.want {
+				t.Errorf("IsValidClusterIdentifier(%q) = %v, want %v", tt.identifier, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/generate_incident.sh
+++ b/test/generate_incident.sh
@@ -22,7 +22,11 @@ declare -A alert_mapping=(
 
 # Function to print help message
 print_help() {
-    echo "Usage: $0 <alertname> <clusterid>"
+    echo "Usage: $0 <alertname> <clusterid> [cluster_id|firing]"
+    echo "The optional third argument selects how the cluster ID is carried in the payload:"
+    echo "  cluster_id (default) - as a dedicated 'cluster_id' custom detail"
+    echo "  firing               - only as a label inside the JSON 'firing' custom detail,"
+    echo "                         the format Alertmanager has produced since the COO cutover"
     echo -n "Available alert names (comma separated): "
     for alert_name in "${!alert_mapping[@]}"; do
         echo -n "$alert_name, "
@@ -30,13 +34,14 @@ print_help() {
     echo
 }
 # Check if the correct number of arguments is provided
-if [ "$#" -ne 2 ]; then
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
     print_help
     exit 1
 fi
 
 alert_name=$1
 cluster_id=$2
+id_format=${3:-cluster_id}
 time_current=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Check if the alert name is in the mapping
@@ -47,6 +52,30 @@ if [ -z "${alert_mapping[$alert_name]}" ]; then
 fi
 
 alert_title="${alert_mapping[$alert_name]}"
+
+# Build the custom details carrying the cluster ID in the requested format
+case "$id_format" in
+    cluster_id)
+        custom_details=$(jq -n --arg alertname "$alert_name" --arg cluster_id "$cluster_id" \
+            '{alertname: $alertname, cluster_id: $cluster_id}')
+        ;;
+    firing)
+        # Alertmanager renders 'firing' as a JSON array of alerts, so the cluster ID is only
+        # reachable as a label and no dedicated 'cluster_id' detail is sent.
+        firing=$(jq -n -c --arg alertname "$alert_name" --arg cluster_id "$cluster_id" --arg ts "$time_current" \
+            '[{status: "firing",
+               labels: {alertname: $alertname, cluster_id: $cluster_id, node_pool_id: "cad-integration-testing", service: "srep", severity: "critical"},
+               annotations: {message: ("HCP Cluster " + $cluster_id + " nodepool upgrade delay for nodepool id : cad-integration-testing")},
+               startsAt: $ts}]')
+        custom_details=$(jq -n --arg alertname "$alert_name" --arg firing "$firing" \
+            '{alertname: $alertname, firing: $firing, num_firing: "1", num_resolved: "0"}')
+        ;;
+    *)
+        echo "Error: Unknown cluster ID format '$id_format'"
+        print_help
+        exit 1
+        ;;
+esac
 
 # Load testing routing key and test service url from vault
 export VAULT_ADDR="https://vault.devshift.net"
@@ -68,10 +97,7 @@ response=$(curl --silent --request POST \
       "timestamp": "'"${time_current}"'",
       "severity": "critical",
       "source": "cad-integration-testing",
-      "custom_details": {
-        "alertname": "'"${alert_name}"'",
-        "cluster_id": "'"${cluster_id}"'"
-      }
+      "custom_details": '"${custom_details}"'
     },
     "routing_key": "'"${pd_test_routing_key}"'",
     "event_action": "trigger",


### PR DESCRIPTION
This also adds an optional argument to the test script to generate JSON payloads, similar to what COO does.

### What type of PR is this?

(feature/bug/documentation/other)

### What this PR does / Why we need it?

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [ ] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PagerDuty incident processing to identify cluster IDs from JSON-formatted firing alerts, including grouped alerts.
  * Avoids confusing `hosted_cluster_id` with `cluster_id` and preserves fallback support for text-based alert formats.
  * Rejects invalid cluster identifiers and uses exact matching when retrieving cluster information.

* **Testing**
  * Added coverage for JSON firing payloads, grouped alerts, label handling, and identifier validation.

* **Chores**
  * Updated the incident-generation utility to support custom-detail and firing-based cluster ID payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->