### PR TITLE
ROSAENG-66516: fix CAD double-escalating PagerDuty incidents on AI fallback

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -243,20 +243,25 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 			return nil, fmt.Errorf("could not initialize pagerduty client: %w", err)
 		}
 
+		// Shared across the executor, the notifier, and every investigation's
+		// Resources.PdClient, so an escalation issued through any of those
+		// paths is visible to the others via HasEscalated().
+		trackedPDClient := newTrackingPDClient(pdClient)
+
 		// Initialize logger early (we'll update with cluster ID later)
 		logger := logging.InitLogger(opts.Common.LogLevel, opts.Common.Identifier, "")
 
 		return &PagerDutyController{
 			config:   opts.Common,
 			pd:       *opts.Pd,
-			pdClient: pdClient,
+			pdClient: trackedPDClient,
 			investigationRunner: investigationRunner{
 				ocmClient:    deps.OCMClient,
 				bpClient:     deps.BackplaneClient,
-				executor:     executor.NewWebhookExecutor(deps.OCMClient, pdClient, deps.BackplaneClient, logger),
+				executor:     executor.NewWebhookExecutor(deps.OCMClient, trackedPDClient, deps.BackplaneClient, logger),
 				logger:       logger,
 				dependencies: deps,
-				notifier:     newPDIncidentNotifier(pdClient),
+				notifier:     newPDIncidentNotifier(trackedPDClient),
 			},
 		}, nil
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -245,7 +245,7 @@ func NewController(opts ControllerOptions, deps *Dependencies) (Controller, erro
 
 		// Shared across the executor, the notifier, and every investigation's
 		// Resources.PdClient, so an escalation issued through any of those
-		// paths is visible to the others via HasEscalated().
+		// paths de-duplicates against the others.
 		trackedPDClient := newTrackingPDClient(pdClient)
 
 		// Initialize logger early (we'll update with cluster ID later)
@@ -543,6 +543,8 @@ func handleCADFailure(err error, rb investigation.ResourceBuilder, notifier inci
 		notes = "🚨 CAD investigation failed prior to resource initialization, CAD team has been notified. Please investigate manually. 🚨"
 	}
 
+	// If this incident was already escalated, trackingPDClient degrades this
+	// to a plain note instead of a real second escalation.
 	if escErr := notifier.EscalateWithNote(notes); escErr != nil {
 		logging.Errorf("Failed to escalate notes to PagerDuty: %v", escErr)
 	} else {

--- a/pkg/controller/escalation_tracker.go
+++ b/pkg/controller/escalation_tracker.go
@@ -1,0 +1,44 @@
+package controller
+
+import (
+	"sync/atomic"
+
+	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
+)
+
+// trackingPDClient wraps a pagerduty.Client and records whether it has
+// already escalated the incident. A single instance is shared by the
+// investigation pipeline (via incidentNotifier.AttachToBuilder), the action
+// executor, and the controller's own fallback logic, so all three agree on
+// whether the incident still needs a generic escalation.
+type trackingPDClient struct {
+	pagerduty.Client
+	escalated atomic.Bool
+}
+
+func newTrackingPDClient(client pagerduty.Client) *trackingPDClient {
+	return &trackingPDClient{Client: client}
+}
+
+func (t *trackingPDClient) EscalateIncident() error {
+	err := t.Client.EscalateIncident()
+	if err == nil {
+		t.escalated.Store(true)
+	}
+	return err
+}
+
+func (t *trackingPDClient) EscalateIncidentWithNote(note string) error {
+	err := t.Client.EscalateIncidentWithNote(note)
+	if err == nil {
+		t.escalated.Store(true)
+	}
+	return err
+}
+
+// HasEscalated reports whether this incident has already been escalated,
+// through any path (investigation action, direct call, or note-attached
+// escalation).
+func (t *trackingPDClient) HasEscalated() bool {
+	return t.escalated.Load()
+}

--- a/pkg/controller/escalation_tracker.go
+++ b/pkg/controller/escalation_tracker.go
@@ -1,19 +1,26 @@
 package controller
 
 import (
-	"sync/atomic"
+	"sync"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 )
 
-// trackingPDClient wraps a pagerduty.Client and records whether it has
-// already escalated the incident. A single instance is shared by the
-// investigation pipeline (via incidentNotifier.AttachToBuilder), the action
-// executor, and the controller's own fallback logic, so all three agree on
-// whether the incident still needs a generic escalation.
+// trackingPDClient wraps a pagerduty.Client and de-duplicates escalations at
+// the source: EscalateIncident/EscalateIncidentWithNote only ever reach the
+// real client once per incident, no matter how many callers (an
+// investigation's direct call, an investigation's action via the executor,
+// or the controller's own fallback/failure-handling logic) try to escalate.
+// A single instance is shared across all of those paths (via
+// incidentNotifier.AttachToBuilder and the executor construction), so the
+// guard applies regardless of which caller gets there first. The mutex makes
+// this correct even if a future change parallelizes PagerDuty action
+// execution or investigation runs, which are currently sequential but not
+// guaranteed to stay that way.
 type trackingPDClient struct {
 	pagerduty.Client
-	escalated atomic.Bool
+	mu        sync.Mutex
+	escalated bool
 }
 
 func newTrackingPDClient(client pagerduty.Client) *trackingPDClient {
@@ -21,24 +28,41 @@ func newTrackingPDClient(client pagerduty.Client) *trackingPDClient {
 }
 
 func (t *trackingPDClient) EscalateIncident() error {
-	err := t.Client.EscalateIncident()
-	if err == nil {
-		t.escalated.Store(true)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.escalated {
+		return nil
 	}
-	return err
+	if err := t.Client.EscalateIncident(); err != nil {
+		return err
+	}
+	t.escalated = true
+	return nil
 }
 
+// EscalateIncidentWithNote degrades to a plain note if the incident was
+// already escalated, so the note's content isn't lost even though the
+// (already-happened) escalation itself isn't repeated.
 func (t *trackingPDClient) EscalateIncidentWithNote(note string) error {
-	err := t.Client.EscalateIncidentWithNote(note)
-	if err == nil {
-		t.escalated.Store(true)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.escalated {
+		return t.AddNote(note)
 	}
-	return err
+	if err := t.Client.EscalateIncidentWithNote(note); err != nil {
+		return err
+	}
+	t.escalated = true
+	return nil
 }
 
 // HasEscalated reports whether this incident has already been escalated,
 // through any path (investigation action, direct call, or note-attached
 // escalation).
 func (t *trackingPDClient) HasEscalated() bool {
-	return t.escalated.Load()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.escalated
 }

--- a/pkg/controller/escalation_tracker_test.go
+++ b/pkg/controller/escalation_tracker_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	pdmock "github.com/openshift/configuration-anomaly-detection/pkg/pagerduty/mock"
 )
 
@@ -55,16 +56,75 @@ func TestTrackingPDClient(t *testing.T) {
 		assert.False(t, tracked.HasEscalated())
 	})
 
-	t.Run("second escalation attempt is still visible as already escalated", func(t *testing.T) {
+	t.Run("a second EscalateIncident call never reaches the real client", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 		mockClient := pdmock.NewMockClient(ctrl)
+		// No .Times()/.AnyTimes(): gomock's default expectation of exactly
+		// one call means a second real EscalateIncident call fails the test.
 		mockClient.EXPECT().EscalateIncident().Return(nil)
 
 		tracked := newTrackingPDClient(mockClient)
 		require.NoError(t, tracked.EscalateIncident())
-
-		// Simulates pagerduty.go's fallback check: a caller that consults
-		// HasEscalated() first must not issue a second EscalateIncident call.
+		require.NoError(t, tracked.EscalateIncident())
 		assert.True(t, tracked.HasEscalated())
 	})
+
+	t.Run("EscalateIncidentWithNote degrades to a note once already escalated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient := pdmock.NewMockClient(ctrl)
+		mockClient.EXPECT().EscalateIncident().Return(nil)
+		mockClient.EXPECT().AddNote("still relevant context").Return(nil)
+
+		tracked := newTrackingPDClient(mockClient)
+		require.NoError(t, tracked.EscalateIncident())
+		// No EscalateIncidentWithNote expectation set: if this fell through
+		// to the real client instead of degrading to AddNote, gomock fails.
+		require.NoError(t, tracked.EscalateIncidentWithNote("still relevant context"))
+	})
+
+	t.Run("a failed escalation allows a later attempt to actually retry", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient := pdmock.NewMockClient(ctrl)
+		gomock.InOrder(
+			mockClient.EXPECT().EscalateIncident().Return(errors.New("pagerduty unavailable")),
+			mockClient.EXPECT().EscalateIncident().Return(nil),
+		)
+
+		tracked := newTrackingPDClient(mockClient)
+		assert.Error(t, tracked.EscalateIncident())
+		assert.False(t, tracked.HasEscalated())
+
+		require.NoError(t, tracked.EscalateIncident())
+		assert.True(t, tracked.HasEscalated())
+	})
+}
+
+// TestPDIncidentNotifier_AttachToBuilder_SharesEscalationState is a wiring
+// invariant test: everything this fix depends on requires that the client
+// handed to investigations via AttachToBuilder is the *same* trackingPDClient
+// instance the notifier and executor use. If AttachToBuilder is ever changed
+// to hand out a different or unwrapped client, an escalation made by an
+// investigation would go unnoticed by the rest of the pipeline, and this
+// test fails.
+func TestPDIncidentNotifier_AttachToBuilder_SharesEscalationState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPD := pdmock.NewMockClient(ctrl)
+	mockPD.EXPECT().EscalateIncident().Return(nil).Times(1)
+
+	tracked := newTrackingPDClient(mockPD)
+	notifier := newPDIncidentNotifier(tracked)
+
+	builder := &investigation.ResourceBuilderMock{Resources: &investigation.Resources{}}
+	notifier.AttachToBuilder(builder)
+
+	// Simulate an investigation escalating through the client it was handed
+	// via Resources.PdClient - exactly what aiassisted.Run does.
+	require.NoError(t, builder.Resources.PdClient.EscalateIncident())
+
+	assert.True(t, tracked.HasEscalated())
 }

--- a/pkg/controller/escalation_tracker_test.go
+++ b/pkg/controller/escalation_tracker_test.go
@@ -1,0 +1,70 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	pdmock "github.com/openshift/configuration-anomaly-detection/pkg/pagerduty/mock"
+)
+
+// TestTrackingPDClient guards against CAD double-escalating PagerDuty
+// incidents (ROSAENG-66516): every code path that might escalate an incident
+// (an investigation's direct call, an investigation's action, or the
+// controller's own generic fallback) goes through the same trackingPDClient,
+// so HasEscalated() is the single source of truth for "has this incident
+// already been escalated".
+func TestTrackingPDClient(t *testing.T) {
+	t.Run("starts unescalated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		tracked := newTrackingPDClient(pdmock.NewMockClient(ctrl))
+
+		assert.False(t, tracked.HasEscalated())
+	})
+
+	t.Run("EscalateIncident marks it escalated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockClient := pdmock.NewMockClient(ctrl)
+		mockClient.EXPECT().EscalateIncident().Return(nil)
+
+		tracked := newTrackingPDClient(mockClient)
+		require.NoError(t, tracked.EscalateIncident())
+		assert.True(t, tracked.HasEscalated())
+	})
+
+	t.Run("EscalateIncidentWithNote marks it escalated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockClient := pdmock.NewMockClient(ctrl)
+		mockClient.EXPECT().EscalateIncidentWithNote("reason").Return(nil)
+
+		tracked := newTrackingPDClient(mockClient)
+		require.NoError(t, tracked.EscalateIncidentWithNote("reason"))
+		assert.True(t, tracked.HasEscalated())
+	})
+
+	t.Run("a failed escalation is not tracked", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockClient := pdmock.NewMockClient(ctrl)
+		mockClient.EXPECT().EscalateIncident().Return(errors.New("pagerduty unavailable"))
+
+		tracked := newTrackingPDClient(mockClient)
+		assert.Error(t, tracked.EscalateIncident())
+		assert.False(t, tracked.HasEscalated())
+	})
+
+	t.Run("second escalation attempt is still visible as already escalated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockClient := pdmock.NewMockClient(ctrl)
+		mockClient.EXPECT().EscalateIncident().Return(nil)
+
+		tracked := newTrackingPDClient(mockClient)
+		require.NoError(t, tracked.EscalateIncident())
+
+		// Simulates pagerduty.go's fallback check: a caller that consults
+		// HasEscalated() first must not issue a second EscalateIncident call.
+		assert.True(t, tracked.HasEscalated())
+	})
+}

--- a/pkg/controller/notifier.go
+++ b/pkg/controller/notifier.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
-	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 )
 
 // incidentNotifier abstracts PagerDuty incident operations so that
@@ -11,17 +10,22 @@ import (
 // nil-checking a *pagerduty.SdkClient.
 type incidentNotifier interface {
 	AddNote(note string) error
+	Escalate() error
 	EscalateWithNote(note string) error
+	// HasEscalated reports whether this incident has already been escalated
+	// by any means (a matched investigation's own action, a direct call, or
+	// Escalate/EscalateWithNote below) so callers can avoid escalating twice.
+	HasEscalated() bool
 	AttachToBuilder(builder investigation.ResourceBuilder)
 	HasPagerDuty() bool
 }
 
 // pdIncidentNotifier wraps a real PagerDuty client.
 type pdIncidentNotifier struct {
-	client *pagerduty.SdkClient
+	client *trackingPDClient
 }
 
-func newPDIncidentNotifier(client *pagerduty.SdkClient) incidentNotifier {
+func newPDIncidentNotifier(client *trackingPDClient) incidentNotifier {
 	return &pdIncidentNotifier{client: client}
 }
 
@@ -29,8 +33,16 @@ func (n *pdIncidentNotifier) AddNote(note string) error {
 	return n.client.AddNote(note)
 }
 
+func (n *pdIncidentNotifier) Escalate() error {
+	return n.client.EscalateIncident()
+}
+
 func (n *pdIncidentNotifier) EscalateWithNote(note string) error {
 	return n.client.EscalateIncidentWithNote(note)
+}
+
+func (n *pdIncidentNotifier) HasEscalated() bool {
+	return n.client.HasEscalated()
 }
 
 func (n *pdIncidentNotifier) AttachToBuilder(builder investigation.ResourceBuilder) {
@@ -53,9 +65,20 @@ func (n *noopIncidentNotifier) AddNote(note string) error {
 	return nil
 }
 
+func (n *noopIncidentNotifier) Escalate() error {
+	logging.Infof("Skipping PD escalation (manual mode)")
+	return nil
+}
+
 func (n *noopIncidentNotifier) EscalateWithNote(note string) error {
 	logging.Infof("Skipping PD escalation (manual mode)")
 	return nil
+}
+
+// HasEscalated always reports false: manual mode has no PagerDuty incident to
+// track escalation state for, and nothing in this controller relies on it.
+func (n *noopIncidentNotifier) HasEscalated() bool {
+	return false
 }
 
 func (n *noopIncidentNotifier) AttachToBuilder(_ investigation.ResourceBuilder) {}

--- a/pkg/controller/notifier.go
+++ b/pkg/controller/notifier.go
@@ -7,15 +7,11 @@ import (
 
 // incidentNotifier abstracts PagerDuty incident operations so that
 // manual (non-PD) runs use a no-op implementation instead of
-// nil-checking a *pagerduty.SdkClient.
+// nil-checking a *trackingPDClient.
 type incidentNotifier interface {
 	AddNote(note string) error
 	Escalate() error
 	EscalateWithNote(note string) error
-	// HasEscalated reports whether this incident has already been escalated
-	// by any means (a matched investigation's own action, a direct call, or
-	// Escalate/EscalateWithNote below) so callers can avoid escalating twice.
-	HasEscalated() bool
 	AttachToBuilder(builder investigation.ResourceBuilder)
 	HasPagerDuty() bool
 }
@@ -39,10 +35,6 @@ func (n *pdIncidentNotifier) Escalate() error {
 
 func (n *pdIncidentNotifier) EscalateWithNote(note string) error {
 	return n.client.EscalateIncidentWithNote(note)
-}
-
-func (n *pdIncidentNotifier) HasEscalated() bool {
-	return n.client.HasEscalated()
 }
 
 func (n *pdIncidentNotifier) AttachToBuilder(builder investigation.ResourceBuilder) {
@@ -71,14 +63,8 @@ func (n *noopIncidentNotifier) Escalate() error {
 }
 
 func (n *noopIncidentNotifier) EscalateWithNote(note string) error {
-	logging.Infof("Skipping PD escalation (manual mode)")
+	logging.Infof("Skipping PD escalation (manual mode): %s", note)
 	return nil
-}
-
-// HasEscalated always reports false: manual mode has no PagerDuty incident to
-// track escalation state for, and nothing in this controller relies on it.
-func (n *noopIncidentNotifier) HasEscalated() bool {
-	return false
 }
 
 func (n *noopIncidentNotifier) AttachToBuilder(_ investigation.ResourceBuilder) {}

--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -83,10 +83,9 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 
 	// Nothing above escalated this incident yet (e.g. the AI-fallback chain
 	// was skipped entirely, or precheck/aiassisted didn't escalate on their
-	// own): issue exactly one generic escalation now.
-	if c.notifier.HasEscalated() {
-		return nil
-	}
+	// own): issue a generic escalation now. If something upstream already
+	// escalated, notifier.Escalate() is a safe no-op (trackingPDClient
+	// de-duplicates at the source) rather than a real second escalation.
 	if escErr := c.notifier.Escalate(); escErr != nil {
 		return fmt.Errorf("could not escalate unsupported alert: %w", escErr)
 	}
@@ -101,6 +100,8 @@ func escalateDocumentationMismatch(docErr *ocm.DocumentationMismatchError, resou
 		message = resources.Notes.String()
 	}
 
+	// If this incident was already escalated (e.g. by aiassisted), trackingPDClient
+	// degrades this to a plain note instead of a real second escalation.
 	if err := notifier.EscalateWithNote(message); err != nil {
 		logging.Errorf("Failed to escalate documentation mismatch notes to PagerDuty: %v", err)
 		return

--- a/pkg/controller/pagerduty.go
+++ b/pkg/controller/pagerduty.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/openshift/configuration-anomaly-detection/pkg/config"
+	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/aiassisted"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
 	"github.com/openshift/configuration-anomaly-detection/pkg/ocm"
@@ -18,7 +19,7 @@ import (
 type PagerDutyController struct {
 	config   CommonConfig
 	pd       PagerDutyConfig
-	pdClient *pagerduty.SdkClient
+	pdClient pagerduty.Client
 	investigationRunner
 }
 
@@ -65,7 +66,7 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 			AlertTitle: "aiassisted-fallback",
 			Investigations: []config.InvestigationEntry{
 				{Name: "precheck"},
-				{Name: "aiassisted", When: &config.FilterNode{
+				{Name: aiassisted.Name, When: &config.FilterNode{
 					Field: config.FieldHCP, Operator: config.OperatorIn, Values: []string{"false"},
 				}},
 			},
@@ -80,7 +81,13 @@ func (c *PagerDutyController) Investigate(ctx context.Context) error {
 		}
 	}
 
-	if escErr := c.pdClient.EscalateIncident(); escErr != nil {
+	// Nothing above escalated this incident yet (e.g. the AI-fallback chain
+	// was skipped entirely, or precheck/aiassisted didn't escalate on their
+	// own): issue exactly one generic escalation now.
+	if c.notifier.HasEscalated() {
+		return nil
+	}
+	if escErr := c.notifier.Escalate(); escErr != nil {
 		return fmt.Errorf("could not escalate unsupported alert: %w", escErr)
 	}
 	return nil

--- a/pkg/controller/pagerduty_test.go
+++ b/pkg/controller/pagerduty_test.go
@@ -1,0 +1,92 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	pdmock "github.com/openshift/configuration-anomaly-detection/pkg/pagerduty/mock"
+)
+
+// TestInvestigate_NoMatchedAlert_EscalatesExactlyOnce is a regression test for
+// ROSAENG-66516: CAD double-escalated PagerDuty incidents on the AI-fallback
+// path because Investigate unconditionally issued a second, generic
+// escalation after its fallback chain ran. With no configured Cfg at all
+// (cfg == nil), Investigate skips both the matched-alert chain and the
+// AI-fallback chain entirely and falls straight to the generic escalation —
+// the simplest reachable path to that final call. This exercises the real
+// wiring introduced by the fix: PagerDutyController.pdClient and
+// investigationRunner.notifier must share the same trackingPDClient so
+// HasEscalated() reflects reality, and EscalateIncident must fire exactly
+// once.
+func TestInvestigate_NoMatchedAlert_EscalatesExactlyOnce(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPD := pdmock.NewMockClient(ctrl)
+	mockPD.EXPECT().RetrieveClusterID().Return("cluster123", nil)
+	mockPD.EXPECT().GetIncidentRef().Return("INC-1").AnyTimes()
+	mockPD.EXPECT().GetServiceID().Return("SVC-1").AnyTimes()
+	mockPD.EXPECT().GetServiceName().Return("some-service").AnyTimes()
+	mockPD.EXPECT().GetTitle().Return("SomeUnhandledAlert").AnyTimes()
+	// The regression: this must be called exactly once. Before the fix,
+	// Investigate had no way to know an escalation already happened and
+	// could call this a second time.
+	mockPD.EXPECT().EscalateIncident().Return(nil).Times(1)
+
+	tracked := newTrackingPDClient(mockPD)
+	c := &PagerDutyController{
+		pdClient: tracked,
+		investigationRunner: investigationRunner{
+			// dependencies.Cfg is nil, so Investigate finds no matched alert
+			// and no AI agent config: both the alert-chain and AI-fallback
+			// blocks are skipped, landing directly on the generic escalate.
+			dependencies: &Dependencies{},
+			notifier:     newPDIncidentNotifier(tracked),
+		},
+	}
+
+	err := c.Investigate(context.Background())
+	require.NoError(t, err)
+	require.True(t, tracked.HasEscalated())
+}
+
+// TestInvestigate_AlreadyEscalated_DoesNotEscalateAgain directly covers the
+// guard added for ROSAENG-66516: once an incident has been escalated by any
+// path sharing the trackingPDClient, Investigate's final fallback must not
+// call EscalateIncident a second time.
+func TestInvestigate_AlreadyEscalated_DoesNotEscalateAgain(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPD := pdmock.NewMockClient(ctrl)
+	mockPD.EXPECT().RetrieveClusterID().Return("cluster123", nil)
+	mockPD.EXPECT().GetIncidentRef().Return("INC-1").AnyTimes()
+	mockPD.EXPECT().GetServiceID().Return("SVC-1").AnyTimes()
+	mockPD.EXPECT().GetServiceName().Return("some-service").AnyTimes()
+	mockPD.EXPECT().GetTitle().Return("SomeUnhandledAlert").AnyTimes()
+	// Simulates the one prior escalation (e.g. from aiassisted). No
+	// EscalateIncident expectation is set at all: gomock fails the test if
+	// Investigate's fallback tries to escalate a second time.
+	mockPD.EXPECT().EscalateIncidentWithNote("already handled upstream").Return(nil).Times(1)
+
+	tracked := newTrackingPDClient(mockPD)
+	notifier := newPDIncidentNotifier(tracked)
+
+	// Simulate an investigation elsewhere in the chain (e.g. aiassisted)
+	// having already escalated this incident on its own.
+	require.NoError(t, notifier.EscalateWithNote("already handled upstream"))
+
+	c := &PagerDutyController{
+		pdClient: tracked,
+		investigationRunner: investigationRunner{
+			dependencies: &Dependencies{},
+			notifier:     notifier,
+		},
+	}
+
+	err := c.Investigate(context.Background())
+	require.NoError(t, err)
+}

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -20,6 +20,10 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 )
 
+// Name is the investigation's registered name, used to reference it from
+// investigation-entry configs (e.g. the AI-fallback chain in pagerduty.go).
+const Name = "aiassisted"
+
 type Investigation struct {
 	AIConfig *config.AIAgentConfig
 }
@@ -248,5 +252,5 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 }
 
 func (c *Investigation) Name() string {
-	return "aiassisted"
+	return Name
 }

--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	"github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
-	"github.com/openshift/configuration-anomaly-detection/pkg/pagerduty"
 )
 
 // Name is the investigation's registered name, used to reference it from
@@ -94,8 +93,7 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	defer cancel()
 
 	// Get PagerDuty incident details
-	pdClient, ok := r.PdClient.(*pagerduty.SdkClient)
-	if !ok {
+	if r.PdClient == nil {
 		notes.AppendWarning("Failed to access PagerDuty client details")
 		result.Actions = append(
 			executor.NoteAndReportFrom(notes, clusterID, c.Name()),
@@ -113,8 +111,8 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 	}
 	logging.Info("Incident escalated immediately for AI investigation - SRE can review results async")
 
-	incidentID := pdClient.GetIncidentID()
-	alertName := pdClient.GetTitle()
+	incidentID := r.PdClient.GetIncidentID()
+	alertName := r.PdClient.GetTitle()
 
 	// Build investigation payload using typed structure
 	investigationData := &InvestigationPayload{

--- a/pkg/investigations/aiassisted/aiassisted_test.go
+++ b/pkg/investigations/aiassisted/aiassisted_test.go
@@ -9,6 +9,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	awsmock "github.com/openshift/configuration-anomaly-detection/pkg/aws/mock"
 	backplanemock "github.com/openshift/configuration-anomaly-detection/pkg/backplane/mock"
+	"github.com/openshift/configuration-anomaly-detection/pkg/config"
 	"github.com/openshift/configuration-anomaly-detection/pkg/executor"
 	investigation "github.com/openshift/configuration-anomaly-detection/pkg/investigations/investigation"
 	"github.com/openshift/configuration-anomaly-detection/pkg/logging"
@@ -115,6 +116,42 @@ var _ = Describe("aiassisted", func() {
 				Expect(result.Actions).NotTo(BeEmpty())
 				Expect(hasEscalateAction(result.Actions)).To(BeTrue())
 				Expect(hasNoteAction(result.Actions)).To(BeTrue())
+			})
+		})
+
+		Context("when a PagerDuty client is available on a non-HCP, non-infra cluster", func() {
+			It("accesses PdClient through the pagerduty.Client interface, not a concrete-type assertion", func() {
+				// Regression test: Run used to fetch incident details via
+				// `r.PdClient.(*pagerduty.SdkClient)`, a concrete-type
+				// assertion. Any interface-only implementation of
+				// pagerduty.Client (like this mock, or the trackingPDClient
+				// wrapper used in production) would fail that assertion and
+				// silently skip the whole AI investigation. These EXPECT
+				// calls only pass if Run instead calls the methods directly
+				// on the pagerduty.Client interface.
+				pdClientMock := pdmock.NewMockClient(mockCtrl)
+				pdClientMock.EXPECT().EscalateIncident().Return(nil).Times(1)
+				pdClientMock.EXPECT().GetIncidentID().Return("INC-123").Times(1)
+				pdClientMock.EXPECT().GetTitle().Return("SomeAlert").Times(1)
+				r.Resources.PdClient = pdClientMock
+
+				inv := Investigation{
+					AIConfig: &config.AIAgentConfig{
+						RuntimeARN:     "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test",
+						Region:         "us-east-1",
+						UserID:         "cad-test",
+						InvokerRoleArn: "arn:aws:iam::123456789012:role/test-role",
+						// Zero timeout means the AWS call below fails
+						// immediately via context cancellation instead of
+						// making a real network call - irrelevant to this
+						// test, which only cares that PdClient was reached.
+						TimeoutSeconds: 0,
+					},
+				}
+				result, err := inv.Run(r)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.Actions).NotTo(BeEmpty())
 			})
 		})
 	})

--- a/pkg/pagerduty/mock/pagerdutymock.go
+++ b/pkg/pagerduty/mock/pagerdutymock.go
@@ -81,6 +81,20 @@ func (mr *MockClientMockRecorder) EscalateIncidentWithNote(notes any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EscalateIncidentWithNote", reflect.TypeOf((*MockClient)(nil).EscalateIncidentWithNote), notes)
 }
 
+// GetIncidentRef mocks base method.
+func (m *MockClient) GetIncidentRef() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIncidentRef")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetIncidentRef indicates an expected call of GetIncidentRef.
+func (mr *MockClientMockRecorder) GetIncidentRef() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIncidentRef", reflect.TypeOf((*MockClient)(nil).GetIncidentRef))
+}
+
 // GetServiceID mocks base method.
 func (m *MockClient) GetServiceID() string {
 	m.ctrl.T.Helper()
@@ -93,6 +107,20 @@ func (m *MockClient) GetServiceID() string {
 func (mr *MockClientMockRecorder) GetServiceID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceID", reflect.TypeOf((*MockClient)(nil).GetServiceID))
+}
+
+// GetServiceName mocks base method.
+func (m *MockClient) GetServiceName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetServiceName indicates an expected call of GetServiceName.
+func (mr *MockClientMockRecorder) GetServiceName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceName", reflect.TypeOf((*MockClient)(nil).GetServiceName))
 }
 
 // GetTitle mocks base method.

--- a/pkg/pagerduty/mock/pagerdutymock.go
+++ b/pkg/pagerduty/mock/pagerdutymock.go
@@ -81,6 +81,20 @@ func (mr *MockClientMockRecorder) EscalateIncidentWithNote(notes any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EscalateIncidentWithNote", reflect.TypeOf((*MockClient)(nil).EscalateIncidentWithNote), notes)
 }
 
+// GetIncidentID mocks base method.
+func (m *MockClient) GetIncidentID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIncidentID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetIncidentID indicates an expected call of GetIncidentID.
+func (mr *MockClientMockRecorder) GetIncidentID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIncidentID", reflect.TypeOf((*MockClient)(nil).GetIncidentID))
+}
+
 // GetIncidentRef mocks base method.
 func (m *MockClient) GetIncidentRef() string {
 	m.ctrl.T.Helper()

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -35,7 +35,9 @@ type Client interface {
 	AddNote(notes string) error
 	EscalateIncident() error
 	EscalateIncidentWithNote(notes string) error
+	GetIncidentRef() string
 	GetServiceID() string
+	GetServiceName() string
 	GetTitle() string
 	MoveToEscalationPolicy(escalationPolicyID string) error
 	RetrieveClusterID() (string, error)

--- a/pkg/pagerduty/pagerduty.go
+++ b/pkg/pagerduty/pagerduty.go
@@ -35,6 +35,7 @@ type Client interface {
 	AddNote(notes string) error
 	EscalateIncident() error
 	EscalateIncidentWithNote(notes string) error
+	GetIncidentID() string
 	GetIncidentRef() string
 	GetServiceID() string
 	GetServiceName() string


### PR DESCRIPTION
## Summary

CAD could escalate the same PagerDuty incident twice when it took the AI fallback path: `aiassisted` always escalates the incident itself whenever it actually runs, but `PagerDutyController.Investigate` also issued a second, generic escalation unconditionally afterward.

Rather than special-case the one reported path, this centralizes escalation de-duplication at the source:

- `trackingPDClient` (`pkg/controller/escalation_tracker.go`) wraps the real `pagerduty.Client` and ensures `EscalateIncident`/`EscalateIncidentWithNote` only ever reach the PagerDuty API once per incident, no matter which caller gets there first (an investigation's direct call, an investigation's action via the executor, or the controller's own fallback/failure-handling logic). A single instance is shared across all of those paths.
- `EscalateIncidentWithNote` degrades to a plain note (instead of no-op) once already escalated, so note content isn't lost.
- This let several per-call-site double-escalation guards (`handleCADFailure`, `escalateDocumentationMismatch`, `Investigate`'s fallback) be simplified to unconditional calls, trusting the client-level guard.

## Bugs found and fixed along the way

- `aiassisted.go` type-asserted its PagerDuty client to the concrete `*pagerduty.SdkClient` type. Since `trackingPDClient` is a different concrete type wrapping that interface, this assertion would always fail once wired up — silently disabling the entire AI-assisted investigation in production. Fixed by widening the `pagerduty.Client` interface (`GetIncidentID`, plus `GetIncidentRef`/`GetServiceName` needed to make `PagerDutyController` mockable at all) and switching to a nil check + direct interface calls.
- Replaced an initial `atomic.Bool`/CompareAndSwap-based tracker with a plain `sync.Mutex`, removing a cross-package assumption (that PagerDuty actions never execute concurrently) that the CAS approach silently depended on.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` all clean
- [x] `go test ./...` passes (including `-race` on the affected packages)
- [x] New regression tests:
  - `pkg/controller/escalation_tracker_test.go` — de-duplication behavior of `trackingPDClient`, including the note-degradation and failed-then-retried-escalation cases
  - `pkg/controller/pagerduty_test.go` — `Investigate()`-level tests asserting `EscalateIncident` fires exactly once
  - `pkg/investigations/aiassisted/aiassisted_test.go` — regression test for the `PdClient` interface-vs-concrete-type bug above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented PagerDuty incidents from being escalated more than once, even when multiple investigation or fallback paths trigger escalation.
  - Preserved context from repeated escalation requests by adding subsequent notes to the incident instead of issuing another escalation.
  - Improved escalation handling when no matching alert or configuration is available.
- **Reliability**
  - PagerDuty integrations now work consistently across supported client implementations without relying on a specific client type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->