### PR TITLE
feat: post structured Cora summary to PagerDuty notes #ROSAENG-65649

### DIFF
--- a/pkg/investigations/aiassisted/aiassisted.go
+++ b/pkg/investigations/aiassisted/aiassisted.go
@@ -226,23 +226,26 @@ func (c *Investigation) Run(rb investigation.ResourceBuilder) (investigation.Inv
 		return result, nil
 	}
 
-	// Format to human-readable markdown
+	// Format to human-readable markdown for backplane report
 	formattedReport := FormatInvestigationReport(&investigationResult)
 
-	// Add simple note about AI automation completion
-	notes.AppendAutomation("AI automation completed. Check recent cluster reports for AI investigation details: 'osdctl cluster reports list --cluster-id %s'", clusterID)
+	// Format a structured PD note with the investigation summary.
+	// Use the authoritative cluster external ID (not Cora's response) for the
+	// osdctl footer so the command always matches the backplane report.
+	reportClusterID := r.Cluster.ExternalID()
+	pdNote := FormatPagerDutyNote(&investigationResult, reportClusterID)
 
 	// Create backplane report action with formatted output
 	backplaneReportAction := &executor.BackplaneReportAction{
-		ClusterID: r.Cluster.ExternalID(),
+		ClusterID: reportClusterID,
 		Summary:   fmt.Sprintf("CAD Investigation: AI-Assisted Analysis for %s", alertName),
 		Data:      formattedReport,
 	}
 
 	// Return actions for executor to handle
 	result.Actions = []executor.Action{
-		executor.NoteFrom(notes), // Send automation message to PagerDuty
-		backplaneReportAction,    // Create cluster report with AI investigation results
+		backplaneReportAction, // Create cluster report first
+		executor.Note(pdNote), // Post structured investigation summary to PagerDuty
 	}
 	return result, nil
 }

--- a/pkg/investigations/aiassisted/aiassisted_test.go
+++ b/pkg/investigations/aiassisted/aiassisted_test.go
@@ -20,6 +20,15 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+// Test constants to avoid goconst violations
+const (
+	testClusterID  = "test-cluster"
+	testAlertName  = "TestAlert"
+	testConfHigh   = "high"
+	testConfMedium = "medium"
+	testConfLow    = "low"
+)
+
 func TestAiassisted(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Aiassisted Suite")
@@ -119,6 +128,129 @@ var _ = Describe("aiassisted", func() {
 		})
 	})
 
+	Describe("FormatPagerDutyNote", func() {
+		Context("when formatting a complete investigation result", func() {
+			It("should produce a well-structured plain text note", func() {
+				command := "oc apply -f fix.yaml"
+				escalationReason := "Requires manual verification"
+
+				result := &CoraInvestigationResult{
+					ClusterID:  "test-cluster-abc",
+					AlertName:  "ClusterOperatorDegraded CRITICAL (1)",
+					Summary:    "The cluster-samples-operator is degraded due to missing ImageStreams",
+					Confidence: testConfHigh,
+					Reasoning:  "Root cause analysis shows the operator cannot find required ImageStreams",
+					RemediationSteps: []RemediationStep{
+						{
+							Action:  "Restore default ImageStreams",
+							Command: &command,
+						},
+					},
+					NeedsEscalation:  true,
+					EscalationReason: &escalationReason,
+				}
+
+				output := FormatPagerDutyNote(result, "test-cluster-abc")
+
+				Expect(output).To(ContainSubstring("🤖 AI-Assisted Investigation 🤖"))
+				Expect(output).To(ContainSubstring("ALERT: ClusterOperatorDegraded CRITICAL (1)"))
+				Expect(output).To(ContainSubstring("CONFIDENCE: HIGH"))
+				Expect(output).To(ContainSubstring("SUMMARY:"))
+				Expect(output).To(ContainSubstring("The cluster-samples-operator is degraded"))
+				Expect(output).To(ContainSubstring("REASONING:"))
+				Expect(output).To(ContainSubstring("Root cause analysis"))
+				Expect(output).To(ContainSubstring("ACTION STEPS:"))
+				Expect(output).To(ContainSubstring("1. Restore default ImageStreams"))
+				Expect(output).To(ContainSubstring("Command: oc apply -f fix.yaml"))
+				Expect(output).To(ContainSubstring("CORA RECOMMENDATION:"))
+				Expect(output).To(ContainSubstring("⚠️ Escalation recommended: Requires manual verification"))
+				Expect(output).To(ContainSubstring("Full report: osdctl cluster reports list --cluster-id test-cluster-abc"))
+			})
+		})
+
+		Context("when no escalation is needed", func() {
+			It("should show no escalation needed message", func() {
+				result := &CoraInvestigationResult{
+					ClusterID:        testClusterID,
+					AlertName:        testAlertName,
+					Summary:          "Self-healing succeeded",
+					Confidence:       testConfHigh,
+					Reasoning:        "System automatically resolved",
+					RemediationSteps: []RemediationStep{},
+					NeedsEscalation:  false,
+				}
+
+				output := FormatPagerDutyNote(result, testClusterID)
+
+				Expect(output).To(ContainSubstring("✅ No further escalation needed"))
+				Expect(output).ToNot(ContainSubstring("ACTION STEPS:"))
+			})
+		})
+
+		Context("when escalation has no reason", func() {
+			It("should show escalation needed without reason", func() {
+				result := &CoraInvestigationResult{
+					ClusterID:        testClusterID,
+					AlertName:        testAlertName,
+					Summary:          "Investigation inconclusive",
+					Confidence:       testConfLow,
+					Reasoning:        "Insufficient data",
+					RemediationSteps: []RemediationStep{},
+					NeedsEscalation:  true,
+					EscalationReason: nil,
+				}
+
+				output := FormatPagerDutyNote(result, testClusterID)
+
+				Expect(output).To(ContainSubstring("⚠️ Escalation recommended"))
+				Expect(output).ToNot(ContainSubstring("⚠️ Escalation recommended:"))
+			})
+		})
+
+		Context("when command is nil", func() {
+			It("should not include Command line", func() {
+				result := &CoraInvestigationResult{
+					ClusterID:  testClusterID,
+					AlertName:  testAlertName,
+					Summary:    "Manual action required",
+					Confidence: testConfMedium,
+					Reasoning:  "Needs human judgment",
+					RemediationSteps: []RemediationStep{
+						{
+							Action:  "Manually verify the configuration in console",
+							Command: nil,
+						},
+					},
+					NeedsEscalation: false,
+				}
+
+				output := FormatPagerDutyNote(result, testClusterID)
+
+				Expect(output).To(ContainSubstring("1. Manually verify the configuration"))
+				Expect(output).ToNot(ContainSubstring("Command:"))
+			})
+		})
+
+		Context("when Cora cluster ID differs from report cluster ID", func() {
+			It("should use the report cluster ID in the footer", func() {
+				result := &CoraInvestigationResult{
+					ClusterID:        "cora-returned-id",
+					AlertName:        testAlertName,
+					Summary:          "Issue found",
+					Confidence:       testConfHigh,
+					Reasoning:        "Evidence gathered",
+					RemediationSteps: []RemediationStep{},
+					NeedsEscalation:  false,
+				}
+
+				output := FormatPagerDutyNote(result, "authoritative-external-id")
+
+				Expect(output).To(ContainSubstring("Full report: osdctl cluster reports list --cluster-id authoritative-external-id"))
+				Expect(output).ToNot(ContainSubstring("cora-returned-id"))
+			})
+		})
+	})
+
 	// Happy Path to Test Investigation Report Format
 	Describe("FormatInvestigationReport", func() {
 		Context("when formatting a complete investigation result", func() {
@@ -129,7 +261,7 @@ var _ = Describe("aiassisted", func() {
 					ClusterID:  "test-cluster-abc",
 					AlertName:  "ClusterOperatorDegraded",
 					Summary:    "The cluster-samples-operator is degraded due to missing ImageStreams",
-					Confidence: "high",
+					Confidence: testConfHigh,
 					Reasoning:  "Root cause analysis shows the operator cannot find required ImageStreams",
 					Evidence:   "Checked cluster-samples-operator logs and found missing ImageStream errors",
 					RemediationSteps: []RemediationStep{
@@ -157,10 +289,10 @@ var _ = Describe("aiassisted", func() {
 		Context("when handling null command", func() {
 			It("should skip code block when command is nil", func() {
 				result := &CoraInvestigationResult{
-					ClusterID:  "test-cluster",
-					AlertName:  "TestAlert",
+					ClusterID:  testClusterID,
+					AlertName:  testAlertName,
 					Summary:    "Issue found",
-					Confidence: "high",
+					Confidence: testConfHigh,
 					Reasoning:  "Manual verification required",
 					Evidence:   "System logs inconclusive",
 					RemediationSteps: []RemediationStep{
@@ -183,10 +315,10 @@ var _ = Describe("aiassisted", func() {
 		Context("when remediation has no steps", func() {
 			It("should show no action steps available message", func() {
 				result := &CoraInvestigationResult{
-					ClusterID:        "test-cluster",
-					AlertName:        "TestAlert",
+					ClusterID:        testClusterID,
+					AlertName:        testAlertName,
 					Summary:          "Self-healing succeeded",
-					Confidence:       "high",
+					Confidence:       testConfHigh,
 					Reasoning:        "System automatically resolved the issue",
 					Evidence:         "Cluster operators returned to healthy state",
 					RemediationSteps: []RemediationStep{},
@@ -228,10 +360,10 @@ var _ = Describe("aiassisted", func() {
 				err := json.Unmarshal([]byte(jsonInput), &result)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result.ClusterID).To(Equal("test-cluster"))
+				Expect(result.ClusterID).To(Equal(testClusterID))
 				Expect(result.AlertName).To(Equal("QuickSchemaTest"))
 				Expect(result.Summary).To(Equal("Test investigation completed successfully"))
-				Expect(result.Confidence).To(Equal("high"))
+				Expect(result.Confidence).To(Equal(testConfHigh))
 				Expect(result.RemediationSteps).To(HaveLen(1))
 				Expect(result.RemediationSteps[0].Command).To(BeNil())
 				Expect(result.NeedsEscalation).To(BeFalse())

--- a/pkg/investigations/aiassisted/formatter.go
+++ b/pkg/investigations/aiassisted/formatter.go
@@ -5,6 +5,63 @@ import (
 	"strings"
 )
 
+// FormatPagerDutyNote converts CoraInvestigationResult into a well-formatted
+// PagerDuty note. PD notes are plain text (no markdown rendering), so this
+// uses emoji, caps, and indentation for structure instead of markdown syntax.
+// reportClusterID is the authoritative cluster external ID used in the osdctl
+// footer command — it must match the ID used for the backplane report.
+func FormatPagerDutyNote(result *CoraInvestigationResult, reportClusterID string) string {
+	var sb strings.Builder
+
+	// Header
+	sb.WriteString("🤖 AI-Assisted Investigation 🤖\n")
+	sb.WriteString("===========================\n\n")
+
+	// Alert & Confidence
+	fmt.Fprintf(&sb, "ALERT: %s\n", result.AlertName)
+	fmt.Fprintf(&sb, "CONFIDENCE: %s\n\n", strings.ToUpper(result.Confidence))
+
+	// Summary
+	sb.WriteString("SUMMARY:\n")
+	fmt.Fprintf(&sb, "%s\n\n", result.Summary)
+
+	// Reasoning
+	sb.WriteString("REASONING:\n")
+	fmt.Fprintf(&sb, "%s\n\n", result.Reasoning)
+
+	// Action Steps
+	if len(result.RemediationSteps) > 0 {
+		sb.WriteString("ACTION STEPS:\n")
+		for i, step := range result.RemediationSteps {
+			fmt.Fprintf(&sb, "%d. %s\n", i+1, step.Action)
+			if step.Command != nil && *step.Command != "" {
+				fmt.Fprintf(&sb, "   Command: %s\n", *step.Command)
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// Escalation recommendation from Cora (the PD incident is always escalated
+	// before the AI investigation runs, so this reflects Cora's assessment, not
+	// the current incident state)
+	sb.WriteString("CORA RECOMMENDATION:\n")
+	if result.NeedsEscalation {
+		sb.WriteString("⚠️ Escalation recommended")
+		if result.EscalationReason != nil && *result.EscalationReason != "" {
+			fmt.Fprintf(&sb, ": %s", *result.EscalationReason)
+		}
+		sb.WriteString("\n")
+	} else {
+		sb.WriteString("✅ No further escalation needed\n")
+	}
+
+	// Footer with cluster report access
+	sb.WriteString("\n---\n")
+	fmt.Fprintf(&sb, "Full report: osdctl cluster reports list --cluster-id %s\n", reportClusterID)
+
+	return sb.String()
+}
+
 // FormatInvestigationReport converts CoraInvestigationResult into human-readable markdown
 func FormatInvestigationReport(result *CoraInvestigationResult) string {
 	var sb strings.Builder


### PR DESCRIPTION
Replace the generic 'check cluster reports' PD note with a well-formatted investigation summary including alert name, confidence level, summary, reasoning, action steps with commands, and escalation status. A footer links to the full cluster report via osdctl.

The full markdown report continues to be stored as a backplane cluster report for detailed review.

### What type of PR is this?

(feature/bug/documentation/other)

### What this PR does / Why we need it?
https://redhat.atlassian.net/browse/ROSAENG-65649

### Special notes for your reviewer

### Test Coverage
#### Guidelines for CAD investigations
- New investgations should be accompanied by unit tests and/or step-by-step manual tests in the investigation README.
- Actioning investigations should be locally tested in staging, and E2E testing is desired. See [README](https://github.com/openshift/configuration-anomaly-detection/blob/main/README.md#graduating-an-investigation) for more info on investigation graduation process.

#### Test coverage checks
- [X] Added tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-assisted investigations now post formatted investigation notes to PagerDuty.
  * PagerDuty notes include alert details, confidence, escalation status, and a link to the full report.

* **Bug Fixes**
  * PagerDuty notes are now posted after the backplane report action is created, ensuring the correct workflow order.
  * Updated note formatting provides clearer headings, separators, and concise escalation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->